### PR TITLE
fix: update DCP JSON-LD file to reflect latest DCP spec

### DIFF
--- a/extensions/common/iam/identity-trust/identity-trust-core/src/main/resources/document/dcp.v1.0.jsonld
+++ b/extensions/common/iam/identity-trust/identity-trust-core/src/main/resources/document/dcp.v1.0.jsonld
@@ -3,7 +3,7 @@
     "@version": 1.1,
     "@protected": true,
     "dcp": "https://w3id.org/dspace-dcp/v1.0/",
-    "cred": "https://www.w3.org/2018/credentials/",
+    "cred": "https://www.w3.org/2018/credentials#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "id": "@id",
     "type": "@type",
@@ -21,11 +21,23 @@
       "@context": {
         "credentials": {
           "@id": "dcp:credentials",
-          "@container": "@set"
+          "@container": "@set",
+          "@type": "@json"
         },
-        "requestId": {
-          "@id": "dcp:requestId",
+        "issuerPid": {
+          "@id": "dcp:issuerPid",
           "@type": "@id"
+        },
+        "holderPid": {
+          "@id": "dcp:holderPid",
+          "@type": "@id"
+        },
+        "status": {
+          "@id": "dcp:status",
+          "@type": "@id"
+        },
+        "rejectionReason": {
+          "@id": "dcp:rejectionReason"
         }
       }
     },
@@ -33,8 +45,7 @@
       "@id": "dcp:CredentialObject",
       "@context": {
         "credentialType": {
-          "@id": "dcp:credentialType",
-          "@container": "@set"
+          "@id": "dcp:credentialType"
         },
         "offerReason": {
           "@id": "dcp:offerReason",
@@ -45,10 +56,9 @@
           "@type": "xsd:string",
           "@container": "@set"
         },
-        "profiles": {
-          "@id": "dcp:profiles",
-          "@type": "xsd:string",
-          "@container": "@set"
+        "profile": {
+          "@id": "dcp:profile",
+          "@type": "xsd:string"
         },
         "issuancePolicy": {
           "@id": "dcp:issuancePolicy",
@@ -59,7 +69,10 @@
     "CredentialOfferMessage": {
       "@id": "dcp:CredentialOfferMessage",
       "@context": {
-        "credentialIssuer": "cred:issuer",
+        "issuer": {
+          "@id": "cred:issuer",
+          "@type": "@id"
+        },
         "credentials": {
           "@id": "dcp:credentials",
           "@container": "@set"
@@ -69,11 +82,13 @@
     "CredentialRequestMessage": {
       "@id": "dcp:CredentialRequestMessage",
       "@context": {
-        "format": "dcp:format",
-        "credentialType": {
-          "@id": "dcp:credentialType",
-          "@type": "@vocab",
-          "@container": "@set"
+        "holderPid": {
+          "@id": "dcp:holderPid",
+          "@type": "@id"
+        },
+        "credentials": {
+          "@id": "dcp:credentials",
+          "@type": "@json"
         }
       }
     },
@@ -81,8 +96,12 @@
     "CredentialStatus": {
       "@id": "dcp:CredentialStatus",
       "@context": {
-        "requestId": {
-          "@id": "dcp:requestId",
+        "holderPid": {
+          "@id": "dcp:holderPid",
+          "@type": "@id"
+        },
+        "issuerPid": {
+          "@id": "dcp:issuerPid",
           "@type": "@id"
         },
         "status": {
@@ -97,7 +116,10 @@
     "IssuerMetadata": {
       "@id": "dcp:IssuerMetadata",
       "@context": {
-        "credentialIssuer": "cred:issuer",
+        "issuer": {
+          "@id": "cred:issuer",
+          "@type": "@id"
+        },
         "credentialsSupported": {
           "@id": "dcp:credentialsSupported",
           "@container": "@set"


### PR DESCRIPTION
## What this PR changes/adds

updates the `dcp.v1.0.jsonld` file with the latest changes from DCP

## Why it does that

this could lead to un-expandable JSON-LD messages, e.g. when IdentityHub is embedded in the connector

## Further notes

- basically just copied IdentityHub's json-ld file over
- 
## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.

## Linked Issue(s)

Closes #5134

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
