### PR TITLE
chore: replace mockserver with wiremock

### DIFF
--- a/core/common/lib/http-lib/build.gradle.kts
+++ b/core/common/lib/http-lib/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     testImplementation(project(":core:common:junit"))
     testImplementation(project(":core:common:lib:json-lib"))
     testImplementation(project(":core:common:lib:util-lib"))
-    testImplementation(libs.mockserver.netty)
+    testImplementation(libs.wiremock)
 }
 
 

--- a/core/common/lib/json-ld-lib/build.gradle.kts
+++ b/core/common/lib/json-ld-lib/build.gradle.kts
@@ -28,6 +28,5 @@ dependencies {
     testImplementation(project(":core:common:lib:util-lib"))
     testImplementation(project(":tests:junit-base"))
 
-    testImplementation(libs.mockserver.netty)
-    testImplementation(libs.mockserver.client)
+    testImplementation(libs.wiremock)
 }

--- a/extensions/common/auth/auth-delegated/build.gradle.kts
+++ b/extensions/common/auth/auth-delegated/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 
     testImplementation(project(":core:common:junit"))
     testImplementation(project(":core:common:lib:keys-lib"))
-    testImplementation(libs.mockserver.netty)
+    testImplementation(libs.wiremock)
     testImplementation(libs.awaitility)
 }
 

--- a/extensions/common/auth/auth-delegated/src/test/java/org/eclipse/edc/api/auth/delegated/JwksPublicKeyResolverTest.java
+++ b/extensions/common/auth/auth-delegated/src/test/java/org/eclipse/edc/api/auth/delegated/JwksPublicKeyResolverTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.api.auth.delegated;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.nimbusds.jose.jwk.JWK;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.keys.KeyParserRegistryImpl;
@@ -24,64 +25,55 @@ import org.eclipse.edc.keys.spi.KeyParserRegistry;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockserver.integration.ClientAndServer;
-import org.mockserver.model.HttpRequest;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.net.MalformedURLException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.nimbusds.jose.jwk.source.JWKSourceBuilder.DEFAULT_CACHE_TIME_TO_LIVE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.api.auth.delegated.TestFunctions.generateKey;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
-import static org.eclipse.edc.util.io.Ports.getFreePort;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
-import static org.mockserver.stop.Stop.stopQuietly;
-import static org.mockserver.verify.VerificationTimes.exactly;
-import static org.mockserver.verify.VerificationTimes.never;
 
 @ComponentTest
 class JwksPublicKeyResolverTest {
 
-    private static ClientAndServer jwksServer;
+    public static final String WELL_KNOWN_JWKS_JSON = "/.well-known/jwks.json";
+    @RegisterExtension
+    static WireMockExtension jwksServer = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
     private final KeyParserRegistry keyParserRegistry = new KeyParserRegistryImpl();
     private final ObjectMapper mapper = new ObjectMapper();
     private final Monitor monitor = mock();
     private JwksPublicKeyResolver resolver;
 
-    @BeforeAll
-    static void prepare() {
-        jwksServer = ClientAndServer.startClientAndServer(getFreePort());
-    }
-
-    @AfterAll
-    static void teardown() {
-        stopQuietly(jwksServer);
-    }
 
     @BeforeEach
     void setup() {
-        jwksServer.reset();
         keyParserRegistry.register(new JwkParser(mapper, monitor));
         resolver = JwksPublicKeyResolver.create(keyParserRegistry, jwksServerUrl(), monitor, DEFAULT_CACHE_TIME_TO_LIVE);
     }
 
     @Test
     void resolve_singleKey() {
-        jwksServer.when(jwksRequest())
-                .respond(response().withStatusCode(200).withBody(jwksObject(generateKey("foo-bar-key").toPublicJWK())));
+
+        jwksServer.stubFor(get(WELL_KNOWN_JWKS_JSON)
+                .willReturn(okJson(jwksObject(generateKey("foo-bar-key").toPublicJWK()))));
 
         assertThat(resolver.resolveKey("foo-bar-key")).isSucceeded();
     }
@@ -91,11 +83,13 @@ class JwksPublicKeyResolverTest {
 
         var key1 = generateKey("foo-bar-key1").toPublicJWK();
         var key2 = generateKey("foo-bar-key2").toPublicJWK();
-        jwksServer.when(jwksRequest())
-                .respond(response().withStatusCode(200).withBody(jwksObject(key1, key2)));
+
+        jwksServer.stubFor(get(WELL_KNOWN_JWKS_JSON)
+                .willReturn(okJson(jwksObject(key1, key2))));
 
         assertThat(resolver.resolveKey("foo-bar-key2")).isSucceeded();
-        jwksServer.verify(jwksRequest(), exactly(1));
+        jwksServer.verify(1, getRequestedFor(urlEqualTo(WELL_KNOWN_JWKS_JSON)));
+
     }
 
     @Test
@@ -103,25 +97,25 @@ class JwksPublicKeyResolverTest {
 
         var key1 = generateKey("foo-bar-keyX").toPublicJWK();
         var key2 = generateKey("foo-bar-keyX").toPublicJWK();
-        jwksServer.when(jwksRequest())
-                .respond(response().withStatusCode(200).withBody(jwksObject(key1, key2)));
+        jwksServer.stubFor(get(WELL_KNOWN_JWKS_JSON)
+                .willReturn(okJson(jwksObject(key1, key2))));
 
         assertThat(resolver.resolveKey("foo-bar-keyX")).isFailed()
                 .detail().isEqualTo("JWKSet contained 2 matching keys (desired keyId: 'foo-bar-keyX'), where only 1 is expected. Will abort!");
-        jwksServer.verify(jwksRequest(), exactly(1));
+        jwksServer.verify(1, getRequestedFor(urlEqualTo(WELL_KNOWN_JWKS_JSON)));
 
     }
 
     @Test
     void resolve_keyNotFound() {
-        jwksServer.when(jwksRequest())
-                .respond(response().withStatusCode(200).withBody(jwksObject(generateKey("foo-bar-key").toPublicJWK())));
+        jwksServer.stubFor(get(WELL_KNOWN_JWKS_JSON)
+                .willReturn(okJson(jwksObject(generateKey("foo-bar-key").toPublicJWK()))));
 
         assertThat(resolver.resolveKey("not-exist")).isFailed()
                 .detail().isEqualTo("JWKSet did not contain a matching key (desired keyId: 'not-exist')");
         // the JWK source has this weird behaviour where it tries again when no key matches the selector.
         // ref: JWKSetBasedJWKSource.java
-        jwksServer.verify(jwksRequest(), exactly(2));
+        jwksServer.verify(2, getRequestedFor(urlEqualTo(WELL_KNOWN_JWKS_JSON)));
 
     }
 
@@ -129,22 +123,22 @@ class JwksPublicKeyResolverTest {
     void resolve_multipleKeys_noKeyIdGiven() {
         var key1 = generateKey("foo-bar-key1").toPublicJWK();
         var key2 = generateKey("foo-bar-key2").toPublicJWK();
-        jwksServer.when(jwksRequest())
-                .respond(response().withStatusCode(200).withBody(jwksObject(key1, key2)));
+        jwksServer.stubFor(get(WELL_KNOWN_JWKS_JSON)
+                .willReturn(okJson(jwksObject(key1, key2))));
 
         assertThat(resolver.resolveKey(null)).isFailed()
                 .detail().isEqualTo("JWKSet contained 2 keys, but no keyId was specified. Please consider specifying a keyId.");
-        jwksServer.verify(jwksRequest(), exactly(1));
+        jwksServer.verify(1, getRequestedFor(urlEqualTo(WELL_KNOWN_JWKS_JSON)));
     }
 
     @Test
     void resolve_singleKey_noKeyId() {
         var key1 = generateKey("foo-bar-key1").toPublicJWK();
-        jwksServer.when(jwksRequest())
-                .respond(response().withStatusCode(200).withBody(jwksObject(key1)));
+        jwksServer.stubFor(get(WELL_KNOWN_JWKS_JSON)
+                .willReturn(okJson(jwksObject(key1))));
 
         assertThat(resolver.resolveKey(null)).isSucceeded();
-        jwksServer.verify(jwksRequest(), exactly(1));
+        jwksServer.verify(1, getRequestedFor(urlEqualTo(WELL_KNOWN_JWKS_JSON)));
     }
 
 
@@ -163,7 +157,7 @@ class JwksPublicKeyResolverTest {
         resolver = JwksPublicKeyResolver.create(keyParserRegistry, "http:_invalid.url", monitor, DEFAULT_CACHE_TIME_TO_LIVE);
         assertThat(resolver.resolveKey("test-key")).isFailed()
                 .detail().contains("Error while retrieving JWKSet");
-        jwksServer.verify(jwksRequest(), never());
+        jwksServer.verify(0, getRequestedFor(urlEqualTo(WELL_KNOWN_JWKS_JSON)));
 
     }
 
@@ -172,18 +166,18 @@ class JwksPublicKeyResolverTest {
         var cacheTtl = 1000;
         resolver = JwksPublicKeyResolver.create(keyParserRegistry, jwksServerUrl(), monitor, cacheTtl);
 
-        jwksServer.when(jwksRequest())
-                .respond(response().withStatusCode(200).withBody(jwksObject(generateKey("foo-bar-key").toPublicJWK())));
+        jwksServer.stubFor(get(WELL_KNOWN_JWKS_JSON)
+                .willReturn(okJson(jwksObject(generateKey("foo-bar-key").toPublicJWK()))));
 
         assertThat(resolver.resolveKey("foo-bar-key")).isSucceeded();
         assertThat(resolver.resolveKey("foo-bar-key")).isSucceeded();
-        jwksServer.verify(jwksRequest(), exactly(1));
+        jwksServer.verify(1, getRequestedFor(urlEqualTo(WELL_KNOWN_JWKS_JSON)));
 
         // now wait for the cache to expire, try again and assert that the key server is hit
         await().atMost(Duration.ofMillis(3 * cacheTtl))
                 .untilAsserted(() -> {
                     assertThat(resolver.resolveKey("foo-bar-key")).isSucceeded();
-                    jwksServer.verify(jwksRequest(), exactly(1));
+                    jwksServer.verify(2, getRequestedFor(urlEqualTo(WELL_KNOWN_JWKS_JSON)));
                 });
 
     }
@@ -192,22 +186,17 @@ class JwksPublicKeyResolverTest {
     void resolve_verifyNoHitsCache() {
         resolver = JwksPublicKeyResolver.create(keyParserRegistry, jwksServerUrl(), monitor);
 
-        jwksServer.when(jwksRequest())
-                .respond(response().withStatusCode(200).withBody(jwksObject(generateKey("foo-bar-key").toPublicJWK())));
+        jwksServer.stubFor(get(WELL_KNOWN_JWKS_JSON)
+                .willReturn(okJson(jwksObject(generateKey("foo-bar-key").toPublicJWK()))));
 
         assertThat(resolver.resolveKey("foo-bar-key")).isSucceeded();
         assertThat(resolver.resolveKey("foo-bar-key")).isSucceeded();
         assertThat(resolver.resolveKey("foo-bar-key")).isSucceeded();
-        jwksServer.verify(jwksRequest(), exactly(3));
+        jwksServer.verify(3, getRequestedFor(urlEqualTo(WELL_KNOWN_JWKS_JSON)));
     }
 
     private @NotNull String jwksServerUrl() {
         return "http://localhost:%d/.well-known/jwks.json".formatted(jwksServer.getPort());
-    }
-
-    private HttpRequest jwksRequest() {
-        return request()
-                .withPath("/.well-known/jwks.json");
     }
 
     private String jwksObject(JWK... keys) {

--- a/extensions/common/events/events-cloud-http/build.gradle.kts
+++ b/extensions/common/events/events-cloud-http/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     testImplementation(project(":core:common:connector-core"))
     testImplementation(project(":core:common:runtime-core"))
 
-    testImplementation(libs.mockserver.netty)
+    testImplementation(libs.wiremock)
     testImplementation(libs.awaitility)
 }
 

--- a/extensions/common/iam/oauth2/oauth2-client/build.gradle.kts
+++ b/extensions/common/iam/oauth2/oauth2-client/build.gradle.kts
@@ -23,8 +23,7 @@ dependencies {
     testImplementation(project(":core:common:lib:json-lib"))
     testImplementation(project(":core:common:lib:util-lib"))
     testImplementation(testFixtures(project(":core:common:lib:http-lib")))
-    testImplementation(libs.mockserver.netty)
-    testImplementation(libs.mockserver.client)
+    testImplementation(libs.wiremock)
 }
 
 

--- a/extensions/common/iam/verifiable-credentials/build.gradle.kts
+++ b/extensions/common/iam/verifiable-credentials/build.gradle.kts
@@ -23,8 +23,8 @@ dependencies {
     implementation(project(":core:common:lib:util-lib"))
     implementation(libs.jsonschema)
 
+    testImplementation(libs.wiremock)
     testImplementation(testFixtures(project(":spi:common:verifiable-credentials-spi")))
-    testImplementation(libs.mockserver.netty)
     testImplementation(project(":tests:junit-base"))
     testImplementation(project(":core:common:lib:http-lib"))
     testImplementation(project(":core:common:lib:util-lib"))

--- a/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/revocation/statuslist/StatusList2021RevocationServiceTest.java
+++ b/extensions/common/iam/verifiable-credentials/src/test/java/org/eclipse/edc/iam/verifiablecredentials/revocation/statuslist/StatusList2021RevocationServiceTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.iam.verifiablecredentials.revocation.statuslist;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import dev.failsafe.RetryPolicy;
 import okhttp3.OkHttpClient;
 import org.eclipse.edc.http.client.EdcHttpClientImpl;
@@ -23,56 +24,52 @@ import org.eclipse.edc.iam.verifiablecredentials.TestData;
 import org.eclipse.edc.iam.verifiablecredentials.revocation.statuslist2021.StatusList2021RevocationService;
 import org.eclipse.edc.iam.verifiablecredentials.spi.TestFunctions;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialStatus;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.mockserver.integration.ClientAndServer;
-import org.mockserver.model.HttpResponse;
-import org.mockserver.verify.VerificationTimes;
 
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static java.util.Collections.singleton;
+import static org.eclipse.edc.iam.verifiablecredentials.TestData.StatusList2021.STATUS_LIST_CREDENTIAL_SINGLE_SUBJECT_INTERMEDIATE;
 import static org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.statuslist2021.StatusList2021Status.STATUS_LIST_CREDENTIAL;
 import static org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.statuslist2021.StatusList2021Status.STATUS_LIST_INDEX;
 import static org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.statuslist2021.StatusList2021Status.STATUS_LIST_PURPOSE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
-import static org.eclipse.edc.util.io.Ports.getFreePort;
 import static org.mockito.Mockito.mock;
-import static org.mockserver.model.HttpRequest.request;
 
 class StatusList2021RevocationServiceTest {
     private static final int NOT_REVOKED_INDEX = 1;
     private static final int REVOKED_INDEX = 2;
+    @RegisterExtension
+    static WireMockExtension clientAndServer = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
     private final StatusList2021RevocationService revocationService = new StatusList2021RevocationService(new ObjectMapper().registerModule(new JavaTimeModule()),
             5 * 60 * 1000, singleton("application/vc+jwt"), new EdcHttpClientImpl(new OkHttpClient(), RetryPolicy.ofDefaults(), mock()));
-    private ClientAndServer clientAndServer;
 
     @BeforeEach
     void setup() {
-        clientAndServer = ClientAndServer.startClientAndServer("localhost", getFreePort());
-        clientAndServer.when(request().withMethod("GET").withPath("/credentials/status/3"))
-                .respond(HttpResponse.response().withStatusCode(200).withBody(TestData.StatusList2021.STATUS_LIST_CREDENTIAL_SINGLE_SUBJECT_INTERMEDIATE));
-    }
-
-    @AfterEach
-    void tearDown() {
-        clientAndServer.stop();
     }
 
     @ParameterizedTest
     @ArgumentsSource(ArraySubjectProvider.class)
     void checkRevocation_whenSubjectIsArray(String testData) {
-        clientAndServer.reset();
-        clientAndServer.when(request().withMethod("GET").withPath("/credentials/status/3"))
-                .respond(HttpResponse.response().withStatusCode(200).withBody(testData));
+        clientAndServer.stubFor(get("/credentials/status/3").willReturn(ok(testData)));
+
         var credential = new CredentialStatus("test-id", "StatusList2021",
                 Map.of(STATUS_LIST_PURPOSE, "revocation",
                         STATUS_LIST_INDEX, NOT_REVOKED_INDEX,
@@ -82,6 +79,8 @@ class StatusList2021RevocationServiceTest {
 
     @Test
     void checkRevocation_whenNotCached_valid() {
+        clientAndServer.stubFor(get("/credentials/status/3").willReturn(ok(STATUS_LIST_CREDENTIAL_SINGLE_SUBJECT_INTERMEDIATE)));
+
         var credential = new CredentialStatus("test-id", "StatusList2021",
                 Map.of(STATUS_LIST_PURPOSE, "revocation",
                         STATUS_LIST_INDEX, NOT_REVOKED_INDEX,
@@ -91,6 +90,8 @@ class StatusList2021RevocationServiceTest {
 
     @Test
     void checkRevocation_whenNotCached_credentialPurposeMismatch() {
+        clientAndServer.stubFor(get("/credentials/status/3").willReturn(ok(STATUS_LIST_CREDENTIAL_SINGLE_SUBJECT_INTERMEDIATE)));
+
         var credential = new CredentialStatus("test-id", "StatusList2021",
                 Map.of(STATUS_LIST_PURPOSE, "suspension",
                         STATUS_LIST_INDEX, NOT_REVOKED_INDEX,
@@ -101,6 +102,8 @@ class StatusList2021RevocationServiceTest {
 
     @Test
     void checkRevocation_whenNotCached_invalid() {
+        clientAndServer.stubFor(get("/credentials/status/3").willReturn(ok(STATUS_LIST_CREDENTIAL_SINGLE_SUBJECT_INTERMEDIATE)));
+
         var credential = new CredentialStatus("test-id", "StatusList2021",
                 Map.of(STATUS_LIST_PURPOSE, "revocation",
                         STATUS_LIST_INDEX, REVOKED_INDEX,
@@ -111,20 +114,21 @@ class StatusList2021RevocationServiceTest {
 
     @Test
     void checkRevocation_whenCached_valid() {
+        clientAndServer.stubFor(get("/credentials/status/3").willReturn(ok(STATUS_LIST_CREDENTIAL_SINGLE_SUBJECT_INTERMEDIATE)));
+
         var credential = new CredentialStatus("test-id", "StatusList2021Entry",
                 Map.of(STATUS_LIST_PURPOSE, "revocation",
                         STATUS_LIST_INDEX, NOT_REVOKED_INDEX,
                         STATUS_LIST_CREDENTIAL, "http://localhost:%d/credentials/status/3".formatted(clientAndServer.getPort())));
         assertThat(revocationService.checkValidity(credential)).isSucceeded();
         assertThat(revocationService.checkValidity(credential)).isSucceeded();
-        clientAndServer.verify(request(), VerificationTimes.exactly(1));
+        clientAndServer.verify(1, getRequestedFor(urlEqualTo("/credentials/status/3")));
     }
 
     @Test
     void checkValidity_wrongContentType_expect415() {
-        clientAndServer.reset()
-                .when(request().withMethod("GET").withPath("/credentials/status/3"))
-                .respond(HttpResponse.response().withStatusCode(415));
+        clientAndServer.stubFor(get("/credentials/status/3").willReturn(aResponse().withStatus(415)));
+
         var credential = new CredentialStatus("test-id", "StatusList2021Entry",
                 Map.of(STATUS_LIST_PURPOSE, "revocation",
                         STATUS_LIST_INDEX, NOT_REVOKED_INDEX,
@@ -138,14 +142,13 @@ class StatusList2021RevocationServiceTest {
     @ParameterizedTest
     @ArgumentsSource(SingleSubjectProvider.class)
     void getStatusPurposes_whenSingleCredentialStatusRevoked(String testData) {
-        clientAndServer.reset();
-        clientAndServer.when(request().withMethod("GET").withPath("/credentials/status/3"))
-                .respond(HttpResponse.response().withStatusCode(200).withBody(testData));
+        clientAndServer.stubFor(get("/credentials/status/3").willReturn(ok(testData)));
+
         var credential = TestFunctions.createCredentialBuilder().credentialStatus(new CredentialStatus("test-id", "StatusList2021",
                         Map.of(STATUS_LIST_PURPOSE, "revocation",
                                 STATUS_LIST_INDEX, REVOKED_INDEX,
                                 STATUS_LIST_CREDENTIAL, "http://localhost:%d/credentials/status/3".formatted(clientAndServer.getPort()))))
-                                 .build();
+                .build();
         assertThat(revocationService.getStatusPurpose(credential)).isSucceeded()
                 .isEqualTo("revocation");
     }
@@ -153,14 +156,13 @@ class StatusList2021RevocationServiceTest {
     @ParameterizedTest
     @ArgumentsSource(ArraySubjectProvider.class)
     void getStatusPurposes_whenMultipleCredentialStatusRevoked(String testData) {
-        clientAndServer.reset();
-        clientAndServer.when(request().withMethod("GET").withPath("/credentials/status/3"))
-                .respond(HttpResponse.response().withStatusCode(200).withBody(testData));
+        clientAndServer.stubFor(get("/credentials/status/3").willReturn(ok(testData)));
+
         var credential = TestFunctions.createCredentialBuilder().credentialStatus(new CredentialStatus("test-id", "StatusList2021",
                         Map.of(STATUS_LIST_PURPOSE, "revocation",
                                 STATUS_LIST_INDEX, REVOKED_INDEX,
                                 STATUS_LIST_CREDENTIAL, "http://localhost:%d/credentials/status/3".formatted(clientAndServer.getPort()))))
-                                 .build();
+                .build();
         assertThat(revocationService.getStatusPurpose(credential)).isSucceeded()
                 .isEqualTo("revocation");
     }
@@ -168,14 +170,13 @@ class StatusList2021RevocationServiceTest {
     @ParameterizedTest
     @ArgumentsSource(SingleSubjectProvider.class)
     void getStatusPurpose_whenCredentialStatusNotActive(String testData) {
-        clientAndServer.reset();
-        clientAndServer.when(request().withMethod("GET").withPath("/credentials/status/3"))
-                .respond(HttpResponse.response().withStatusCode(200).withBody(testData));
+        clientAndServer.stubFor(get("/credentials/status/3").willReturn(ok(testData)));
+
         var credential = TestFunctions.createCredentialBuilder().credentialStatus(new CredentialStatus("test-id", "StatusList2021",
                         Map.of(STATUS_LIST_PURPOSE, "revocation",
                                 STATUS_LIST_INDEX, NOT_REVOKED_INDEX,
                                 STATUS_LIST_CREDENTIAL, "http://localhost:%d/credentials/status/3".formatted(clientAndServer.getPort()))))
-                                 .build();
+                .build();
         assertThat(revocationService.getStatusPurpose(credential)).isSucceeded()
                 .isNull();
     }
@@ -183,9 +184,8 @@ class StatusList2021RevocationServiceTest {
     @ParameterizedTest
     @ArgumentsSource(SingleSubjectProvider.class)
     void getStatusPurpose_whenNoCredentialStatus(String testData) {
-        clientAndServer.reset();
-        clientAndServer.when(request().withMethod("GET").withPath("/credentials/status/3"))
-                .respond(HttpResponse.response().withStatusCode(200).withBody(testData));
+        clientAndServer.stubFor(get("/credentials/status/3").willReturn(ok(testData)));
+
         var credential = TestFunctions.createCredentialBuilder().build();
         assertThat(revocationService.getStatusPurpose(credential))
                 .isNotNull()
@@ -197,7 +197,7 @@ class StatusList2021RevocationServiceTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) {
             return Stream.of(
-                    Arguments.of(Named.of("VC (intermediate)", TestData.StatusList2021.STATUS_LIST_CREDENTIAL_SINGLE_SUBJECT_INTERMEDIATE)),
+                    Arguments.of(Named.of("VC (intermediate)", STATUS_LIST_CREDENTIAL_SINGLE_SUBJECT_INTERMEDIATE)),
                     Arguments.of(Named.of("VC 1.1", TestData.StatusList2021.STATUS_LIST_CREDENTIAL_SINGLE_SUBJECT_1_0)),
                     Arguments.of(Named.of("VC 2.0", TestData.StatusList2021.STATUS_LIST_CREDENTIAL_SINGLE_SUBJECT_2_0))
 

--- a/extensions/common/json-ld/build.gradle.kts
+++ b/extensions/common/json-ld/build.gradle.kts
@@ -25,8 +25,5 @@ dependencies {
 
     implementation(project(":core:common:lib:json-ld-lib"))
     testImplementation(project(":core:common:junit"));
-
-    testImplementation(libs.mockserver.netty)
-    testImplementation(libs.mockserver.client)
-
+    
 }

--- a/extensions/control-plane/callback/callback-http-dispatcher/build.gradle.kts
+++ b/extensions/control-plane/callback/callback-http-dispatcher/build.gradle.kts
@@ -10,8 +10,7 @@ dependencies {
     api(project(":spi:control-plane:control-plane-spi"))
 
 
-    testImplementation(libs.mockserver.netty)
-    testImplementation(libs.mockserver.client)
+    testImplementation(libs.wiremock)
     testImplementation(testFixtures(project(":core:common:lib:http-lib")))
     testImplementation(project(":core:common:junit"))
 

--- a/extensions/data-plane/data-plane-http-oauth2-core/build.gradle.kts
+++ b/extensions/data-plane/data-plane-http-oauth2-core/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
 
     testImplementation(project(":core:common:junit"))
     testImplementation(libs.restAssured)
-    testImplementation(libs.mockserver.netty)
 }
 
 

--- a/extensions/data-plane/data-plane-http/build.gradle.kts
+++ b/extensions/data-plane/data-plane-http/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     testImplementation(project(":core:data-plane:data-plane-core"))
     testImplementation(project(":extensions:common:json-ld"))
     testImplementation(libs.restAssured)
-    testImplementation(libs.mockserver.netty)
+    testImplementation(libs.wiremock)
 
     testImplementation(testFixtures(project(":core:common:lib:http-lib")))
     testImplementation(testFixtures(project(":spi:data-plane:data-plane-spi")))

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/params/HttpRequestFactoryTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/params/HttpRequestFactoryTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.dataplane.http.params;
 
-import io.netty.handler.codec.http.HttpMethod;
 import org.eclipse.edc.connector.dataplane.http.spi.HttpRequestParams;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
 import org.junit.jupiter.api.Nested;
@@ -29,7 +28,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Map;
 
-import static io.netty.handler.codec.http.HttpMethod.POST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.dataplane.http.testfixtures.TestFunctions.formatRequestBodyAsString;
 
@@ -50,7 +48,7 @@ class HttpRequestFactoryTest {
         void verifyPathIgnoredWhenNullOrBlank(String p) {
             var params = HttpRequestParams.Builder.newInstance()
                     .baseUrl(BASE_URL)
-                    .method(HttpMethod.GET.name())
+                    .method("GET")
                     .path(p)
                     .build();
 
@@ -64,7 +62,7 @@ class HttpRequestFactoryTest {
         void verifyQueryParamsIgnoredWhenNullOrBlank(String qp) {
             var params = HttpRequestParams.Builder.newInstance()
                     .baseUrl(BASE_URL)
-                    .method(HttpMethod.GET.name())
+                    .method("GET")
                     .queryParams(qp)
                     .build();
 
@@ -78,7 +76,7 @@ class HttpRequestFactoryTest {
             var headers = Map.of("key1", "value1");
             var params = HttpRequestParams.Builder.newInstance()
                     .baseUrl(BASE_URL)
-                    .method(HttpMethod.GET.name())
+                    .method("GET")
                     .headers(headers)
                     .build();
 
@@ -94,7 +92,7 @@ class HttpRequestFactoryTest {
             var queryParams = "test-queryparams";
             var params = HttpRequestParams.Builder.newInstance()
                     .baseUrl(BASE_URL)
-                    .method(HttpMethod.GET.name())
+                    .method("GET")
                     .path(path)
                     .queryParams(queryParams)
                     .build();
@@ -105,7 +103,7 @@ class HttpRequestFactoryTest {
             assertBaseUrl(url);
             assertThat(url.getPath()).isEqualTo("/" + path);
             assertThat(url.getQuery()).isEqualTo(queryParams);
-            assertThat(httpRequest.method()).isEqualTo(HttpMethod.GET.name());
+            assertThat(httpRequest.method()).isEqualTo("GET");
         }
 
         @Test
@@ -114,7 +112,7 @@ class HttpRequestFactoryTest {
             var contentType = "application/octet-stream";
             var params = HttpRequestParams.Builder.newInstance()
                     .baseUrl(BASE_URL)
-                    .method(POST.name())
+                    .method("POST")
                     .body(body)
                     .build();
 
@@ -131,7 +129,7 @@ class HttpRequestFactoryTest {
             var contentType = "text/plain";
             var params = HttpRequestParams.Builder.newInstance()
                     .baseUrl(BASE_URL)
-                    .method(POST.name())
+                    .method("POST")
                     .contentType(contentType)
                     .body(body)
                     .build();
@@ -149,7 +147,7 @@ class HttpRequestFactoryTest {
             var contentType = "test/content-type";
             var params = HttpRequestParams.Builder.newInstance()
                     .baseUrl(BASE_URL)
-                    .method(HttpMethod.GET.name())
+                    .method("GET")
                     .contentType(contentType)
                     .build();
 
@@ -174,7 +172,7 @@ class HttpRequestFactoryTest {
             var body = "Test body";
             var params = HttpRequestParams.Builder.newInstance()
                     .baseUrl(BASE_URL)
-                    .method(POST.name())
+                    .method("POST")
                     .contentType("application/json")
                     .build();
 
@@ -190,7 +188,7 @@ class HttpRequestFactoryTest {
         void verifyChunkedRequest() throws IOException {
             var params = HttpRequestParams.Builder.newInstance()
                     .baseUrl(BASE_URL)
-                    .method(POST.name())
+                    .method("POST")
                     .nonChunkedTransfer(false)
                     .build();
 
@@ -205,7 +203,7 @@ class HttpRequestFactoryTest {
         void verifyNotChunkedRequest() throws IOException {
             var params = HttpRequestParams.Builder.newInstance()
                     .baseUrl(BASE_URL)
-                    .method(POST.name())
+                    .method("POST")
                     .nonChunkedTransfer(true)
                     .build();
 

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/DataSourceToDataSinkTests.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/DataSourceToDataSinkTests.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.edc.connector.dataplane.http.pipeline;
 
-import io.netty.handler.codec.http.HttpMethod;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.Protocol;
@@ -70,7 +69,7 @@ class DataSourceToDataSinkTests {
         var dataSource = HttpDataSource.Builder.newInstance()
                 .params(HttpRequestParams.Builder.newInstance()
                         .baseUrl(NULL_ENDPOINT)
-                        .method(HttpMethod.GET.name())
+                        .method("GET")
                         .build())
                 .name("test.json")
                 .requestId("1")
@@ -84,7 +83,7 @@ class DataSourceToDataSinkTests {
         var dataSink = HttpDataSink.Builder.newInstance()
                 .params(HttpRequestParams.Builder.newInstance()
                         .baseUrl("https://example.com/sink")
-                        .method(HttpMethod.POST.name())
+                        .method("POST")
                         .contentType(CONTENT_TYPE)
                         .build())
                 .requestId("1")
@@ -117,7 +116,7 @@ class DataSourceToDataSinkTests {
         var dataSource = HttpDataSource.Builder.newInstance()
                 .params(HttpRequestParams.Builder.newInstance()
                         .baseUrl(NULL_ENDPOINT)
-                        .method(HttpMethod.GET.name())
+                        .method("GET")
                         .build())
                 .name("test.json")
                 .requestId("1")
@@ -131,7 +130,7 @@ class DataSourceToDataSinkTests {
         var dataSink = HttpDataSink.Builder.newInstance()
                 .params(HttpRequestParams.Builder.newInstance()
                         .baseUrl("https://example.com/sink")
-                        .method(HttpMethod.POST.name())
+                        .method("POST")
                         .contentType(CONTENT_TYPE)
                         .build())
                 .requestId("1")
@@ -163,7 +162,7 @@ class DataSourceToDataSinkTests {
         var dataSource = HttpDataSource.Builder.newInstance()
                 .params(HttpRequestParams.Builder.newInstance()
                         .baseUrl(NULL_ENDPOINT)
-                        .method(HttpMethod.GET.name())
+                        .method("GET")
                         .build())
                 .name("test.json")
                 .requestId("1")
@@ -183,7 +182,7 @@ class DataSourceToDataSinkTests {
         var dataSink = HttpDataSink.Builder.newInstance()
                 .params(HttpRequestParams.Builder.newInstance()
                         .baseUrl(NULL_ENDPOINT)
-                        .method(HttpMethod.POST.name())
+                        .method("POST")
                         .contentType(CONTENT_TYPE)
                         .build())
                 .requestId("1")
@@ -218,7 +217,7 @@ class DataSourceToDataSinkTests {
         var dataSink = HttpDataSink.Builder.newInstance()
                 .params(HttpRequestParams.Builder.newInstance()
                         .baseUrl("https://example.com/sink")
-                        .method(HttpMethod.POST.name())
+                        .method("POST")
                         .contentType(CONTENT_TYPE)
                         .build())
                 .requestId("1")

--- a/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-http/src/test/java/org/eclipse/edc/connector/dataplane/http/pipeline/HttpDataSinkFactoryTest.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.edc.connector.dataplane.http.pipeline;
 
-import io.netty.handler.codec.http.HttpMethod;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 import org.eclipse.edc.connector.dataplane.http.params.HttpRequestFactory;
@@ -83,7 +82,7 @@ class HttpDataSinkFactoryTest {
         var request = createRequest(address);
         var params = HttpRequestParams.Builder.newInstance()
                 .baseUrl("http://some.base.url")
-                .method(HttpMethod.POST.name())
+                .method("POST")
                 .contentType("application/json")
                 .build();
         when(provider.provideSinkParams(request)).thenReturn(params);
@@ -106,7 +105,7 @@ class HttpDataSinkFactoryTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "POST", "GET", "PUT" })
+    @ValueSource(strings = {"POST", "GET", "PUT"})
     void verifyCreateMethodDestination(String method) throws IOException {
         var address = HttpDataAddress.Builder.newInstance().build();
         var request = createRequest(address);

--- a/extensions/data-plane/data-plane-integration-tests/build.gradle.kts
+++ b/extensions/data-plane/data-plane-integration-tests/build.gradle.kts
@@ -19,8 +19,7 @@ plugins {
 dependencies {
     testImplementation(libs.restAssured)
     testImplementation(libs.awaitility)
-    testImplementation(libs.mockserver.netty)
-    testImplementation(libs.mockserver.client)
+    testImplementation(libs.wiremock)
 
     testImplementation(project(":core:common:connector-core"))
     testImplementation(project(":core:common:runtime-core"))

--- a/extensions/data-plane/data-plane-kafka/build.gradle.kts
+++ b/extensions/data-plane/data-plane-kafka/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     implementation(libs.kafkaClients)
 
     testImplementation(project(":core:common:junit"))
-    testImplementation(libs.mockserver.netty)
     testImplementation(libs.restAssured)
     testImplementation(libs.awaitility)
 }

--- a/extensions/data-plane/data-plane-public-api-v2/build.gradle.kts
+++ b/extensions/data-plane/data-plane-public-api-v2/build.gradle.kts
@@ -33,8 +33,6 @@ dependencies {
     testImplementation(project(":core:common:junit"))
     testImplementation(libs.jersey.multipart)
     testImplementation(libs.restAssured)
-    testImplementation(libs.mockserver.netty)
-    testImplementation(libs.mockserver.client)
     testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
 }
 edcBuild {

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/build.gradle.kts
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/build.gradle.kts
@@ -33,8 +33,7 @@ dependencies {
     testImplementation(project(":core:common:lib:json-ld-lib"))
     testImplementation(project(":extensions:common:json-ld"))
     testImplementation(libs.restAssured)
-    testImplementation(libs.mockserver.netty)
-    testImplementation(libs.mockserver.client)
+    testImplementation(libs.wiremock)
 
     testImplementation(testFixtures(project(":core:common:lib:http-lib")))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,6 @@ cloudEvents = "4.0.1"
 edc = "0.14.0-SNAPSHOT"
 failsafe = "3.3.2"
 h2 = "2.3.232"
-httpMockServer = "5.15.0"
 jakarta-annotation = "3.0.0"
 jakarta-json = "2.1.3"
 jakarta-servlet = "6.1.0"
@@ -41,6 +40,7 @@ tink = "1.18.0"
 dsp-tck = "1.0.0-RC4"
 dcp-tck = "1.0.0-RC4"
 junit = "1.13.4"
+wiremock = "3.13.1"
 
 [libraries]
 iron-vc = { module = "com.apicatalog:iron-verifiable-credentials", version.ref = "apicatalog" }
@@ -80,8 +80,7 @@ junit-pioneer = { module = "org.junit-pioneer:junit-pioneer", version.ref = "jun
 micrometer = { module = "io.micrometer:micrometer-core", version.ref = "micrometer" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito" }
-mockserver-client = { module = "org.mock-server:mockserver-client-java", version.ref = "httpMockServer" }
-mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "httpMockServer" }
+wiremock = { module = "org.wiremock:wiremock-jetty12", version.ref = "wiremock" }
 nimbus-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbus" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version.ref = "opentelemetry" }

--- a/system-tests/bom-tests/build.gradle.kts
+++ b/system-tests/bom-tests/build.gradle.kts
@@ -21,8 +21,7 @@ dependencies {
     testImplementation(project(":core:common:lib:boot-lib"))
     testImplementation(libs.restAssured)
     testImplementation(libs.awaitility)
-    testImplementation(libs.mockserver.netty)
-    testImplementation(libs.mockserver.client)
+    testImplementation(libs.wiremock)
 }
 
 edcBuild {

--- a/system-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
+++ b/system-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
@@ -14,28 +14,27 @@
 
 package org.eclipse.edc.test.bom;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockserver.integration.ClientAndServer;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
-import static org.mockserver.stop.Stop.stopQuietly;
 
 public class BomSmokeTests {
     abstract static class SmokeTest {
@@ -63,21 +62,21 @@ public class BomSmokeTests {
         protected RuntimeExtension runtime = new RuntimePerMethodExtension(
                 new EmbeddedRuntime("control-plane-dcp-bom", ":dist:bom:controlplane-dcp-bom")
                         .configurationProvider(() -> ConfigFactory.fromMap(new HashMap<>() {{
-                                put("edc.iam.sts.oauth.token.url", "https://sts.com/token");
-                                put("edc.iam.sts.oauth.client.id", "test-client");
-                                put("edc.iam.sts.oauth.client.secret.alias", "test-alias");
-                                put("web.http.port", DEFAULT_PORT);
-                                put("web.http.path", DEFAULT_PATH);
-                                put("web.http.version.port", String.valueOf(getFreePort()));
-                                put("web.http.version.path", "/api/version");
-                                put("web.http.control.port", String.valueOf(getFreePort()));
-                                put("web.http.control.path", "/api/control");
-                                put("web.http.management.port", "8081");
-                                put("web.http.management.path", "/api/management");
-                                put("edc.iam.sts.privatekey.alias", "privatekey");
-                                put("edc.iam.sts.publickey.id", "publickey");
-                                put("edc.iam.issuer.id", "did:web:someone");
-                            }})
+                                    put("edc.iam.sts.oauth.token.url", "https://sts.com/token");
+                                    put("edc.iam.sts.oauth.client.id", "test-client");
+                                    put("edc.iam.sts.oauth.client.secret.alias", "test-alias");
+                                    put("web.http.port", DEFAULT_PORT);
+                                    put("web.http.path", DEFAULT_PATH);
+                                    put("web.http.version.port", String.valueOf(getFreePort()));
+                                    put("web.http.version.path", "/api/version");
+                                    put("web.http.control.port", String.valueOf(getFreePort()));
+                                    put("web.http.control.path", "/api/control");
+                                    put("web.http.management.port", "8081");
+                                    put("web.http.management.path", "/api/management");
+                                    put("edc.iam.sts.privatekey.alias", "privatekey");
+                                    put("edc.iam.sts.publickey.id", "publickey");
+                                    put("edc.iam.issuer.id", "did:web:someone");
+                                }})
                         )
         );
     }
@@ -86,7 +85,11 @@ public class BomSmokeTests {
     @EndToEndTest
     public class DataPlaneBase extends SmokeTest {
 
-        private static ClientAndServer server;
+        @RegisterExtension
+        static WireMockExtension server = WireMockExtension.newInstance()
+                .options(wireMockConfig().dynamicPort())
+                .build();
+
         @RegisterExtension
         protected RuntimeExtension runtime =
                 new RuntimePerMethodExtension(new EmbeddedRuntime("data-plane-base-bom", ":dist:bom:dataplane-base-bom")
@@ -102,16 +105,9 @@ public class BomSmokeTests {
                                 "web.http.path", DEFAULT_PATH)))
                 );
 
-        @BeforeAll
-        static void setup() {
-            server = ClientAndServer.startClientAndServer(getFreePort());
-            server.when(request().withPath("/selector"))
-                    .respond(response().withStatusCode(200));
-        }
-
-        @AfterAll
-        static void afterAll() {
-            stopQuietly(server);
+        @BeforeEach
+        void setup() {
+            server.stubFor(post("/selector").willReturn(ok()));
         }
     }
 

--- a/system-tests/dcp-tck-tests/presentation/build.gradle.kts
+++ b/system-tests/dcp-tck-tests/presentation/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     testImplementation(libs.dcp.tck.runtime)
     testImplementation(libs.dcp.system)
     testImplementation(libs.dsp.core)
-    testImplementation(libs.mockserver.netty)
+    testImplementation(libs.wiremock)
     testImplementation(libs.junit.platform.launcher)
     testImplementation(libs.testcontainers.junit)
 }

--- a/system-tests/e2e-dataplane-tests/tests/build.gradle.kts
+++ b/system-tests/e2e-dataplane-tests/tests/build.gradle.kts
@@ -29,9 +29,8 @@ dependencies {
 
     testImplementation(libs.restAssured)
     testImplementation(libs.awaitility)
-    testImplementation(libs.mockserver.netty)
-    testImplementation(libs.mockserver.client)
     testImplementation(libs.testcontainers.postgres)
+    testImplementation(libs.wiremock)
 
     testCompileOnly(project(":system-tests:e2e-dataplane-tests:runtimes:data-plane"))
 }

--- a/system-tests/e2e-transfer-test/runner/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/runner/build.gradle.kts
@@ -33,12 +33,11 @@ dependencies {
     testImplementation(libs.postgres)
     testImplementation(libs.restAssured)
     testImplementation(libs.awaitility)
-    testImplementation(libs.mockserver.netty)
-    testImplementation(libs.mockserver.client)
     testImplementation(libs.kafkaClients)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.kafka)
     testImplementation(libs.testcontainers.postgres)
+    testImplementation(libs.wiremock)
 
     testCompileOnly(project(":system-tests:e2e-transfer-test:control-plane"))
     testCompileOnly(project(":system-tests:e2e-transfer-test:data-plane"))

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
@@ -14,14 +14,14 @@
 
 package org.eclipse.edc.test.e2e;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpMethod;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
+import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures;
@@ -47,41 +47,39 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockserver.mock.action.ExpectationResponseCallback;
-import org.mockserver.model.HttpRequest;
-import org.mockserver.model.HttpResponse;
-import org.mockserver.model.HttpStatusCode;
-import org.mockserver.model.MediaType;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static java.time.Duration.ofDays;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static okhttp3.MediaType.get;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.inForceDatePolicy;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.DEPROVISIONED;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.REQUESTED;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.STARTED;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.SUSPENDED;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATED;
 import static org.eclipse.edc.http.client.testfixtures.HttpTestUtils.testHttpClient;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
-import static org.eclipse.edc.util.io.Ports.getFreePort;
-import static org.mockserver.integration.ClientAndServer.startClientAndServer;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
-import static org.mockserver.stop.Stop.stopQuietly;
 
 
 class TransferPullEndToEndTest {
@@ -89,6 +87,12 @@ class TransferPullEndToEndTest {
     abstract static class Tests extends TransferEndToEndTestBase {
 
         private static final ObjectMapper MAPPER = new ObjectMapper();
+
+        @RegisterExtension
+        static WireMockExtension callbacksEndpoint = WireMockExtension.newInstance()
+                .options(wireMockConfig().dynamicPort())
+                .build();
+
 
         private static @NotNull Map<String, Object> httpSourceDataAddress() {
             return Map.of(
@@ -99,22 +103,17 @@ class TransferPullEndToEndTest {
         }
 
         @Test
-        void httpPull_dataTransfer_withCallbacks() {
-            var callbacksEndpoint = startClientAndServer(getFreePort());
+        void httpPull_dataTransfer_withCallbacks() throws IOException {
             var assetId = UUID.randomUUID().toString();
             createResourcesOnProvider(assetId, httpSourceDataAddress());
 
-            var callbackUrl = String.format("http://localhost:%d/hooks", callbacksEndpoint.getLocalPort());
+            var callbackUrl = String.format("http://localhost:%d/hooks", callbacksEndpoint.getPort());
             var callbacks = Json.createArrayBuilder()
                     .add(createCallback(callbackUrl, true, Set.of("transfer.process.started")))
                     .build();
 
-            var request = request().withPath("/hooks")
-                    .withMethod(HttpMethod.POST.name());
 
-            var events = new ConcurrentHashMap<String, TransferProcessStarted>();
-
-            callbacksEndpoint.when(request).respond(req -> this.cacheEdr(req, events));
+            callbacksEndpoint.stubFor(post("/hooks").willReturn(okJson("{}")));
 
             var transferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
                     .withTransferType("HttpData-PULL")
@@ -123,13 +122,18 @@ class TransferPullEndToEndTest {
 
             CONSUMER.awaitTransferToBeInState(transferProcessId, STARTED);
 
-            await().atMost(timeout).untilAsserted(() -> assertThat(events.get(transferProcessId)).isNotNull());
+            await().atMost(timeout).untilAsserted(() -> callbacksEndpoint.verify(postRequestedFor(urlEqualTo("/hooks"))));
 
-            var event = events.get(transferProcessId);
+            var requests = callbacksEndpoint.getAllServeEvents();
+            assertThat(requests).hasSize(1);
+            var request = requests.get(0).getRequest();
+
+            var event = MAPPER.readValue(request.getBody(), new TypeReference<EventEnvelope<TransferProcessStarted>>() {
+            });
+
             var msg = UUID.randomUUID().toString();
-            await().atMost(timeout).untilAsserted(() -> CONSUMER.pullData(event.getDataAddress(), Map.of("message", msg), body -> assertThat(body).isEqualTo("data")));
+            await().atMost(timeout).untilAsserted(() -> CONSUMER.pullData(event.getPayload().getDataAddress(), Map.of("message", msg), body -> assertThat(body).isEqualTo("data")));
 
-            stopQuietly(callbacksEndpoint);
         }
 
         @Test
@@ -204,13 +208,16 @@ class TransferPullEndToEndTest {
 
         @Test
         void pullFromHttp_httpProvision() {
-            var provisionServer = startClientAndServer(PROVIDER.getHttpProvisionerPort());
-            provisionServer.when(request("/provision")).respond(new HttpProvisionerCallback());
+
+            var provisionServer = new WireMockServer(options().port(PROVIDER.getHttpProvisionerPort()));
+
+            provisionServer.stubFor(post(urlEqualTo("/provision")).willReturn(ok()));
+            provisionServer.start();
 
             var assetId = UUID.randomUUID().toString();
             createResourcesOnProvider(assetId, Map.of(
                     "name", "transfer-test",
-                    "baseUrl", "http://localhost:" + provisionServer.getPort() + "/provision",
+                    "baseUrl", "http://localhost:" + provisionServer.port() + "/provision",
                     "type", "HttpProvision",
                     "proxyQueryParams", "true"
             ));
@@ -219,23 +226,34 @@ class TransferPullEndToEndTest {
                     .withTransferType("HttpData-PULL")
                     .execute();
 
+            CONSUMER.awaitTransferToBeInState(consumerTransferProcessId, REQUESTED);
+
+            var providerTransferProcessId = new AtomicReference<String>();
+
+            await().untilAsserted(() -> {
+                var ptId = PROVIDER.getTransferProcesses().stream()
+                        .filter(filter -> filter.asJsonObject().getString("correlationId").equals(consumerTransferProcessId))
+                        .map(id -> id.asJsonObject().getString("@id")).findFirst().orElseThrow();
+
+                assertThat(ptId).isNotNull();
+                providerTransferProcessId.set(ptId);
+            });
+
+            provision(provisionServer);
+
+            provisionServer.verify(postRequestedFor(urlEqualTo("/provision")));
+            provisionServer.resetRequests();
+
             CONSUMER.awaitTransferToBeInState(consumerTransferProcessId, STARTED);
 
             assertConsumerCanAccessData(consumerTransferProcessId);
 
-            provisionServer.verify(request("/provision"));
-            provisionServer.clear(request("provision"));
+            PROVIDER.terminateTransfer(providerTransferProcessId.get());
+            PROVIDER.awaitTransferToBeInState(providerTransferProcessId.get(), DEPROVISIONED);
 
-            var providerTransferProcessId = PROVIDER.getTransferProcesses().stream()
-                    .filter(filter -> filter.asJsonObject().getString("correlationId").equals(consumerTransferProcessId))
-                    .map(id -> id.asJsonObject().getString("@id")).findFirst().orElseThrow();
+            provisionServer.verify(postRequestedFor(urlEqualTo("/provision")));
 
-            PROVIDER.terminateTransfer(providerTransferProcessId);
-            PROVIDER.awaitTransferToBeInState(providerTransferProcessId, DEPROVISIONED);
-
-            provisionServer.verify(request("/provision"));
-
-            stopQuietly(provisionServer);
+            provisionServer.stop();
         }
 
         @Test
@@ -347,33 +365,12 @@ class TransferPullEndToEndTest {
             );
         }
 
-        private HttpResponse cacheEdr(HttpRequest request, Map<String, TransferProcessStarted> events) {
-
+        private void provision(WireMockServer provisionServer) {
+            var events = provisionServer.getAllServeEvents();
+            assertThat(events).hasSize(1);
+            var request = events.get(0).getRequest();
             try {
-                var event = MAPPER.readValue(request.getBody().toString(), new TypeReference<EventEnvelope<TransferProcessStarted>>() {
-                });
-                events.put(event.getPayload().getTransferProcessId(), event.getPayload());
-                return response()
-                        .withStatusCode(HttpStatusCode.OK_200.code())
-                        .withHeader(HttpHeaderNames.CONTENT_TYPE.toString(), MediaType.PLAIN_TEXT_UTF_8.toString())
-                        .withBody("{}");
-
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        private record EdrMessage(DataAddress address, String message) {
-        }
-
-        /**
-         * Mocked http provisioner
-         */
-        private static class HttpProvisionerCallback implements ExpectationResponseCallback {
-
-            @Override
-            public HttpResponse handle(HttpRequest httpRequest) throws Exception {
-                var requestBody = MAPPER.readValue(httpRequest.getBodyAsString(), Map.class);
+                var requestBody = MAPPER.readValue(request.getBody(), Map.class);
 
                 if ("provision".equals(requestBody.get("type"))) {
                     var callbackRequestBody = Map.of(
@@ -388,21 +385,26 @@ class TransferPullEndToEndTest {
 
                     Executors.newScheduledThreadPool(1).schedule(() -> {
                         try {
-                            var request = new Request.Builder()
+                            var provisionRequest = new Request.Builder()
                                     .url("%s/%s/provision".formatted(requestBody.get("callbackAddress"), requestBody.get("transferProcessId")))
-                                    .post(RequestBody.create(MAPPER.writeValueAsString(callbackRequestBody), get("application/json")))
+                                    .post(RequestBody.create(MAPPER.writeValueAsString(callbackRequestBody), MediaType.get("application/json")))
                                     .build();
 
-                            testHttpClient().execute(request).close();
+                            testHttpClient().execute(provisionRequest).close();
                         } catch (Exception e) {
                             throw new EdcException(e);
                         }
                     }, 1, SECONDS);
                 }
-
-                return response();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
             }
+
         }
+
+        private record EdrMessage(DataAddress address, String message) {
+        }
+
     }
 
     @Nested

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferStreamingEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferStreamingEndToEndTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.test.e2e;
 
-import io.netty.handler.codec.http.HttpMethod;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -38,8 +38,13 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import javax.validation.constraints.NotNull;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.moreThanOrExactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static java.lang.String.format;
 import static java.time.Duration.ZERO;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
@@ -53,15 +58,159 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATED;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
-import static org.eclipse.edc.util.io.Ports.getFreePort;
-import static org.mockserver.integration.ClientAndServer.startClientAndServer;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
-import static org.mockserver.stop.Stop.stopQuietly;
-import static org.mockserver.verify.VerificationTimes.atLeast;
-import static org.mockserver.verify.VerificationTimes.never;
 
 public class TransferStreamingEndToEndTest {
+
+    @Testcontainers
+    abstract static class Tests extends TransferEndToEndTestBase {
+
+        @RegisterExtension
+        static WireMockExtension destinationServer = WireMockExtension.newInstance()
+                .options(wireMockConfig().dynamicPort())
+                .build();
+        
+        protected final String sinkTopic = "sink_topic_" + UUID.randomUUID();
+        private final String sourceTopic = "source_topic_" + UUID.randomUUID();
+
+        protected abstract KafkaExtension getKafkaExtension();
+
+        @BeforeEach
+        void setUp() {
+            var producer = getKafkaExtension().createKafkaProducer();
+
+            newSingleThreadScheduledExecutor().scheduleAtFixedRate(
+                    () -> producer.send(new ProducerRecord<>(sourceTopic, sampleMessage())),
+                    0, 100, MILLISECONDS);
+        }
+
+        @Test
+        void kafkaToHttpTransfer() {
+
+            destinationServer.stubFor(post("/api/service")
+                    .willReturn(okJson("{}")));
+
+            var assetId = UUID.randomUUID().toString();
+            createResourcesOnProvider(assetId, contractExpiresIn("10s"), kafkaSourceProperty(getKafkaExtension().getBootstrapServers()));
+
+            var destination = httpSink(destinationServer.getPort(), "/api/service");
+            var transferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
+                    .withDestination(destination).withTransferType("HttpData-PUSH").execute();
+
+            await().atMost(timeout).untilAsserted(() -> {
+                destinationServer.verify(moreThanOrExactly(1), postRequestedFor(urlEqualTo("/api/service")));
+            });
+
+            CONSUMER.awaitTransferToBeInState(transferProcessId, TERMINATED);
+
+            destinationServer.resetRequests();
+
+            await().pollDelay(5, SECONDS).atMost(timeout).untilAsserted(() -> {
+                try {
+                    destinationServer.verify(0, postRequestedFor(urlEqualTo("/api/service")));
+                } catch (AssertionError assertionError) {
+                    destinationServer.resetRequests();
+                    throw assertionError;
+                }
+            });
+
+        }
+
+        @Test
+        void kafkaToKafkaTransfer() {
+            try (var consumer = getKafkaExtension().createKafkaConsumer()) {
+                consumer.subscribe(List.of(sinkTopic));
+
+                var assetId = UUID.randomUUID().toString();
+                createResourcesOnProvider(assetId, contractExpiresIn("10s"), kafkaSourceProperty(getKafkaExtension().getBootstrapServers()));
+
+                var transferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
+                        .withDestination(kafkaSink(getKafkaExtension().getBootstrapServers())).withTransferType("Kafka-PUSH").execute();
+                assertMessagesAreSentTo(consumer);
+
+                CONSUMER.awaitTransferToBeInState(transferProcessId, TERMINATED);
+                assertNoMoreMessagesAreSentTo(consumer);
+            }
+        }
+
+        @Test
+        void shouldSuspendAndResumeTransfer() {
+            try (var consumer = getKafkaExtension().createKafkaConsumer()) {
+                consumer.subscribe(List.of(sinkTopic));
+
+                var assetId = UUID.randomUUID().toString();
+                createResourcesOnProvider(assetId, kafkaSourceProperty(getKafkaExtension().getBootstrapServers()));
+
+                var transferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
+                        .withDestination(kafkaSink(getKafkaExtension().getBootstrapServers())).withTransferType("Kafka-PUSH").execute();
+                assertMessagesAreSentTo(consumer);
+
+                CONSUMER.suspendTransfer(transferProcessId, "any kind of reason");
+                CONSUMER.awaitTransferToBeInState(transferProcessId, SUSPENDED);
+                assertNoMoreMessagesAreSentTo(consumer);
+
+                CONSUMER.resumeTransfer(transferProcessId);
+                CONSUMER.awaitTransferToBeInState(transferProcessId, STARTED);
+                assertMessagesAreSentTo(consumer);
+            }
+        }
+
+        protected void assertMessagesAreSentTo(Consumer<String, String> consumer) {
+            await().atMost(timeout).untilAsserted(() -> {
+                var records = consumer.poll(ZERO);
+                assertThat(records.isEmpty()).isFalse();
+                records.records(sinkTopic).forEach(record -> assertThat(record.value()).isEqualTo(sampleMessage()));
+            });
+        }
+
+        protected void assertNoMoreMessagesAreSentTo(Consumer<String, String> consumer) {
+            consumer.poll(ZERO);
+            await().pollDelay(5, SECONDS).atMost(timeout).untilAsserted(() -> {
+                var recordsFound = consumer.poll(Duration.ofSeconds(1)).records(sinkTopic);
+                assertThat(recordsFound).isEmpty();
+            });
+        }
+
+        private JsonObject httpSink(Integer port, String path) {
+            return Json.createObjectBuilder()
+                    .add(TYPE, EDC_NAMESPACE + "DataAddress")
+                    .add(EDC_NAMESPACE + "type", "HttpData")
+                    .add(EDC_NAMESPACE + "properties", Json.createObjectBuilder()
+                            .add(EDC_NAMESPACE + "name", "data")
+                            .add(EDC_NAMESPACE + "baseUrl", format("http://localhost:%s", port))
+                            .add(EDC_NAMESPACE + "path", path)
+                            .build())
+                    .build();
+        }
+
+        protected JsonObject kafkaSink(String bootstrapServers) {
+            return Json.createObjectBuilder()
+                    .add(TYPE, EDC_NAMESPACE + "DataAddress")
+                    .add(EDC_NAMESPACE + "type", "Kafka")
+                    .add(EDC_NAMESPACE + "properties", Json.createObjectBuilder()
+                            .add(EDC_NAMESPACE + "topic", sinkTopic)
+                            .add(EDC_NAMESPACE + kafkaProperty("bootstrap.servers"), bootstrapServers)
+                            .build())
+                    .build();
+        }
+
+        protected Map<String, Object> kafkaSourceProperty(String bootstrapServers) {
+            return Map.of(
+                    "name", "data",
+                    "type", "Kafka",
+                    "topic", sourceTopic,
+                    kafkaProperty("bootstrap.servers"), bootstrapServers,
+                    kafkaProperty("max.poll.records"), "100"
+            );
+        }
+
+        private String kafkaProperty(String property) {
+            return "kafka." + property;
+        }
+
+        private String sampleMessage() {
+            return "sampleMessage";
+        }
+    }
 
     @Nested
     @EndToEndTest
@@ -73,20 +222,20 @@ public class TransferStreamingEndToEndTest {
 
         @RegisterExtension
         static final RuntimeExtension CONSUMER_CONTROL_PLANE = new RuntimePerClassExtension(
-                    Runtimes.IN_MEMORY_CONTROL_PLANE.create("consumer-control-plane")
-                            .configurationProvider(CONSUMER::controlPlaneConfig)
+                Runtimes.IN_MEMORY_CONTROL_PLANE.create("consumer-control-plane")
+                        .configurationProvider(CONSUMER::controlPlaneConfig)
         );
 
         @RegisterExtension
         static final RuntimeExtension PROVIDER_CONTROL_PLANE = new RuntimePerClassExtension(
-                    Runtimes.IN_MEMORY_CONTROL_PLANE.create("provider-control-plane")
-                            .configurationProvider(PROVIDER::controlPlaneConfig)
+                Runtimes.IN_MEMORY_CONTROL_PLANE.create("provider-control-plane")
+                        .configurationProvider(PROVIDER::controlPlaneConfig)
         );
 
         @RegisterExtension
         static final RuntimeExtension PROVIDER_DATA_PLANE = new RuntimePerClassExtension(
-                    Runtimes.IN_MEMORY_DATA_PLANE.create("provider-data-plane")
-                            .configurationProvider(PROVIDER::dataPlaneConfig)
+                Runtimes.IN_MEMORY_DATA_PLANE.create("provider-data-plane")
+                        .configurationProvider(PROVIDER::dataPlaneConfig)
         );
 
         @Override
@@ -171,158 +320,6 @@ public class TransferStreamingEndToEndTest {
                 CONSUMER.awaitTransferToBeInState(transferProcessId, STARTED);
                 assertMessagesAreSentTo(consumer);
             }
-        }
-    }
-
-    @Testcontainers
-    abstract static class Tests extends TransferEndToEndTestBase {
-
-        private final String sourceTopic = "source_topic_" + UUID.randomUUID();
-        protected final String sinkTopic = "sink_topic_" + UUID.randomUUID();
-
-        protected abstract KafkaExtension getKafkaExtension();
-
-        @BeforeEach
-        void setUp() {
-            var producer = getKafkaExtension().createKafkaProducer();
-
-            newSingleThreadScheduledExecutor().scheduleAtFixedRate(
-                    () -> producer.send(new ProducerRecord<>(sourceTopic, sampleMessage())),
-                    0, 100, MILLISECONDS);
-        }
-
-        @Test
-        void kafkaToHttpTransfer() {
-            var destinationServer = startClientAndServer(getFreePort());
-            var request = request()
-                    .withMethod(HttpMethod.POST.name())
-                    .withPath("/api/service");
-            destinationServer.when(request).respond(response());
-
-            var assetId = UUID.randomUUID().toString();
-            createResourcesOnProvider(assetId, contractExpiresIn("10s"), kafkaSourceProperty(getKafkaExtension().getBootstrapServers()));
-
-            var destination = httpSink(destinationServer.getLocalPort(), "/api/service");
-            var transferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
-                    .withDestination(destination).withTransferType("HttpData-PUSH").execute();
-
-            await().atMost(timeout).untilAsserted(() -> {
-                destinationServer.verify(request, atLeast(1));
-            });
-
-            CONSUMER.awaitTransferToBeInState(transferProcessId, TERMINATED);
-
-            destinationServer.clear(request)
-                    .when(request).respond(response());
-            await().pollDelay(5, SECONDS).atMost(timeout).untilAsserted(() -> {
-                try {
-                    destinationServer.verify(request, never());
-                } catch (AssertionError assertionError) {
-                    destinationServer.clear(request)
-                            .when(request).respond(response());
-                    throw assertionError;
-                }
-            });
-
-            stopQuietly(destinationServer);
-        }
-
-        @Test
-        void kafkaToKafkaTransfer() {
-            try (var consumer = getKafkaExtension().createKafkaConsumer()) {
-                consumer.subscribe(List.of(sinkTopic));
-
-                var assetId = UUID.randomUUID().toString();
-                createResourcesOnProvider(assetId, contractExpiresIn("10s"), kafkaSourceProperty(getKafkaExtension().getBootstrapServers()));
-
-                var transferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
-                        .withDestination(kafkaSink(getKafkaExtension().getBootstrapServers())).withTransferType("Kafka-PUSH").execute();
-                assertMessagesAreSentTo(consumer);
-
-                CONSUMER.awaitTransferToBeInState(transferProcessId, TERMINATED);
-                assertNoMoreMessagesAreSentTo(consumer);
-            }
-        }
-
-        @Test
-        void shouldSuspendAndResumeTransfer() {
-            try (var consumer = getKafkaExtension().createKafkaConsumer()) {
-                consumer.subscribe(List.of(sinkTopic));
-
-                var assetId = UUID.randomUUID().toString();
-                createResourcesOnProvider(assetId, kafkaSourceProperty(getKafkaExtension().getBootstrapServers()));
-
-                var transferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
-                        .withDestination(kafkaSink(getKafkaExtension().getBootstrapServers())).withTransferType("Kafka-PUSH").execute();
-                assertMessagesAreSentTo(consumer);
-
-                CONSUMER.suspendTransfer(transferProcessId, "any kind of reason");
-                CONSUMER.awaitTransferToBeInState(transferProcessId, SUSPENDED);
-                assertNoMoreMessagesAreSentTo(consumer);
-
-                CONSUMER.resumeTransfer(transferProcessId);
-                CONSUMER.awaitTransferToBeInState(transferProcessId, STARTED);
-                assertMessagesAreSentTo(consumer);
-            }
-        }
-
-        protected void assertMessagesAreSentTo(Consumer<String, String> consumer) {
-            await().atMost(timeout).untilAsserted(() -> {
-                var records = consumer.poll(ZERO);
-                assertThat(records.isEmpty()).isFalse();
-                records.records(sinkTopic).forEach(record -> assertThat(record.value()).isEqualTo(sampleMessage()));
-            });
-        }
-
-        protected void assertNoMoreMessagesAreSentTo(Consumer<String, String> consumer) {
-            consumer.poll(ZERO);
-            await().pollDelay(5, SECONDS).atMost(timeout).untilAsserted(() -> {
-                var recordsFound = consumer.poll(Duration.ofSeconds(1)).records(sinkTopic);
-                assertThat(recordsFound).isEmpty();
-            });
-        }
-
-        private JsonObject httpSink(Integer port, String path) {
-            return Json.createObjectBuilder()
-                    .add(TYPE, EDC_NAMESPACE + "DataAddress")
-                    .add(EDC_NAMESPACE + "type", "HttpData")
-                    .add(EDC_NAMESPACE + "properties", Json.createObjectBuilder()
-                            .add(EDC_NAMESPACE + "name", "data")
-                            .add(EDC_NAMESPACE + "baseUrl", format("http://localhost:%s", port))
-                            .add(EDC_NAMESPACE + "path", path)
-                            .build())
-                    .build();
-        }
-
-        @NotNull
-        protected JsonObject kafkaSink(String bootstrapServers) {
-            return Json.createObjectBuilder()
-                    .add(TYPE, EDC_NAMESPACE + "DataAddress")
-                    .add(EDC_NAMESPACE + "type", "Kafka")
-                    .add(EDC_NAMESPACE + "properties", Json.createObjectBuilder()
-                            .add(EDC_NAMESPACE + "topic", sinkTopic)
-                            .add(EDC_NAMESPACE + kafkaProperty("bootstrap.servers"), bootstrapServers)
-                            .build())
-                    .build();
-        }
-
-        @NotNull
-        protected Map<String, Object> kafkaSourceProperty(String bootstrapServers) {
-            return Map.of(
-                    "name", "data",
-                    "type", "Kafka",
-                    "topic", sourceTopic,
-                    kafkaProperty("bootstrap.servers"), bootstrapServers,
-                    kafkaProperty("max.poll.records"), "100"
-            );
-        }
-
-        private String kafkaProperty(String property) {
-            return "kafka." + property;
-        }
-
-        private String sampleMessage() {
-            return "sampleMessage";
         }
     }
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/provision/ProvisioningTransferProviderEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/provision/ProvisioningTransferProviderEndToEndTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.test.e2e.provision;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import okhttp3.Request;
 import org.eclipse.edc.connector.dataplane.spi.DataFlow;
 import org.eclipse.edc.connector.dataplane.spi.DataFlowStates;
@@ -45,13 +46,20 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockserver.integration.ClientAndServer;
 
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static jakarta.json.Json.createObjectBuilder;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -64,8 +72,6 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
 
 public class ProvisioningTransferProviderEndToEndTest {
 
@@ -79,168 +85,6 @@ public class ProvisioningTransferProviderEndToEndTest {
             .build();
 
     private static final int SOURCE_BACKEND_PORT = getFreePort();
-
-    @Nested
-    class EmbeddedDataPlaneInMemory extends Tests {
-        @RegisterExtension
-        @Order(0)
-        private final RuntimeExtension consumerControlPlane = new RuntimePerMethodExtension(
-                Runtimes.IN_MEMORY_CONTROL_PLANE_EMBEDDED_DATA_PLANE.create("consumer-control-plane")
-                        .configurationProvider(CONSUMER::controlPlaneEmbeddedDataPlaneConfig)
-        );
-
-        @RegisterExtension
-        @Order(0)
-        private final RuntimeExtension providerControlPlane = new RuntimePerMethodExtension(
-                Runtimes.IN_MEMORY_CONTROL_PLANE_EMBEDDED_DATA_PLANE.create("provider-control-plane")
-                        .configurationProvider(PROVIDER::controlPlaneEmbeddedDataPlaneConfig)
-                        .registerSystemExtension(ServiceExtension.class, new TestProviderProvisionerExtension())
-        );
-
-        @Override
-        protected DataPlaneStore providerDataPlaneStore() {
-            return providerControlPlane.getService(DataPlaneStore.class);
-        }
-    }
-
-    @Nested
-    class InMemory extends Tests {
-
-        @RegisterExtension
-        @Order(0)
-        private final RuntimeExtension consumerControlPlane = new RuntimePerMethodExtension(
-                Runtimes.IN_MEMORY_CONTROL_PLANE.create("consumer-control-plane")
-                        .configurationProvider(CONSUMER::controlPlaneConfig)
-        );
-
-        @RegisterExtension
-        @Order(1)
-        private final RuntimeExtension consumerDataPlane = new RuntimePerMethodExtension(
-                Runtimes.IN_MEMORY_DATA_PLANE.create("consumer-data-plane")
-                        .configurationProvider(CONSUMER::dataPlaneConfig)
-        );
-
-        @RegisterExtension
-        @Order(0)
-        private final RuntimeExtension providerControlPlane = new RuntimePerMethodExtension(
-                Runtimes.IN_MEMORY_CONTROL_PLANE.create("provider-control-plane")
-                        .configurationProvider(PROVIDER::controlPlaneConfig)
-        );
-
-        @RegisterExtension
-        @Order(1)
-        private final RuntimeExtension providerDataPlane = new RuntimePerMethodExtension(
-                Runtimes.IN_MEMORY_DATA_PLANE.create("provider-data-plane")
-                        .configurationProvider(PROVIDER::dataPlaneConfig)
-                        .registerSystemExtension(ServiceExtension.class, new TestProviderProvisionerExtension())
-        );
-
-        @Override
-        protected DataPlaneStore providerDataPlaneStore() {
-            return providerDataPlane.getService(DataPlaneStore.class);
-        }
-    }
-
-    class Postgres extends Tests {
-
-        @RegisterExtension
-        @Order(0)
-        static final PostgresqlEndToEndExtension POSTGRESQL_EXTENSION = new PostgresqlEndToEndExtension();
-
-        @Order(1)
-        @RegisterExtension
-        static final BeforeAllCallback CREATE_DATABASES = context -> {
-            POSTGRESQL_EXTENSION.createDatabase(CONSUMER.getName());
-            POSTGRESQL_EXTENSION.createDatabase(PROVIDER.getName());
-        };
-
-        @RegisterExtension
-        @Order(1)
-        private final RuntimeExtension consumerControlPlane = new RuntimePerMethodExtension(
-                Runtimes.POSTGRES_CONTROL_PLANE.create("consumer-control-plane")
-                        .configurationProvider(CONSUMER::controlPlaneConfig)
-                        .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(CONSUMER.getName()))
-        );
-
-        @RegisterExtension
-        @Order(2)
-        private final RuntimeExtension consumerDataPlane = new RuntimePerMethodExtension(
-                Runtimes.POSTGRES_DATA_PLANE.create("consumer-data-plane")
-                        .configurationProvider(CONSUMER::dataPlaneConfig)
-                        .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(CONSUMER.getName()))
-        );
-
-        @RegisterExtension
-        @Order(1)
-        private final RuntimeExtension providerControlPlane = new RuntimePerMethodExtension(
-                Runtimes.POSTGRES_CONTROL_PLANE.create("provider-control-plane")
-                        .configurationProvider(PROVIDER::controlPlaneConfig)
-                        .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(PROVIDER.getName()))
-        );
-
-        @RegisterExtension
-        @Order(2)
-        private final RuntimeExtension providerDataPlane = new RuntimePerMethodExtension(
-                Runtimes.POSTGRES_DATA_PLANE.create("provider-data-plane")
-                        .configurationProvider(PROVIDER::dataPlaneConfig)
-                        .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(PROVIDER.getName()))
-                        .registerSystemExtension(ServiceExtension.class, new TestProviderProvisionerExtension())
-        );
-
-        @Override
-        protected DataPlaneStore providerDataPlaneStore() {
-            return providerDataPlane.getService(DataPlaneStore.class);
-        }
-    }
-
-    abstract class Tests {
-        @Test
-        void shouldExecuteConsumerProvisioningAndDeprovisioning() {
-            var source = ClientAndServer.startClientAndServer(SOURCE_BACKEND_PORT);
-            source.when(request("/source")).respond(response("data"));
-            source.when(request("/deprovision")).respond(response());
-            var destination = ClientAndServer.startClientAndServer(getFreePort());
-            destination.when(request()).respond(response());
-
-            var assetId = UUID.randomUUID().toString();
-            var sourceDataAddress = Map.<String, Object>of(
-                    EDC_NAMESPACE + "name", "transfer-test",
-                    EDC_NAMESPACE + "baseUrl", "http://localhost:%d/source".formatted(source.getPort()),
-                    EDC_NAMESPACE + "type", "HttpData"
-            );
-
-            createResourcesOnProvider(assetId, sourceDataAddress);
-
-            var consumerTransferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
-                    .withTransferType("HttpData-PUSH")
-                    .withDestination(createObjectBuilder()
-                            .add(TYPE, EDC_NAMESPACE + "DataAddress")
-                            .add(EDC_NAMESPACE + "type", "HttpData")
-                            .add(EDC_NAMESPACE + "baseUrl", "http://localhost:%d/destination".formatted(destination.getPort()))
-                            .build()
-                    )
-                    .execute();
-
-            CONSUMER.awaitTransferToBeInState(consumerTransferProcessId, COMPLETED);
-
-            source.verify(request().withHeader("provisionHeader", "value"));
-
-            var providerTransferProcessId = PROVIDER.getTransferProcesses().stream()
-                    .filter(filter -> filter.asJsonObject().getString("correlationId").equals(consumerTransferProcessId))
-                    .map(id -> id.asJsonObject().getString("@id")).findFirst().orElseThrow();
-
-            await().untilAsserted(() -> source.verify(request("/deprovision")));
-            await().untilAsserted(() -> {
-                var dataFlow = providerDataPlaneStore().findById(providerTransferProcessId);
-                assertThat(dataFlow).isNotNull().extracting(StatefulEntity::getState).isEqualTo(DataFlowStates.DEPROVISIONED.code());
-            });
-
-            source.stop();
-            destination.stop();
-        }
-
-        protected abstract DataPlaneStore providerDataPlaneStore();
-    }
 
     private void createResourcesOnProvider(String assetId, Map<String, Object> dataAddressProperties) {
         PROVIDER.createAsset(assetId, Map.of("description", "description"), dataAddressProperties);
@@ -400,6 +244,177 @@ public class ProvisioningTransferProviderEndToEndTest {
                 return completedFuture(StatusResult.success(resource));
             }
         }
+    }
+
+    @Nested
+    class EmbeddedDataPlaneInMemory extends Tests {
+        @RegisterExtension
+        @Order(0)
+        private final RuntimeExtension consumerControlPlane = new RuntimePerMethodExtension(
+                Runtimes.IN_MEMORY_CONTROL_PLANE_EMBEDDED_DATA_PLANE.create("consumer-control-plane")
+                        .configurationProvider(CONSUMER::controlPlaneEmbeddedDataPlaneConfig)
+        );
+
+        @RegisterExtension
+        @Order(0)
+        private final RuntimeExtension providerControlPlane = new RuntimePerMethodExtension(
+                Runtimes.IN_MEMORY_CONTROL_PLANE_EMBEDDED_DATA_PLANE.create("provider-control-plane")
+                        .configurationProvider(PROVIDER::controlPlaneEmbeddedDataPlaneConfig)
+                        .registerSystemExtension(ServiceExtension.class, new TestProviderProvisionerExtension())
+        );
+
+        @Override
+        protected DataPlaneStore providerDataPlaneStore() {
+            return providerControlPlane.getService(DataPlaneStore.class);
+        }
+    }
+
+    @Nested
+    class InMemory extends Tests {
+
+        @RegisterExtension
+        @Order(0)
+        private final RuntimeExtension consumerControlPlane = new RuntimePerMethodExtension(
+                Runtimes.IN_MEMORY_CONTROL_PLANE.create("consumer-control-plane")
+                        .configurationProvider(CONSUMER::controlPlaneConfig)
+        );
+
+        @RegisterExtension
+        @Order(1)
+        private final RuntimeExtension consumerDataPlane = new RuntimePerMethodExtension(
+                Runtimes.IN_MEMORY_DATA_PLANE.create("consumer-data-plane")
+                        .configurationProvider(CONSUMER::dataPlaneConfig)
+        );
+
+        @RegisterExtension
+        @Order(0)
+        private final RuntimeExtension providerControlPlane = new RuntimePerMethodExtension(
+                Runtimes.IN_MEMORY_CONTROL_PLANE.create("provider-control-plane")
+                        .configurationProvider(PROVIDER::controlPlaneConfig)
+        );
+
+        @RegisterExtension
+        @Order(1)
+        private final RuntimeExtension providerDataPlane = new RuntimePerMethodExtension(
+                Runtimes.IN_MEMORY_DATA_PLANE.create("provider-data-plane")
+                        .configurationProvider(PROVIDER::dataPlaneConfig)
+                        .registerSystemExtension(ServiceExtension.class, new TestProviderProvisionerExtension())
+        );
+
+        @Override
+        protected DataPlaneStore providerDataPlaneStore() {
+            return providerDataPlane.getService(DataPlaneStore.class);
+        }
+    }
+
+    class Postgres extends Tests {
+
+        @RegisterExtension
+        @Order(0)
+        static final PostgresqlEndToEndExtension POSTGRESQL_EXTENSION = new PostgresqlEndToEndExtension();
+
+        @Order(1)
+        @RegisterExtension
+        static final BeforeAllCallback CREATE_DATABASES = context -> {
+            POSTGRESQL_EXTENSION.createDatabase(CONSUMER.getName());
+            POSTGRESQL_EXTENSION.createDatabase(PROVIDER.getName());
+        };
+
+        @RegisterExtension
+        @Order(1)
+        private final RuntimeExtension consumerControlPlane = new RuntimePerMethodExtension(
+                Runtimes.POSTGRES_CONTROL_PLANE.create("consumer-control-plane")
+                        .configurationProvider(CONSUMER::controlPlaneConfig)
+                        .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(CONSUMER.getName()))
+        );
+
+        @RegisterExtension
+        @Order(2)
+        private final RuntimeExtension consumerDataPlane = new RuntimePerMethodExtension(
+                Runtimes.POSTGRES_DATA_PLANE.create("consumer-data-plane")
+                        .configurationProvider(CONSUMER::dataPlaneConfig)
+                        .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(CONSUMER.getName()))
+        );
+
+        @RegisterExtension
+        @Order(1)
+        private final RuntimeExtension providerControlPlane = new RuntimePerMethodExtension(
+                Runtimes.POSTGRES_CONTROL_PLANE.create("provider-control-plane")
+                        .configurationProvider(PROVIDER::controlPlaneConfig)
+                        .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(PROVIDER.getName()))
+        );
+
+        @RegisterExtension
+        @Order(2)
+        private final RuntimeExtension providerDataPlane = new RuntimePerMethodExtension(
+                Runtimes.POSTGRES_DATA_PLANE.create("provider-data-plane")
+                        .configurationProvider(PROVIDER::dataPlaneConfig)
+                        .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(PROVIDER.getName()))
+                        .registerSystemExtension(ServiceExtension.class, new TestProviderProvisionerExtension())
+        );
+
+        @Override
+        protected DataPlaneStore providerDataPlaneStore() {
+            return providerDataPlane.getService(DataPlaneStore.class);
+        }
+    }
+
+    abstract class Tests {
+
+        @RegisterExtension
+        static WireMockExtension source = WireMockExtension.newInstance()
+                .options(wireMockConfig().port(SOURCE_BACKEND_PORT))
+                .build();
+
+        @RegisterExtension
+        static WireMockExtension destination = WireMockExtension.newInstance()
+                .options(wireMockConfig().dynamicPort())
+                .build();
+
+        @Test
+        void shouldExecuteConsumerProvisioningAndDeprovisioning() {
+
+            source.stubFor(get("/source").willReturn(ok("data")));
+            source.stubFor(get("/deprovision").willReturn(ok()));
+
+            destination.stubFor(post(anyUrl()).willReturn(ok()));
+
+            var assetId = UUID.randomUUID().toString();
+            var sourceDataAddress = Map.<String, Object>of(
+                    EDC_NAMESPACE + "name", "transfer-test",
+                    EDC_NAMESPACE + "baseUrl", "http://localhost:%d/source".formatted(source.getPort()),
+                    EDC_NAMESPACE + "type", "HttpData"
+            );
+
+            createResourcesOnProvider(assetId, sourceDataAddress);
+
+            var consumerTransferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
+                    .withTransferType("HttpData-PUSH")
+                    .withDestination(createObjectBuilder()
+                            .add(TYPE, EDC_NAMESPACE + "DataAddress")
+                            .add(EDC_NAMESPACE + "type", "HttpData")
+                            .add(EDC_NAMESPACE + "baseUrl", "http://localhost:%d/destination".formatted(destination.getPort()))
+                            .build()
+                    )
+                    .execute();
+
+            CONSUMER.awaitTransferToBeInState(consumerTransferProcessId, COMPLETED);
+
+            source.verify(getRequestedFor(anyUrl()).withHeader("provisionHeader", equalTo("value")));
+
+            var providerTransferProcessId = PROVIDER.getTransferProcesses().stream()
+                    .filter(filter -> filter.asJsonObject().getString("correlationId").equals(consumerTransferProcessId))
+                    .map(id -> id.asJsonObject().getString("@id")).findFirst().orElseThrow();
+
+            await().untilAsserted(() -> source.verify(getRequestedFor(urlEqualTo("/deprovision"))));
+            await().untilAsserted(() -> {
+                var dataFlow = providerDataPlaneStore().findById(providerTransferProcessId);
+                assertThat(dataFlow).isNotNull().extracting(StatefulEntity::getState).isEqualTo(DataFlowStates.DEPROVISIONED.code());
+            });
+
+        }
+
+        protected abstract DataPlaneStore providerDataPlaneStore();
     }
 
 }

--- a/system-tests/telemetry/telemetry-test-runner/build.gradle.kts
+++ b/system-tests/telemetry/telemetry-test-runner/build.gradle.kts
@@ -25,8 +25,7 @@ dependencies {
 
     testImplementation(libs.restAssured)
     testImplementation(libs.awaitility)
-    testImplementation(libs.mockserver.netty)
-    testImplementation(libs.mockserver.client)
+    testImplementation(libs.wiremock)
     testImplementation(libs.opentelemetry.proto)
 
     testCompileOnly(project(":system-tests:telemetry:telemetry-test-runtime"))


### PR DESCRIPTION
## What this PR changes/adds

Replace mockserver with wiremock

## Why it does that

mockserver is abandoned 

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4885 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
