### PR TITLE
feat: make response channels dynamic

### DIFF
--- a/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/dspace/to/JsonObjectToDataAddressDspaceTransformer.java
+++ b/core/common/lib/transform-lib/src/main/java/org/eclipse/edc/transform/transformer/dspace/to/JsonObjectToDataAddressDspaceTransformer.java
@@ -65,8 +65,12 @@ public class JsonObjectToDataAddressDspaceTransformer extends AbstractNamespaceA
     private void transformEndpointProperties(JsonValue jsonValue, Consumer<DspaceEndpointProperty> consumer, TransformerContext context) {
         Function<JsonObject, DspaceEndpointProperty> converter = (jo) -> {
             var name = transformString(jo.get(forNamespace(ENDPOINT_PROPERTY_NAME_PROPERTY_TERM)), context);
-            var value = transformString(jo.get(forNamespace(ENDPOINT_PROPERTY_VALUE_PROPERTY_TERM)), context);
-            return new DspaceEndpointProperty(name, value);
+            var valueObj = jo.get(forNamespace(ENDPOINT_PROPERTY_VALUE_PROPERTY_TERM));
+
+            if (name.equals(EDC_DATA_ADDRESS_RESPONSE_CHANNEL)) {
+                return new DspaceEndpointProperty(name, transformObject(valueObj, DataAddress.class, context));
+            }
+            return new DspaceEndpointProperty(name, transformString(valueObj, context));
         };
         if (jsonValue instanceof JsonObject object) {
             consumer.accept(converter.apply(object));
@@ -78,6 +82,6 @@ public class JsonObjectToDataAddressDspaceTransformer extends AbstractNamespaceA
     }
 
     //container to hold endpoint property objects
-    private record DspaceEndpointProperty(String name, String value) {
+    private record DspaceEndpointProperty(String name, Object value) {
     }
 }

--- a/core/common/lib/transform-lib/src/test/java/org/eclipse/edc/transform/transformer/dspace/to/JsonObjectToDataAddressDspaceTransformerTest.java
+++ b/core/common/lib/transform-lib/src/test/java/org/eclipse/edc/transform/transformer/dspace/to/JsonObjectToDataAddressDspaceTransformerTest.java
@@ -44,6 +44,7 @@ class JsonObjectToDataAddressDspaceTransformerTest {
 
     @Test
     void transform() {
+        var nestedResponseChannel = responseChannelAddress();
         var jsonObj = jsonFactory.createObjectBuilder()
                 .add(CONTEXT, createContextBuilder().build())
                 .add(TYPE, DSPACE_DATAADDRESS_TYPE_IRI)
@@ -54,6 +55,7 @@ class JsonObjectToDataAddressDspaceTransformerTest {
                         .add(property("authType", "bearer"))
                         .add(property("foo", "bar"))
                         .add(property("fizz", "buzz"))
+                        .add(propertyWith(nestedResponseChannel))
                 )
                 .build();
 
@@ -72,6 +74,22 @@ class JsonObjectToDataAddressDspaceTransformerTest {
                 .add(TYPE, ENDPOINT_PROPERTY_PROPERTY_TYPE_IRI)
                 .add("name", key)
                 .add("value", value);
+    }
+
+    private JsonObjectBuilder propertyWith(JsonObjectBuilder builder) {
+        return jsonFactory.createObjectBuilder()
+                .add(TYPE, ENDPOINT_PROPERTY_PROPERTY_TYPE_IRI)
+                .add("name", EDC_DATA_ADDRESS_RESPONSE_CHANNEL)
+                .add("value", builder);
+    }
+
+    private JsonObjectBuilder responseChannelAddress() {
+        return jsonFactory.createObjectBuilder()
+                .add(TYPE, DSPACE_DATAADDRESS_TYPE_IRI)
+                .add(ENDPOINT_TYPE_PROPERTY_IRI, "SomeType")
+                .add(ENDPOINT_PROPERTIES_PROPERTY_IRI, jsonFactory.createArrayBuilder()
+                        .add(property("john", "doe"))
+                        .add(property("internal", "prop")));
     }
 
     private JsonArrayBuilder createContextBuilder() {

--- a/extensions/data-plane/data-plane-iam/src/main/java/org/eclipse/edc/connector/dataplane/iam/service/DataPlaneAuthorizationServiceImpl.java
+++ b/extensions/data-plane/data-plane-iam/src/main/java/org/eclipse/edc/connector/dataplane/iam/service/DataPlaneAuthorizationServiceImpl.java
@@ -80,9 +80,10 @@ public class DataPlaneAuthorizationServiceImpl implements DataPlaneAuthorization
         // "decorate" the data address with response channel properties
         var responseChannelType = dataFlow.getTransferType().responseChannelType();
         if (responseChannelType != null) {
+            var responseChannel = dataFlow.getSource().getResponseChannel();
             var responseChannelTokenParams = createTokenParams(dataFlow);
             dataAddressBuilder = dataAddressBuilder.compose(builder -> endpointGenerator.generateResponseFor(responseChannelType)
-                    .compose(ep -> createSecureEndpoint(ep, responseChannelTokenParams, additionalProperties, sourceDataAddress))
+                    .compose(ep -> createSecureEndpoint(ep, responseChannelTokenParams, additionalProperties, responseChannel))
                     .compose(endpoint -> addResponseChannel(builder, endpoint.tokenRepresentation(), endpoint.endpoint())));
         }
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
@@ -150,6 +150,20 @@ public class TransferEndToEndParticipant extends Participant {
         assertThat(data).satisfies(bodyAssertion);
     }
 
+    public void postResponse(DataAddress edr, ThrowingConsumer<String> bodyAssertion) {
+        var data = given()
+                .baseUri(edr.getStringProperty("responseChannel-endpoint"))
+                .header("Authorization", edr.getStringProperty("responseChannel-authorization"))
+                .when()
+                .post()
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .extract().body().asString();
+
+        assertThat(data).satisfies(bodyAssertion);
+    }
+
     @NotNull
     private String resourceAbsolutePath(String filename) {
         return System.getProperty("user.dir") + separator + "build" + separator + "resources" + separator + "test" + separator + filename;

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
@@ -54,6 +54,7 @@ import org.mockserver.model.HttpStatusCode;
 import org.mockserver.model.MediaType;
 
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -91,11 +92,11 @@ class TransferPullEndToEndTest {
         private static final ObjectMapper MAPPER = new ObjectMapper();
 
         private static @NotNull Map<String, Object> httpSourceDataAddress() {
-            return Map.of(
+            return new HashMap<>(Map.of(
                     EDC_NAMESPACE + "name", "transfer-test",
                     EDC_NAMESPACE + "baseUrl", "http://any/source",
                     EDC_NAMESPACE + "type", "HttpData"
-            );
+            ));
         }
 
         @Test
@@ -147,6 +148,27 @@ class TransferPullEndToEndTest {
             var edrEntry = assertConsumerCanAccessData(transferProcessId);
 
             assertConsumerCanNotAccessData(transferProcessId, edrEntry);
+        }
+
+        @Test
+        void httpPull_dataTransfer_withHttpResponseChannel() {
+            var assetId = UUID.randomUUID().toString();
+            var responseChannel = Map.of(
+                    EDC_NAMESPACE + "name", "transfer-test",
+                    EDC_NAMESPACE + "baseUrl", "http://any/response/channel",
+                    EDC_NAMESPACE + "type", "HttpData"
+            );
+            var sourceDataAddress = httpSourceDataAddress();
+            sourceDataAddress.put(EDC_NAMESPACE + "responseChannel", responseChannel);
+            createResourcesOnProvider(assetId, PolicyFixtures.contractExpiresIn("10s"), sourceDataAddress);
+
+            var transferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
+                    .withTransferType("HttpData-PULL-HttpData")
+                    .execute();
+
+            CONSUMER.awaitTransferToBeInState(transferProcessId, STARTED);
+            assertConsumerCanSendResponse(transferProcessId);
+
         }
 
         @Test
@@ -345,6 +367,11 @@ class TransferPullEndToEndTest {
                                     body -> assertThat(body).isEqualTo("data"))
                     )
             );
+        }
+
+        private void assertConsumerCanSendResponse(String consumerTransferProcessId) {
+            var edr = await().atMost(timeout).until(() -> CONSUMER.getEdr(consumerTransferProcessId), Objects::nonNull);
+            await().atMost(timeout).untilAsserted(() -> CONSUMER.postResponse(edr, body -> assertThat(body).isEqualTo("response received")));
         }
 
         private HttpResponse cacheEdr(HttpRequest request, Map<String, TransferProcessStarted> events) {


### PR DESCRIPTION
## What this PR changes/adds

Adapts the DataplaneAuthorizationServiceImpl to generate the response channel EDR endpoint based on the source data address response channel.
Adapts the JsonObjectFrom/ToDataAddressDspaceTransformer s to permit serdes of the response channel property.

## Why it does that

To allow HTTP response channels to be dynamic and defined by the data provider.

## Who will sponsor this feature?

@ndr-brt 
@jimmarino 

For consistency.

## Linked Issue(s)

Part of #4988 

