### PR TITLE
feat: add participantId to DataspaceProfileContext

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *       Cofinity-X - unauthenticated DSP version endpoint
+ *       Cofinity-X - add participantId to DataspaceProfileContext
  *
  */
 
@@ -221,9 +222,9 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     }
 
     @Provider
-    public CatalogProtocolService catalogProtocolService(ServiceExtensionContext context) {
+    public CatalogProtocolService catalogProtocolService() {
         return new CatalogProtocolServiceImpl(datasetResolver, dataServiceRegistry,
-                protocolTokenValidator(), context.getParticipantId(), transactionContext);
+                protocolTokenValidator(), dataspaceProfileContextRegistry, transactionContext);
     }
 
     @Provider

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogProtocolServiceImpl.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Cofinity-X - add participantId to DataspaceProfileContext
  *
  */
 
@@ -22,6 +23,7 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.DatasetResolver;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
 import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolTokenValidator;
 import org.eclipse.edc.policy.context.request.spi.RequestCatalogPolicyContext;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transaction.spi.TransactionContext;
@@ -33,7 +35,7 @@ public class CatalogProtocolServiceImpl implements CatalogProtocolService {
 
     private final DatasetResolver datasetResolver;
     private final DataServiceRegistry dataServiceRegistry;
-    private final String participantId;
+    private final DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
     private final TransactionContext transactionContext;
 
     private final ProtocolTokenValidator protocolTokenValidator;
@@ -41,12 +43,12 @@ public class CatalogProtocolServiceImpl implements CatalogProtocolService {
     public CatalogProtocolServiceImpl(DatasetResolver datasetResolver,
                                       DataServiceRegistry dataServiceRegistry,
                                       ProtocolTokenValidator protocolTokenValidator,
-                                      String participantId,
+                                      DataspaceProfileContextRegistry dataspaceProfileContextRegistry,
                                       TransactionContext transactionContext) {
         this.datasetResolver = datasetResolver;
         this.dataServiceRegistry = dataServiceRegistry;
         this.protocolTokenValidator = protocolTokenValidator;
-        this.participantId = participantId;
+        this.dataspaceProfileContextRegistry = dataspaceProfileContextRegistry;
         this.transactionContext = transactionContext;
     }
 
@@ -61,7 +63,7 @@ public class CatalogProtocolServiceImpl implements CatalogProtocolService {
                         return Catalog.Builder.newInstance()
                                 .dataServices(dataServices)
                                 .datasets(datasets.toList())
-                                .participantId(participantId)
+                                .participantId(dataspaceProfileContextRegistry.getParticipantId(message.getProtocol()))
                                 .build();
                     }
                 })

--- a/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/ContractManagerExtension.java
+++ b/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/ContractManagerExtension.java
@@ -143,8 +143,6 @@ public class ContractManagerExtension implements ServiceExtension {
     }
 
     private void registerServices(ServiceExtensionContext context) {
-        var participantId = context.getParticipantId();
-
         WaitStrategy consumerWaitStrategy;
         WaitStrategy providerWaitStrategy;
         if (context.getConfig().hasKey(DEPRECATED_ITERATION_WAIT_MILLIS_KEY)) {
@@ -159,7 +157,6 @@ public class ContractManagerExtension implements ServiceExtension {
         }
 
         consumerNegotiationManager = ConsumerContractNegotiationManagerImpl.Builder.newInstance()
-                .participantId(participantId)
                 .waitStrategy(consumerWaitStrategy)
                 .dispatcherRegistry(dispatcherRegistry)
                 .monitor(monitor)
@@ -176,7 +173,6 @@ public class ContractManagerExtension implements ServiceExtension {
                 .build();
 
         providerNegotiationManager = ProviderContractNegotiationManagerImpl.Builder.newInstance()
-                .participantId(participantId)
                 .waitStrategy(providerWaitStrategy)
                 .dispatcherRegistry(dispatcherRegistry)
                 .monitor(monitor)

--- a/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/AbstractContractNegotiationManager.java
+++ b/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/AbstractContractNegotiationManager.java
@@ -44,7 +44,6 @@ import static org.eclipse.edc.spi.persistence.StateEntityStore.isNotPending;
 
 public abstract class AbstractContractNegotiationManager extends AbstractStateEntityManager<ContractNegotiation, ContractNegotiationStore> {
 
-    protected String participantId;
     protected RemoteMessageDispatcherRegistry dispatcherRegistry;
     protected ContractNegotiationObservable observable;
     protected PolicyDefinitionStore policyStore;
@@ -224,17 +223,12 @@ public abstract class AbstractContractNegotiationManager extends AbstractStateEn
         @Override
         public T build() {
             super.build();
-            Objects.requireNonNull(manager.participantId, "participantId");
+            Objects.requireNonNull(manager.dataspaceProfileContextRegistry, "dataspaceProfileContextRegistry");
             Objects.requireNonNull(manager.dispatcherRegistry, "dispatcherRegistry");
             Objects.requireNonNull(manager.observable, "observable");
 
             Objects.requireNonNull(manager.policyStore, "policyStore");
             return manager;
-        }
-
-        public Builder<T> participantId(String id) {
-            manager.participantId = id;
-            return this;
         }
 
         public Builder<T> dispatcherRegistry(RemoteMessageDispatcherRegistry dispatcherRegistry) {

--- a/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -13,6 +13,7 @@
  *       Daimler TSS GmbH - fixed contract dates to epoch seconds
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - refactor
  *       ZF Friedrichshafen AG - fixed contract validity issue
+ *       Cofinity-X - add participantId to DataspaceProfileContext
  *
  */
 
@@ -133,15 +134,16 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
         var agreement = Optional.ofNullable(negotiation.getContractAgreement())
                 .orElseGet(() -> {
                     var lastOffer = negotiation.getLastContractOffer();
+                    var protocol = negotiation.getProtocol();
 
                     var contractPolicy = lastOffer.getPolicy().toBuilder().type(PolicyType.CONTRACT)
                             .assignee(negotiation.getCounterPartyId())
-                            .assigner(participantId)
+                            .assigner(dataspaceProfileContextRegistry.getParticipantId(protocol))
                             .build();
 
                     return ContractAgreement.Builder.newInstance()
                             .contractSigningDate(clock.instant().getEpochSecond())
-                            .providerId(participantId)
+                            .providerId(dataspaceProfileContextRegistry.getParticipantId(protocol))
                             .consumerId(negotiation.getCounterPartyId())
                             .policy(contractPolicy)
                             .assetId(lastOffer.getAssetId())

--- a/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -86,7 +86,6 @@ import static org.mockito.Mockito.when;
 
 class ConsumerContractNegotiationManagerImplTest {
 
-    private static final String PARTICIPANT_ID = "participantId";
     private static final int RETRY_LIMIT = 1;
 
     private final ContractNegotiationStore store = mock();
@@ -105,7 +104,6 @@ class ConsumerContractNegotiationManagerImplTest {
         observable.registerListener(listener);
 
         manager = ConsumerContractNegotiationManagerImpl.Builder.newInstance()
-                .participantId(PARTICIPANT_ID)
                 .dispatcherRegistry(dispatcherRegistry)
                 .monitor(mock(Monitor.class))
                 .observable(observable)

--- a/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *       Microsoft Corporation - introduced Awaitility
+ *       Cofinity-X - add participantId to DataspaceProfileContext
  *
  */
 
@@ -136,7 +137,6 @@ class ContractNegotiationIntegrationTest {
         when(dataspaceProfileContextRegistry.getWebhook(any())).thenReturn(protocolWebhook);
 
         providerManager = ProviderContractNegotiationManagerImpl.Builder.newInstance()
-                .participantId(PROVIDER_ID)
                 .dispatcherRegistry(providerDispatcherRegistry)
                 .monitor(monitor)
                 .waitStrategy(() -> 1000)
@@ -147,7 +147,6 @@ class ContractNegotiationIntegrationTest {
                 .build();
 
         consumerManager = ConsumerContractNegotiationManagerImpl.Builder.newInstance()
-                .participantId(CONSUMER_ID)
                 .dispatcherRegistry(consumerDispatcherRegistry)
                 .monitor(monitor).waitStrategy(() -> 1000)
                 .observable(mock())
@@ -182,6 +181,8 @@ class ContractNegotiationIntegrationTest {
         when(validationService.validateInitialOffer(participantAgent, validatableOffer)).thenReturn(Result.success(new ValidatedConsumerOffer(CONSUMER_ID, offer)));
         when(validationService.validateConfirmed(eq(participantAgent), any(ContractAgreement.class), any(ContractOffer.class))).thenReturn(Result.success());
         when(validationService.validateRequest(eq(participantAgent), any(ContractNegotiation.class))).thenReturn(Result.success());
+        
+        when(dataspaceProfileContextRegistry.getParticipantId(any())).thenReturn(PROVIDER_ID);
 
         // Start provider and consumer negotiation managers
         providerManager.start();
@@ -265,6 +266,8 @@ class ContractNegotiationIntegrationTest {
         when(offerResolver.resolveOffer(any())).thenReturn(ServiceResult.success(validatableOffer));
         when(validationService.validateInitialOffer(participantAgent, validatableOffer)).thenReturn(Result.success(new ValidatedConsumerOffer(CONSUMER_ID, offer)));
         when(validationService.validateConfirmed(eq(participantAgent), any(ContractAgreement.class), any(ContractOffer.class))).thenReturn(Result.failure("error"));
+        
+        when(dataspaceProfileContextRegistry.getParticipantId(any())).thenReturn(PROVIDER_ID);
 
         // Start provider and consumer negotiation managers
         providerManager.start();

--- a/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Fraunhofer Institute for Software and Systems Engineering - initial API and implementation
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - improvements
+ *       Cofinity-X - add participantId to DataspaceProfileContext
  *
  */
 
@@ -104,7 +105,6 @@ class ProviderContractNegotiationManagerImplTest {
         var observable = new ContractNegotiationObservableImpl();
         observable.registerListener(listener);
         manager = ProviderContractNegotiationManagerImpl.Builder.newInstance()
-                .participantId(PROVIDER_ID)
                 .dispatcherRegistry(dispatcherRegistry)
                 .monitor(mock())
                 .observable(observable)
@@ -217,6 +217,7 @@ class ProviderContractNegotiationManagerImplTest {
         when(store.findById(negotiation.getId())).thenReturn(negotiation);
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).id("policyId").build());
         when(dataspaceProfileContextRegistry.getWebhook(negotiation.getProtocol())).thenReturn(() -> "http://callback.address");
+        when(dataspaceProfileContextRegistry.getParticipantId(negotiation.getProtocol())).thenReturn(PROVIDER_ID);
 
         manager.start();
 
@@ -293,6 +294,7 @@ class ProviderContractNegotiationManagerImplTest {
         when(dispatcherRegistry.dispatch(any(), any())).thenReturn(result);
         when(store.findById(negotiation.getId())).thenReturn(negotiation);
         when(dataspaceProfileContextRegistry.getWebhook(negotiation.getProtocol())).thenReturn(() -> "http://callback.address");
+        when(dataspaceProfileContextRegistry.getParticipantId(negotiation.getProtocol())).thenReturn(PROVIDER_ID);
 
         manager.start();
 

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/profile/DataspaceProfileContextRegistryImpl.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/profile/DataspaceProfileContextRegistryImpl.java
@@ -57,7 +57,16 @@ public class DataspaceProfileContextRegistryImpl implements DataspaceProfileCont
         return profiles().stream().filter(it -> it.name().equals(protocol))
                 .map(DataspaceProfileContext::protocolVersion).findAny().orElse(null);
     }
-
+    
+    @Override
+    public @Nullable String getParticipantId(String protocol) {
+        return profiles().stream()
+                .filter(it -> it.name().equals(protocol))
+                .map(DataspaceProfileContext::participantId)
+                .findAny()
+                .orElse(null);
+    }
+    
     private List<DataspaceProfileContext> profiles() {
         return standardProfiles.isEmpty() ? defaultProfiles : standardProfiles;
     }

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/controlplane/profile/DataspaceProfileContextRegistryImplTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/controlplane/profile/DataspaceProfileContextRegistryImplTest.java
@@ -9,6 +9,7 @@
  *
  *  Contributors:
  *       Cofinity-X - initial API and implementation
+ *       Cofinity-X - add participantId to DataspaceProfileContext
  *
  */
 
@@ -31,7 +32,7 @@ class DataspaceProfileContextRegistryImplTest {
         @Test
         void shouldReturnVersions_whenContextsRegisteredDefault() {
             var version = new ProtocolVersion("version name", "/path");
-            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url"));
+            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url", "participantId"));
 
             var result = registry.getProtocolVersions().protocolVersions();
 
@@ -42,8 +43,8 @@ class DataspaceProfileContextRegistryImplTest {
         void shouldIgnoreDefaultContexts_whenStandardAreRegistered() {
             var defaultVersion = new ProtocolVersion("default", "/path");
             var standardVersion = new ProtocolVersion("default", "/path");
-            registry.registerDefault(new DataspaceProfileContext("default", defaultVersion, () -> "url"));
-            registry.register(new DataspaceProfileContext("standard", standardVersion, () -> "url"));
+            registry.registerDefault(new DataspaceProfileContext("default", defaultVersion, () -> "url", "participantId"));
+            registry.register(new DataspaceProfileContext("standard", standardVersion, () -> "url", "participantId"));
 
             var result = registry.getProtocolVersions().protocolVersions();
 
@@ -64,7 +65,7 @@ class DataspaceProfileContextRegistryImplTest {
         @Test
         void shouldReturnWebhookForName() {
             var version = new ProtocolVersion("version name", "/path");
-            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url"));
+            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url", "participantId"));
 
             var result = registry.getWebhook("profile");
 
@@ -85,11 +86,31 @@ class DataspaceProfileContextRegistryImplTest {
         @Test
         void shouldReturnVersionForName() {
             var version = new ProtocolVersion("version name", "/path");
-            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url"));
+            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url", "participantId"));
 
             var result = registry.getProtocolVersion("profile");
 
             assertThat(result).isEqualTo(version);
+        }
+    }
+    
+    @Nested
+    class GetParticipantId {
+        @Test
+        void shouldReturnNull_whenNoParticipantIdFound() {
+            var result = registry.getParticipantId("unexistent");
+            
+            assertThat(result).isNull();
+        }
+        
+        @Test
+        void shouldReturnParticipantIdForName() {
+            var version = new ProtocolVersion("version name", "/path");
+            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url", "participantId"));
+            
+            var result = registry.getParticipantId("profile");
+            
+            assertThat(result).isEqualTo("participantId");
         }
     }
 }

--- a/data-protocols/dsp/dsp-08/dsp-http-api-configuration-08/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiConfigurationV08Extension.java
+++ b/data-protocols/dsp/dsp-08/dsp-http-api-configuration-08/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiConfigurationV08Extension.java
@@ -85,7 +85,7 @@ public class DspApiConfigurationV08Extension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        dataspaceProfileContextRegistry.registerDefault(new DataspaceProfileContext(DATASPACE_PROTOCOL_HTTP, V_08, () -> dspWebhookAddress.get()));
+        dataspaceProfileContextRegistry.registerDefault(new DataspaceProfileContext(DATASPACE_PROTOCOL_HTTP, V_08, () -> dspWebhookAddress.get(), context.getParticipantId()));
 
         // registers ns for DSP scope
         registerNamespaces();

--- a/data-protocols/dsp/dsp-2024/dsp-http-api-configuration-2024/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiConfigurationV2024Extension.java
+++ b/data-protocols/dsp/dsp-2024/dsp-http-api-configuration-2024/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiConfigurationV2024Extension.java
@@ -95,7 +95,7 @@ public class DspApiConfigurationV2024Extension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         var v2024Path = dspWebhookAddress.get() + (wellKnownPathEnabled ? "" : V_2024_1_PATH);
 
-        dataspaceProfileContextRegistry.registerDefault(new DataspaceProfileContext(DATASPACE_PROTOCOL_HTTP_V_2024_1, V_2024_1, () -> v2024Path));
+        dataspaceProfileContextRegistry.registerDefault(new DataspaceProfileContext(DATASPACE_PROTOCOL_HTTP_V_2024_1, V_2024_1, () -> v2024Path, context.getParticipantId()));
 
         // registers ns for DSP scope
         registerNamespaces();

--- a/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/v2025/DspApiConfigurationV2025Extension.java
+++ b/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/v2025/DspApiConfigurationV2025Extension.java
@@ -83,7 +83,7 @@ public class DspApiConfigurationV2025Extension implements ServiceExtension {
         registerNamespaces();
         registerTransformers();
 
-        dataspaceProfileContextRegistry.registerDefault(new DataspaceProfileContext(DATASPACE_PROTOCOL_HTTP_V_2025_1, V_2025_1, () -> dspWebhookAddress.get() + V_2025_1_PATH));
+        dataspaceProfileContextRegistry.registerDefault(new DataspaceProfileContext(DATASPACE_PROTOCOL_HTTP_V_2025_1, V_2025_1, () -> dspWebhookAddress.get() + V_2025_1_PATH, context.getParticipantId()));
     }
 
     private void registerNamespaces() {

--- a/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/DataspaceProfileContext.java
+++ b/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/DataspaceProfileContext.java
@@ -21,6 +21,6 @@ package org.eclipse.edc.protocol.spi;
  * @param protocolVersion the protocol version associated.
  * @param webhook the protocol endpoint url.
  */
-public record DataspaceProfileContext(String name, ProtocolVersion protocolVersion, ProtocolWebhook webhook) {
+public record DataspaceProfileContext(String name, ProtocolVersion protocolVersion, ProtocolWebhook webhook, String participantId) {
 
 }

--- a/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/DataspaceProfileContextRegistry.java
+++ b/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/DataspaceProfileContextRegistry.java
@@ -66,4 +66,13 @@ public interface DataspaceProfileContextRegistry {
      */
     @Nullable
     ProtocolVersion getProtocolVersion(String protocol);
+    
+    /**
+     * Get the participant id for a given protocol.
+     *
+     * @param protocol the protocol name
+     * @return the participant id, or null if no participant id is registered for the protocol
+     */
+    @Nullable
+    String getParticipantId(String protocol);
 }

--- a/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspVersionApiEndToEndTest.java
+++ b/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspVersionApiEndToEndTest.java
@@ -48,7 +48,7 @@ class DspVersionApiEndToEndTest {
     @Test
     void shouldReturnValidJson() {
         runtime.getService(DataspaceProfileContextRegistry.class)
-                .register(new DataspaceProfileContext("profile", new ProtocolVersion("1.0", "/v1/path"), () -> "url"));
+                .register(new DataspaceProfileContext("profile", new ProtocolVersion("1.0", "/v1/path"), () -> "url", "participantId"));
 
         var response = given()
                 .port(PROTOCOL_PORT)


### PR DESCRIPTION
## What this PR changes/adds

Adds the participant id to the `DataspaceProfileContext` and makes it obtainable via the `DataspaceProfileContextRegistry`. The standard participant id is added as the participant id for all registered default profiles.

This is the first part of the implementation outlined in [this DR](https://github.com/eclipse-edc/Connector/tree/main/docs/developer/decision-records/2025-07-25-multiple-participant-identifiers). I decided to split the implementation into 2 PRs (one for resolution of the own participant id, one for extraction of counter-party ids) to keep the PRs small.

## Why it does that

to support different dataspaces potentially using different participant identifiers

## Further notes

There are 3 other areas in the code where the participant id is inserted, which are not included in this PR, as a protocol-dependent id should not be required there:
- `IamMockExtension`: as this module should only be used for testing and samples, it should not be used in conjunction with custom `DataspaceProfileContexts` anyway
- `DelegatedAuthenticationExtension`: participant id used as the fallback audience if no audience is explicitely configured
- `DataPlaneAuthorizationServiceImpl`: participant id used as issuer and subject in tokens issued by the data plane. should not be an issue here, as these tokens will be validated by the same data plane instance


## Who will sponsor this feature?

me


## Linked Issue(s)

Part of #5006

