### PR TITLE
chore: add missing -r option to cp command for schema publishing

### DIFF
--- a/.github/workflows/publish-context.yaml
+++ b/.github/workflows/publish-context.yaml
@@ -43,7 +43,7 @@ jobs:
           cp extensions/common/json-ld/src/main/resources/document/management-context-v1.jsonld public/context/
           cp extensions/common/json-ld/src/main/resources/document/management-context-v2.jsonld public/context/
           mkdir -p public/schema
-          cp extensions/common/api/management-api-schema-validator/src/main/resources/schema/management public/schema/
+          cp -r extensions/common/api/management-api-schema-validator/src/main/resources/schema/management public/schema/
       - name: deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v4
         with:


### PR DESCRIPTION
## What this PR changes/adds

add missing -r option to cp command for schema publishing

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
