### PR TITLE
feat: adds asset mgmt api v4alpha

### DIFF
--- a/extensions/common/api/lib/management-api-lib/src/main/java/org/eclipse/edc/api/management/schema/ManagementApiJsonSchema.java
+++ b/extensions/common/api/lib/management-api-lib/src/main/java/org/eclipse/edc/api/management/schema/ManagementApiJsonSchema.java
@@ -19,4 +19,31 @@ public interface ManagementApiJsonSchema {
     String EDC_MGMT_V4_SCHEMA_PREFIX = "https://w3id.org/edc/connector/management/schema/v4";
     String DSPACE_2025_SCHEMA_PREFIX = "https://w3id.org/dspace/2025/1";
 
+    interface V4 {
+        String ID_RESPONSE = EDC_MGMT_V4_SCHEMA_PREFIX + "/id-response-schema.json";
+        String ASSET = EDC_MGMT_V4_SCHEMA_PREFIX + "/asset-schema.json";
+        String CATALOG_ASSET = EDC_MGMT_V4_SCHEMA_PREFIX + "/catalog-asset-schema.json";
+        String QUERY_SPEC = EDC_MGMT_V4_SCHEMA_PREFIX + "/query-spec-schema.json";
+        String POLICY_DEFINITION = EDC_MGMT_V4_SCHEMA_PREFIX + "/policy-definition-schema.json";
+        String CONTRACT_DEFINITION = EDC_MGMT_V4_SCHEMA_PREFIX + "/contract-definition-schema.json";
+        String DATAPLANE_INSTANCE = EDC_MGMT_V4_SCHEMA_PREFIX + "/dataplane-instance-schema.json";
+        String EDR_ENTRY = EDC_MGMT_V4_SCHEMA_PREFIX + "/edr-entry-schema.json";
+        String POLICY_EVALUATION_REQUEST = EDC_MGMT_V4_SCHEMA_PREFIX + "/policy-evaluation-plan-request-schema.json";
+        String POLICY_EVALUATION_PLAN = EDC_MGMT_V4_SCHEMA_PREFIX + "/policy-evaluation-plan-schema.json";
+        String POLICY_VALIDATION_RESULT = EDC_MGMT_V4_SCHEMA_PREFIX + "/policy-validation-result-schema.json";
+        String SECRET = EDC_MGMT_V4_SCHEMA_PREFIX + "/secret-schema.json";
+        String CATALOG_REQUEST = EDC_MGMT_V4_SCHEMA_PREFIX + "/catalog-request-schema.json";
+        String DATASET_REQUEST = EDC_MGMT_V4_SCHEMA_PREFIX + "/dataset-request-schema.json";
+        String CONTRACT_REQUEST = EDC_MGMT_V4_SCHEMA_PREFIX + "/contract-request-schema.json";
+        String CONTRACT_NEGOTIATION = EDC_MGMT_V4_SCHEMA_PREFIX + "/contract-negotiation-schema.json";
+        String CONTRACT_NEGOTIATION_STATE = EDC_MGMT_V4_SCHEMA_PREFIX + "/contract-negotiation-schema.json#/definitions/NegotiationState";
+        String TERMINATE_NEGOTIATION = EDC_MGMT_V4_SCHEMA_PREFIX + "/contract-terminate-schema.json";
+        String CONTRACT_AGREEMENT = EDC_MGMT_V4_SCHEMA_PREFIX + "/contract-agreement-schema.json";
+        String TRANSFER_REQUEST = EDC_MGMT_V4_SCHEMA_PREFIX + "/transfer-request-schema.json";
+        String TRANSFER_PROCESS = EDC_MGMT_V4_SCHEMA_PREFIX + "/transfer-process-schema.json";
+        String TRANSFER_PROCESS_STATE = EDC_MGMT_V4_SCHEMA_PREFIX + "/transfer-process-schema.json#/definitions/TransferState";
+        String TERMINATE_TRANSFER = EDC_MGMT_V4_SCHEMA_PREFIX + "/transfer-terminate-schema.json";
+        String SUSPEND_TRANSFER = EDC_MGMT_V4_SCHEMA_PREFIX + "/transfer-suspend-schema.json";
+
+    }
 }

--- a/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtension.java
+++ b/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtension.java
@@ -45,7 +45,6 @@ import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToCriterionTransfo
 import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToDataAddressTransformer;
 import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToQuerySpecTransformer;
 import org.eclipse.edc.transform.transformer.edc.to.JsonValueToGenericTypeTransformer;
-import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.jersey.providers.jsonld.ObjectMapperProvider;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
@@ -138,7 +137,6 @@ public class ManagementApiConfigurationExtension implements ServiceExtension {
         jsonLd.registerContext(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2, MANAGEMENT_SCOPE_V4);
 
         webService.registerResource(ApiContext.MANAGEMENT, new ObjectMapperProvider(typeManager, JSON_LD));
-        webService.registerResource(ApiContext.MANAGEMENT, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
 
         var managementApiTransformerRegistry = transformerRegistry.forContext(MANAGEMENT_API_CONTEXT);
 

--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -8,7 +8,7 @@
   {
     "version": "4.0.0-alpha",
     "urlPath": "/v4alpha",
-    "lastUpdated": "2025-01-08T14:26:00Z",
+    "lastUpdated": "2025-08-01T14:26:00Z",
     "maturity": "alpha"
   }
 ]

--- a/extensions/common/api/management-api-configuration/src/test/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtensionTest.java
+++ b/extensions/common/api/management-api-configuration/src/test/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtensionTest.java
@@ -25,7 +25,6 @@ import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
-import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.jersey.providers.jsonld.ObjectMapperProvider;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
@@ -85,7 +84,6 @@ class ManagementApiConfigurationExtensionTest {
         extension.initialize(context);
 
         verify(portMappingRegistry).register(new PortMapping(ApiContext.MANAGEMENT, DEFAULT_MANAGEMENT_PORT, DEFAULT_MANAGEMENT_PATH));
-        verify(webService).registerResource(eq(ApiContext.MANAGEMENT), isA(JerseyJsonLdInterceptor.class));
         verify(webService).registerResource(eq(ApiContext.MANAGEMENT), isA(ObjectMapperProvider.class));
 
         verify(jsonLd).registerNamespace(VOCAB, EDC_NAMESPACE, MANAGEMENT_SCOPE);

--- a/extensions/common/api/management-api-schema-validator/src/main/java/org/eclipse/edc/connector/api/management/schema/ManagementApiSchemaValidatorExtension.java
+++ b/extensions/common/api/management-api-schema-validator/src/main/java/org/eclipse/edc/connector/api/management/schema/ManagementApiSchemaValidatorExtension.java
@@ -26,8 +26,33 @@ import java.util.Map;
 
 import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.DSPACE_2025_SCHEMA_PREFIX;
 import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.EDC_MGMT_V4_SCHEMA_PREFIX;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.ASSET;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.CATALOG_ASSET;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.CATALOG_REQUEST;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.CONTRACT_AGREEMENT;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.CONTRACT_DEFINITION;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.CONTRACT_NEGOTIATION;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.CONTRACT_NEGOTIATION_STATE;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.CONTRACT_REQUEST;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.DATAPLANE_INSTANCE;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.DATASET_REQUEST;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.EDR_ENTRY;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.ID_RESPONSE;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.POLICY_DEFINITION;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.POLICY_EVALUATION_PLAN;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.POLICY_EVALUATION_REQUEST;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.POLICY_VALIDATION_RESULT;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.QUERY_SPEC;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.SECRET;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.SUSPEND_TRANSFER;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.TERMINATE_NEGOTIATION;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.TERMINATE_TRANSFER;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.TRANSFER_PROCESS;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.TRANSFER_PROCESS_STATE;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.TRANSFER_REQUEST;
 import static org.eclipse.edc.connector.api.management.schema.ManagementApiSchemaValidatorExtension.NAME;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_TYPE_TERM;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_CATALOG_ASSET_TYPE_TERM;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_TYPE_TERM;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_TYPE_TERM;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement.CONTRACT_AGREEMENT_TYPE_TERM;
@@ -56,28 +81,32 @@ public class ManagementApiSchemaValidatorExtension implements ServiceExtension {
 
     private final Map<String, String> schemaV4 = new HashMap<>() {
         {
-            put(DATAPLANE_INSTANCE_TYPE_TERM, "dataplane-instance-schema.json");
-            put(DATASET_REQUEST_TYPE_TERM, "dataset-request-schema.json");
-            put(CATALOG_REQUEST_TYPE_TERM, "catalog-request-schema.json");
-            put(EDC_QUERY_SPEC_TYPE_TERM, "query-spec-schema.json");
-            put(EDC_ASSET_TYPE_TERM, "asset-schema.json");
-            put(CONTRACT_DEFINITION_TYPE_TERM, "contract-definition-schema.json");
-            put(CONTRACT_AGREEMENT_TYPE_TERM, "contract-agreement-schema.json");
-            put(EDR_ENTRY_TYPE_TERM, "edr-entry-schema.json");
-            put(EDC_POLICY_DEFINITION_TYPE_TERM, "policy-definition-schema.json");
-            put("PolicyEvaluationPlanRequest", "policy-evaluation-plan-request-schema.json");
-            put(EDC_POLICY_EVALUATION_PLAN_TYPE_TERM, "policy-evaluation-plan-schema.json");
-            put("PolicyValidationResult", "policy-validation-result-schema.json");
-            put(EDC_SECRET_TYPE_TERM, "secret-schema.json");
-            put(CONTRACT_REQUEST_TYPE_TERM, "contract-request-schema.json");
-            put(TERMINATE_NEGOTIATION_TYPE_TERM, "contract-terminate-schema.json");
-            put(CONTRACT_NEGOTIATION_TYPE_TERM, "contract-negotiation-schema.json");
-            put("NegotiationState", "contract-negotiation-schema.json#/definitions/NegotiationState");
-            put(TRANSFER_REQUEST_TYPE_TERM, "transfer-request-schema.json");
-            put(TRANSFER_PROCESS_TYPE_TERM, "transfer-process-schema.json");
-            put("TransferState", "transfer-process-schema.json#/definitions/TransferState");
-            put("TerminateTransfer", "transfer-terminate-schema.json");
-            put("SuspendTransfer", "transfer-suspend-schema.json");
+            put("IdResponse", ID_RESPONSE);
+            put(EDC_ASSET_TYPE_TERM, ASSET);
+            put(EDC_CATALOG_ASSET_TYPE_TERM, CATALOG_ASSET);
+            put(EDC_QUERY_SPEC_TYPE_TERM, QUERY_SPEC);
+            put(EDC_POLICY_DEFINITION_TYPE_TERM, POLICY_DEFINITION);
+            put(CONTRACT_DEFINITION_TYPE_TERM, CONTRACT_DEFINITION);
+            put(DATAPLANE_INSTANCE_TYPE_TERM, DATAPLANE_INSTANCE);
+            put(EDR_ENTRY_TYPE_TERM, EDR_ENTRY);
+            put("PolicyEvaluationPlanRequest", POLICY_EVALUATION_REQUEST);
+            put(EDC_POLICY_EVALUATION_PLAN_TYPE_TERM, POLICY_EVALUATION_PLAN);
+            put("PolicyValidationResult", POLICY_VALIDATION_RESULT);
+            put(EDC_SECRET_TYPE_TERM, SECRET);
+            put(CATALOG_REQUEST_TYPE_TERM, CATALOG_REQUEST);
+            put(DATASET_REQUEST_TYPE_TERM, DATASET_REQUEST);
+            put(CONTRACT_REQUEST_TYPE_TERM, CONTRACT_REQUEST);
+            put(CONTRACT_NEGOTIATION_TYPE_TERM, CONTRACT_NEGOTIATION);
+            put("NegotiationState", CONTRACT_NEGOTIATION_STATE);
+            put(TERMINATE_NEGOTIATION_TYPE_TERM, TERMINATE_NEGOTIATION);
+            put(CONTRACT_AGREEMENT_TYPE_TERM, CONTRACT_AGREEMENT);
+            put(TRANSFER_REQUEST_TYPE_TERM, TRANSFER_REQUEST);
+            put(TRANSFER_PROCESS_TYPE_TERM, TRANSFER_PROCESS);
+            put("TransferState", TRANSFER_PROCESS_STATE);
+            put("TerminateTransfer", TERMINATE_TRANSFER);
+            put("SuspendTransfer", SUSPEND_TRANSFER);
+
+
         }
     };
 
@@ -99,7 +128,7 @@ public class ManagementApiSchemaValidatorExtension implements ServiceExtension {
     }
 
     void registerValidatorsV4(ManagementApiSchemaValidatorProvider validatorProvider) {
-        schemaV4.forEach((type, schema) -> validator.register(V_4_PREFIX + type, validatorProvider.validatorFor(EDC_MGMT_V4_SCHEMA_PREFIX + "/" + schema)));
+        schemaV4.forEach((type, schema) -> validator.register(V_4_PREFIX + type, validatorProvider.validatorFor(schema)));
     }
 
 }

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/catalog-asset-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/catalog-asset-schema.json
@@ -1,15 +1,15 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "title": "AssetSchema",
+  "title": "CatalogAssetSchema",
   "type": "object",
   "allOf": [
     {
-      "$ref": "#/definitions/Asset"
+      "$ref": "#/definitions/CatalogAsset"
     }
   ],
-  "$id": "https://w3id.org/edc/connector/management/schema/v4/asset-schema.json",
+  "$id": "https://w3id.org/edc/connector/management/schema/v4/catalog-asset-schema.json",
   "definitions": {
-    "Asset": {
+    "CatalogAsset": {
       "type": "object",
       "properties": {
         "@context": {
@@ -17,7 +17,7 @@
         },
         "@type": {
           "type": "string",
-          "const": "Asset"
+          "const": "CatalogAsset"
         },
         "@id": {
           "type": "string"
@@ -27,6 +27,9 @@
         },
         "privateProperties": {
           "type": "object"
+        },
+        "isCatalog": {
+          "type": "boolean"
         },
         "dataAddress": {
           "$ref": "https://w3id.org/edc/connector/management/schema/v4/data-address-schema.json"

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/id-response-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/id-response-schema.json
@@ -1,15 +1,15 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "title": "AssetSchema",
+  "title": "IdResponseSchema",
   "type": "object",
   "allOf": [
     {
-      "$ref": "#/definitions/Asset"
+      "$ref": "#/definitions/IdResponse"
     }
   ],
-  "$id": "https://w3id.org/edc/connector/management/schema/v4/asset-schema.json",
+  "$id": "https://w3id.org/edc/connector/management/schema/v4/id-response-schema.json",
   "definitions": {
-    "Asset": {
+    "IdResponse": {
       "type": "object",
       "properties": {
         "@context": {
@@ -17,26 +17,20 @@
         },
         "@type": {
           "type": "string",
-          "const": "Asset"
+          "const": "IdResponse"
         },
         "@id": {
           "type": "string"
         },
-        "properties": {
-          "type": "object"
-        },
-        "privateProperties": {
-          "type": "object"
-        },
-        "dataAddress": {
-          "$ref": "https://w3id.org/edc/connector/management/schema/v4/data-address-schema.json"
+        "createdAt": {
+          "type": "number"
         }
       },
       "required": [
         "@context",
         "@type",
-        "properties",
-        "dataAddress"
+        "@id",
+        "createdAt"
       ]
     }
   }

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/query-spec-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/query-spec-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "title": "QuertSpecSchema",
+  "title": "QuerySpecSchema",
   "type": "object",
   "allOf": [
     {
@@ -49,14 +49,14 @@
       "type": "object",
       "allOf": [
         {
-          "$ref": "#/definitions/QuerySpec"
-        },
-        {
           "properties": {
             "@context": {
               "$ref": "https://w3id.org/edc/connector/management/schema/v4/context-schema.json"
             }
           }
+        },
+        {
+          "$ref": "#/definitions/QuerySpec"
         }
       ],
       "required": [

--- a/extensions/common/json-ld/src/main/resources/document/management-context-v2.jsonld
+++ b/extensions/common/json-ld/src/main/resources/document/management-context-v2.jsonld
@@ -25,6 +25,30 @@
         }
       }
     },
+    "CatalogAsset": {
+      "@id": "edc:CatalogAsset",
+      "@context": {
+        "properties": {
+          "@id": "edc:properties",
+          "@context": {
+            "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          }
+        },
+        "privateProperties": {
+          "@id": "edc:privateProperties",
+          "@context": {
+            "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          }
+        },
+        "dataAddress": {
+          "@id": "edc:dataAddress",
+          "@context": {
+            "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+          }
+        },
+        "isCatalog": "edc:isCatalog"
+      }
+    },
     "PolicyDefinition": {
       "@id": "edc:PolicyDefinition",
       "@context": {
@@ -405,6 +429,12 @@
         },
         "stateTimestamp": "edc:stateTimestamp",
         "lastActive": "edc:lastActive"
+      }
+    },
+    "IdResponse": {
+      "@id": "edc:IdResponse",
+      "@context": {
+        "createdAt": "edc:createdAt"
       }
     },
     "inForceDate": "edc:inForceDate",

--- a/extensions/control-plane/api/management-api/asset-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/asset-api/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation(project(":core:common:lib:api-lib"))
     implementation(project(":core:common:lib:validator-lib"))
     implementation(project(":extensions:common:api:lib:management-api-lib"))
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
 
     implementation(libs.jakarta.rsApi)
 

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/AssetApiExtension.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/AssetApiExtension.java
@@ -17,19 +17,26 @@
 package org.eclipse.edc.connector.controlplane.api.management.asset;
 
 import org.eclipse.edc.api.validation.DataAddressValidator;
-import org.eclipse.edc.connector.controlplane.api.management.asset.v3.AssetApiController;
+import org.eclipse.edc.connector.controlplane.api.management.asset.v3.AssetApiV3Controller;
+import org.eclipse.edc.connector.controlplane.api.management.asset.v4.AssetApiV4Controller;
 import org.eclipse.edc.connector.controlplane.api.management.asset.validation.AssetValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.asset.AssetService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
 
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE_V4;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 import static org.eclipse.edc.spi.types.domain.DataAddress.EDC_DATA_ADDRESS_TYPE;
 
 @Extension(value = AssetApiExtension.NAME)
@@ -49,6 +56,12 @@ public class AssetApiExtension implements ServiceExtension {
     @Inject
     private JsonObjectValidatorRegistry validator;
 
+    @Inject
+    private JsonLd jsonLd;
+
+    @Inject
+    private TypeManager typeManager;
+
     @Override
     public String name() {
         return NAME;
@@ -63,7 +76,13 @@ public class AssetApiExtension implements ServiceExtension {
 
         var managementTypeTransformerRegistry = transformerRegistry.forContext("management-api");
 
-        webService.registerResource(ApiContext.MANAGEMENT, new AssetApiController(assetService,
+        webService.registerResource(ApiContext.MANAGEMENT, new AssetApiV3Controller(assetService,
                 managementTypeTransformerRegistry, monitor, validator));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, AssetApiV3Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
+
+        webService.registerResource(ApiContext.MANAGEMENT, new AssetApiV4Controller(assetService,
+                managementTypeTransformerRegistry, monitor, validator));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, AssetApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validator, "v4"));
+
     }
 }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/v3/AssetApiV3.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/v3/AssetApiV3.java
@@ -1,0 +1,166 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.asset.v3;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.management.schema.ManagementApiSchema;
+import org.eclipse.edc.api.model.ApiCoreSchema;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+
+@OpenAPIDefinition(
+        info = @Info(description = "This contains both the current and the new Asset API, which accepts JSON-LD and will " +
+                "become the standard API once the Dataspace Protocol is stable.", title = "Asset API", version = "v3"))
+@Tag(name = "Asset V3")
+public interface AssetApiV3 {
+    @Operation(description = "Creates a new asset together with a data address",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = AssetInputSchema.class))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Asset was created successfully. Returns the asset Id and created timestamp",
+                            content = @Content(schema = @Schema(implementation = ApiCoreSchema.IdResponseSchema.class))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "409", description = "Could not create asset, because an asset with that ID already exists",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))}
+    )
+    JsonObject createAssetV3(JsonObject asset);
+
+    @Operation(description = "Request all assets according to a particular query",
+            requestBody = @RequestBody(
+                    content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The assets matching the query",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = AssetOutputSchema.class)))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            })
+    JsonArray requestAssetsV3(JsonObject querySpecJson);
+
+    @Operation(description = "Gets an asset with the given ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The asset",
+                            content = @Content(schema = @Schema(implementation = AssetOutputSchema.class))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "An asset with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    JsonObject getAssetV3(String id);
+
+    @Operation(description = "Removes an asset with the given ID if possible. Deleting an asset is only possible if that asset is not yet referenced " +
+            "by a contract agreement, in which case an error is returned. " +
+            "DANGER ZONE: Note that deleting assets can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Asset was deleted successfully"),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "An asset with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "409", description = "The asset cannot be deleted, because it is referenced by a contract agreement",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            })
+    void removeAssetV3(String id);
+
+    @Operation(description = "Updates an asset with the given ID if it exists. If the asset is not found, no further action is taken. " +
+            "DANGER ZONE: Note that updating assets can have unexpected results, especially for contract offers that have been sent out or are ongoing in contract negotiations.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = AssetInputSchema.class))),
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Asset was updated successfully"),
+                    @ApiResponse(responseCode = "404", description = "Asset could not be updated, because it does not exist."),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+            })
+    void updateAssetV3(JsonObject asset);
+
+    @Schema(name = "AssetInput", example = AssetInputSchema.ASSET_INPUT_EXAMPLE)
+    record AssetInputSchema(
+            @Schema(name = CONTEXT, requiredMode = REQUIRED)
+            Object context,
+            @Schema(name = ID)
+            String id,
+            @Schema(name = TYPE, example = EDC_ASSET_TYPE)
+            String type,
+            @Schema(requiredMode = REQUIRED)
+            ManagementApiSchema.FreeFormPropertiesSchema properties,
+            ManagementApiSchema.FreeFormPropertiesSchema privateProperties,
+            @Schema(requiredMode = REQUIRED)
+            ApiCoreSchema.DataAddressSchema dataAddress
+    ) {
+        public static final String ASSET_INPUT_EXAMPLE = """
+                {
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@id": "asset-id",
+                    "properties": {
+                        "key": "value"
+                    },
+                    "privateProperties": {
+                        "privateKey": "privateValue"
+                    },
+                    "dataAddress": {
+                        "type": "HttpData",
+                        "baseUrl": "https://jsonplaceholder.typicode.com/todos"
+                    }
+                }
+                """;
+    }
+
+    @ArraySchema()
+    @Schema(name = "AssetOutput", example = AssetOutputSchema.ASSET_OUTPUT_EXAMPLE)
+    record AssetOutputSchema(
+            @Schema(name = ID)
+            String id,
+            @Schema(name = TYPE, example = EDC_ASSET_TYPE)
+            String type,
+            ManagementApiSchema.FreeFormPropertiesSchema properties,
+            ManagementApiSchema.FreeFormPropertiesSchema privateProperties,
+            ApiCoreSchema.DataAddressSchema dataAddress,
+            long createdAt
+    ) {
+        public static final String ASSET_OUTPUT_EXAMPLE = """
+                {
+                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
+                    "@id": "asset-id",
+                    "properties": {
+                        "key": "value"
+                    },
+                    "privateProperties": {
+                        "privateKey": "privateValue"
+                    },
+                    "dataAddress": {
+                        "type": "HttpData",
+                        "baseUrl": "https://jsonplaceholder.typicode.com/todos"
+                    },
+                    "createdAt": 1688465655
+                }
+                """;
+    }
+
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/v3/AssetApiV3Controller.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/v3/AssetApiV3Controller.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.asset.v3;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import org.eclipse.edc.connector.controlplane.api.management.asset.BaseAssetApiController;
+import org.eclipse.edc.connector.controlplane.services.spi.asset.AssetService;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v3/assets")
+public class AssetApiV3Controller extends BaseAssetApiController implements AssetApiV3 {
+
+    public AssetApiV3Controller(AssetService service, TypeTransformerRegistry transformerRegistry,
+                                Monitor monitor, JsonObjectValidatorRegistry validator) {
+        super(transformerRegistry, service, monitor, validator);
+    }
+
+    @POST
+    @Override
+    public JsonObject createAssetV3(JsonObject asset) {
+        return createAsset(asset);
+    }
+
+    @POST
+    @Path("/request")
+    @Override
+    public JsonArray requestAssetsV3(JsonObject querySpecJson) {
+        return requestAssets(querySpecJson);
+    }
+
+    @GET
+    @Path("{id}")
+    @Override
+    public JsonObject getAssetV3(@PathParam("id") String id) {
+        return getAsset(id);
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Override
+    public void removeAssetV3(@PathParam("id") String id) {
+        removeAsset(id);
+    }
+
+    @PUT
+    @Override
+    public void updateAssetV3(JsonObject asset) {
+        updateAsset(asset);
+    }
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/v4/AssetApiV4.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/v4/AssetApiV4.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2025 Metaform Systems, Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,11 +8,11 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Metaform Systems, Inc. - initial API and implementation
  *
  */
 
-package org.eclipse.edc.connector.controlplane.api.management.asset.v3;
+package org.eclipse.edc.connector.controlplane.api.management.asset.v4;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,55 +25,49 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
-import org.eclipse.edc.api.management.schema.ManagementApiSchema;
+import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.api.model.ApiCoreSchema;
-
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
-import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_TYPE;
-import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
-import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
-import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
 @OpenAPIDefinition(
         info = @Info(description = "This contains both the current and the new Asset API, which accepts JSON-LD and will " +
-                "become the standard API once the Dataspace Protocol is stable.", title = "Asset API", version = "v3"))
-@Tag(name = "Asset V3")
-public interface AssetApi {
+                "become the standard API once the Dataspace Protocol is stable.", title = "Asset API", version = "v4alpha"))
+@Tag(name = "Asset v4alpha")
+public interface AssetApiV4 {
     @Operation(description = "Creates a new asset together with a data address",
-            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = AssetInputSchema.class))),
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.ASSET))),
             responses = {
                     @ApiResponse(responseCode = "200", description = "Asset was created successfully. Returns the asset Id and created timestamp",
-                            content = @Content(schema = @Schema(implementation = ApiCoreSchema.IdResponseSchema.class))),
+                            content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.ID_RESPONSE))),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "409", description = "Could not create asset, because an asset with that ID already exists",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))) }
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))}
     )
-    JsonObject createAssetV3(JsonObject asset);
+    JsonObject createAssetV4(JsonObject asset);
 
     @Operation(description = "Request all assets according to a particular query",
             requestBody = @RequestBody(
-                    content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))
+                    content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.QUERY_SPEC))
             ),
             responses = {
                     @ApiResponse(responseCode = "200", description = "The assets matching the query",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = AssetOutputSchema.class)))),
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.ASSET)))),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
-    JsonArray requestAssetsV3(JsonObject querySpecJson);
+    JsonArray requestAssetsV4(JsonObject querySpecJson);
 
     @Operation(description = "Gets an asset with the given ID",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The asset",
-                            content = @Content(schema = @Schema(implementation = AssetOutputSchema.class))),
+                            content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.ASSET))),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "404", description = "An asset with the given ID does not exist",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    JsonObject getAssetV3(String id);
+    JsonObject getAssetV4(String id);
 
     @Operation(description = "Removes an asset with the given ID if possible. Deleting an asset is only possible if that asset is not yet referenced " +
             "by a contract agreement, in which case an error is returned. " +
@@ -87,80 +81,17 @@ public interface AssetApi {
                     @ApiResponse(responseCode = "409", description = "The asset cannot be deleted, because it is referenced by a contract agreement",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             })
-    void removeAssetV3(String id);
+    void removeAssetV4(String id);
 
     @Operation(description = "Updates an asset with the given ID if it exists. If the asset is not found, no further action is taken. " +
             "DANGER ZONE: Note that updating assets can have unexpected results, especially for contract offers that have been sent out or are ongoing in contract negotiations.",
-            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = AssetInputSchema.class))),
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.ASSET))),
             responses = {
                     @ApiResponse(responseCode = "204", description = "Asset was updated successfully"),
                     @ApiResponse(responseCode = "404", description = "Asset could not be updated, because it does not exist."),
                     @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
             })
-    void updateAssetV3(JsonObject asset);
-
-    @Schema(name = "AssetInput", example = AssetInputSchema.ASSET_INPUT_EXAMPLE)
-    record AssetInputSchema(
-            @Schema(name = CONTEXT, requiredMode = REQUIRED)
-            Object context,
-            @Schema(name = ID)
-            String id,
-            @Schema(name = TYPE, example = EDC_ASSET_TYPE)
-            String type,
-            @Schema(requiredMode = REQUIRED)
-            ManagementApiSchema.FreeFormPropertiesSchema properties,
-            ManagementApiSchema.FreeFormPropertiesSchema privateProperties,
-            @Schema(requiredMode = REQUIRED)
-            ApiCoreSchema.DataAddressSchema dataAddress
-    ) {
-        public static final String ASSET_INPUT_EXAMPLE = """
-                {
-                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
-                    "@id": "asset-id",
-                    "properties": {
-                        "key": "value"
-                    },
-                    "privateProperties": {
-                        "privateKey": "privateValue"
-                    },
-                    "dataAddress": {
-                        "type": "HttpData",
-                        "baseUrl": "https://jsonplaceholder.typicode.com/todos"
-                    }
-                }
-                """;
-    }
-
-    @ArraySchema()
-    @Schema(name = "AssetOutput", example = AssetOutputSchema.ASSET_OUTPUT_EXAMPLE)
-    record AssetOutputSchema(
-            @Schema(name = ID)
-            String id,
-            @Schema(name = TYPE, example = EDC_ASSET_TYPE)
-            String type,
-            ManagementApiSchema.FreeFormPropertiesSchema properties,
-            ManagementApiSchema.FreeFormPropertiesSchema privateProperties,
-            ApiCoreSchema.DataAddressSchema dataAddress,
-            long createdAt
-    ) {
-        public static final String ASSET_OUTPUT_EXAMPLE = """
-                {
-                    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
-                    "@id": "asset-id",
-                    "properties": {
-                        "key": "value"
-                    },
-                    "privateProperties": {
-                        "privateKey": "privateValue"
-                    },
-                    "dataAddress": {
-                        "type": "HttpData",
-                        "baseUrl": "https://jsonplaceholder.typicode.com/todos"
-                    },
-                    "createdAt": 1688465655
-                }
-                """;
-    }
+    void updateAssetV4(JsonObject asset);
 
 }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/v4/AssetApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/v4/AssetApiV4Controller.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.asset.v4;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import org.eclipse.edc.connector.controlplane.api.management.asset.BaseAssetApiController;
+import org.eclipse.edc.connector.controlplane.services.spi.asset.AssetService;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.spi.validation.SchemaType;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_TYPE_TERM;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_CATALOG_ASSET_TYPE_TERM;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v4alpha/assets")
+public class AssetApiV4Controller extends BaseAssetApiController implements AssetApiV4 {
+
+    public AssetApiV4Controller(AssetService service, TypeTransformerRegistry transformerRegistry,
+                                Monitor monitor, JsonObjectValidatorRegistry validator) {
+        super(transformerRegistry, service, monitor, validator);
+    }
+
+    @POST
+    @Override
+    public JsonObject createAssetV4(@SchemaType({EDC_ASSET_TYPE_TERM, EDC_CATALOG_ASSET_TYPE_TERM}) JsonObject asset) {
+        return createAsset(asset);
+    }
+
+    @POST
+    @Path("/request")
+    @Override
+    public JsonArray requestAssetsV4(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson) {
+        return requestAssets(querySpecJson);
+    }
+
+    @GET
+    @Path("{id}")
+    @Override
+    public JsonObject getAssetV4(@PathParam("id") String id) {
+        return getAsset(id);
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Override
+    public void removeAssetV4(@PathParam("id") String id) {
+        removeAsset(id);
+    }
+
+    @PUT
+    @Override
+    public void updateAssetV4(@SchemaType({EDC_ASSET_TYPE_TERM, EDC_CATALOG_ASSET_TYPE_TERM}) JsonObject asset) {
+        updateAsset(asset);
+    }
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/AssetApiV3ExtensionTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/AssetApiV3ExtensionTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.connector.controlplane.api.management.asset;
 
-import org.eclipse.edc.connector.controlplane.api.management.asset.v3.AssetApiController;
+import org.eclipse.edc.connector.controlplane.api.management.asset.v3.AssetApiV3Controller;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(DependencyInjectionExtension.class)
-class AssetApiExtensionTest {
+class AssetApiV3ExtensionTest {
 
     private final JsonObjectValidatorRegistry validatorRegistry = mock();
     private final WebService webService = mock();
@@ -47,7 +47,7 @@ class AssetApiExtensionTest {
     void initialize_shouldRegisterControllers(AssetApiExtension extension, ServiceExtensionContext context) {
         extension.initialize(context);
 
-        verify(webService).registerResource(any(), isA(AssetApiController.class));
+        verify(webService).registerResource(any(), isA(AssetApiV3Controller.class));
     }
 
     @Test

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/v3/AssetApiV3ControllerTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/v3/AssetApiV3ControllerTest.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.asset.v3;
+
+import org.eclipse.edc.connector.controlplane.api.management.asset.BaseAssetApiControllerTest;
+import org.eclipse.edc.junit.annotations.ApiTest;
+
+@ApiTest
+class AssetApiV3ControllerTest extends BaseAssetApiControllerTest {
+
+
+    @Override
+    protected Object controller() {
+        return new AssetApiV3Controller(service, transformerRegistry, monitor, validator);
+    }
+
+
+    @Override
+    protected String versionPath() {
+        return "v3";
+    }
+}

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/v3/AssetApiV3Test.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/v3/AssetApiV3Test.java
@@ -33,8 +33,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.map;
-import static org.eclipse.edc.connector.controlplane.api.management.asset.v3.AssetApi.AssetInputSchema.ASSET_INPUT_EXAMPLE;
-import static org.eclipse.edc.connector.controlplane.api.management.asset.v3.AssetApi.AssetOutputSchema.ASSET_OUTPUT_EXAMPLE;
+import static org.eclipse.edc.connector.controlplane.api.management.asset.v3.AssetApiV3.AssetInputSchema.ASSET_INPUT_EXAMPLE;
+import static org.eclipse.edc.connector.controlplane.api.management.asset.v3.AssetApiV3.AssetOutputSchema.ASSET_OUTPUT_EXAMPLE;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_DATA_ADDRESS;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_PRIVATE_PROPERTIES;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_PROPERTIES;
@@ -43,7 +43,7 @@ import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class AssetApiTest {
+class AssetApiV3Test {
     private final TypeManager typeManager = mock();
     private final ObjectMapper objectMapper = JacksonJsonLd.createObjectMapper();
     private final JsonLd jsonLd = new TitaniumJsonLd(mock());

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/v4/AssetApiV4ControllerTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/v4/AssetApiV4ControllerTest.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.asset.v4;
+
+import org.eclipse.edc.connector.controlplane.api.management.asset.BaseAssetApiControllerTest;
+import org.eclipse.edc.junit.annotations.ApiTest;
+
+@ApiTest
+class AssetApiV4ControllerTest extends BaseAssetApiControllerTest {
+
+
+    @Override
+    protected Object controller() {
+        return new AssetApiV4Controller(service, transformerRegistry, monitor, validator);
+    }
+
+    @Override
+    protected String versionPath() {
+        return "v4alpha";
+    }
+
+}

--- a/extensions/control-plane/api/management-api/catalog-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/catalog-api/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation(project(":core:common:lib:api-lib"))
     implementation(project(":core:common:lib:validator-lib"))
     implementation(project(":extensions:common:api:lib:management-api-lib"))
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
 
     implementation(libs.jakarta.rsApi)
 

--- a/extensions/control-plane/api/management-api/contract-agreement-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 
     implementation(project(":core:common:lib:api-lib"))
     implementation(project(":extensions:common:api:lib:management-api-lib"))
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
 
     implementation(libs.jakarta.rsApi)
 

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/ContractAgreementApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/ContractAgreementApiExtension.java
@@ -18,17 +18,22 @@ package org.eclipse.edc.connector.controlplane.api.management.contractagreement;
 import org.eclipse.edc.connector.controlplane.api.management.contractagreement.v3.ContractAgreementApiV3Controller;
 import org.eclipse.edc.connector.controlplane.api.management.contractagreement.v4alpha.ContractAgreementApiV4AlphaController;
 import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.ContractAgreementService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
 
 import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_API_CONTEXT;
 import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_API_V_4_ALPHA;
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
 @Extension(value = ContractAgreementApiExtension.NAME)
 public class ContractAgreementApiExtension implements ServiceExtension {
@@ -46,6 +51,12 @@ public class ContractAgreementApiExtension implements ServiceExtension {
     @Inject
     private JsonObjectValidatorRegistry validatorRegistry;
 
+    @Inject
+    private JsonLd jsonLd;
+
+    @Inject
+    private TypeManager typeManager;
+
     @Override
     public String name() {
         return NAME;
@@ -59,6 +70,10 @@ public class ContractAgreementApiExtension implements ServiceExtension {
         var managementApiTransformerRegistryV4Alpha = managementApiTransformerRegistry.forContext(MANAGEMENT_API_V_4_ALPHA);
 
         webService.registerResource(ApiContext.MANAGEMENT, new ContractAgreementApiV3Controller(service, managementApiTransformerRegistry, monitor, validatorRegistry));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractAgreementApiV3Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
+
         webService.registerResource(ApiContext.MANAGEMENT, new ContractAgreementApiV4AlphaController(service, managementApiTransformerRegistryV4Alpha, monitor, validatorRegistry));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractAgreementApiV4AlphaController.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
+
     }
 }

--- a/extensions/control-plane/api/management-api/contract-definition-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/contract-definition-api/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(project(":extensions:common:api:lib:management-api-lib"))
     implementation(project(":core:common:lib:api-lib"))
     implementation(project(":core:common:lib:validator-lib"))
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
 
     implementation(libs.jakarta.rsApi)
 

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/ContractDefinitionApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/ContractDefinitionApiExtension.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.
 import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.v3.ContractDefinitionApiV3Controller;
 import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.validation.ContractDefinitionValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.contractdefinition.ContractDefinitionService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
@@ -30,11 +31,13 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
 
 import java.util.Map;
 
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
@@ -61,6 +64,9 @@ public class ContractDefinitionApiExtension implements ServiceExtension {
     @Inject
     private CriterionOperatorRegistry criterionOperatorRegistry;
 
+    @Inject
+    private JsonLd jsonLd;
+
     @Override
     public String name() {
         return NAME;
@@ -77,5 +83,7 @@ public class ContractDefinitionApiExtension implements ServiceExtension {
         var managementApiTransformerRegistry = transformerRegistry.forContext("management-api");
 
         webService.registerResource(ApiContext.MANAGEMENT, new ContractDefinitionApiV3Controller(managementApiTransformerRegistry, service, context.getMonitor(), validatorRegistry));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractDefinitionApiV3Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
+
     }
 }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation(project(":extensions:common:api:lib:management-api-lib"))
     implementation(project(":core:common:lib:api-lib"))
     implementation(project(":core:common:lib:validator-lib"))
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
 
     implementation(libs.jakarta.rsApi)
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiExtension.java
@@ -24,19 +24,24 @@ import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation
 import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.validation.ContractRequestValidator;
 import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.validation.TerminateNegotiationValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
 
 import java.util.Map;
 
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.command.TerminateNegotiationCommand.TERMINATE_NEGOTIATION_TYPE;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest.CONTRACT_REQUEST_TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
 @Extension(value = ContractNegotiationApiExtension.NAME)
 public class ContractNegotiationApiExtension implements ServiceExtension {
@@ -54,6 +59,12 @@ public class ContractNegotiationApiExtension implements ServiceExtension {
 
     @Inject
     private JsonObjectValidatorRegistry validatorRegistry;
+
+    @Inject
+    private JsonLd jsonLd;
+
+    @Inject
+    private TypeManager typeManager;
 
     @Override
     public String name() {
@@ -77,5 +88,7 @@ public class ContractNegotiationApiExtension implements ServiceExtension {
         validatorRegistry.register(TERMINATE_NEGOTIATION_TYPE, TerminateNegotiationValidator.instance());
 
         webService.registerResource(ApiContext.MANAGEMENT, new ContractNegotiationApiV3Controller(service, managementApiTransformerRegistry, monitor, validatorRegistry));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractNegotiationApiV3Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
+
     }
 }

--- a/extensions/control-plane/api/management-api/edr-cache-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/edr-cache-api/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     api(project(":spi:control-plane:control-plane-spi"))
     implementation(project(":core:common:lib:api-lib"))
     implementation(project(":core:common:lib:validator-lib"))
+    implementation(project(":extensions:common:api:lib:management-api-lib"))
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
 
     implementation(libs.jakarta.rsApi)
 

--- a/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/EdrCacheApiExtension.java
+++ b/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/EdrCacheApiExtension.java
@@ -18,19 +18,24 @@ import jakarta.json.Json;
 import org.eclipse.edc.connector.controlplane.api.management.edr.transform.JsonObjectFromEndpointDataReferenceEntryTransformer;
 import org.eclipse.edc.connector.controlplane.api.management.edr.v3.EdrCacheApiV3Controller;
 import org.eclipse.edc.edr.spi.store.EndpointDataReferenceStore;
+import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
 
 import java.util.Map;
 
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
 import static org.eclipse.edc.connector.controlplane.api.management.edr.EdrCacheApiExtension.NAME;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
 @Extension(NAME)
 public class EdrCacheApiExtension implements ServiceExtension {
@@ -48,6 +53,12 @@ public class EdrCacheApiExtension implements ServiceExtension {
     @Inject
     private Monitor monitor;
 
+    @Inject
+    private JsonLd jsonLd;
+
+    @Inject
+    private TypeManager typeManager;
+
     @Override
     public String name() {
         return NAME;
@@ -61,5 +72,7 @@ public class EdrCacheApiExtension implements ServiceExtension {
         managementTypeTransformerRegistry.register(new JsonObjectFromEndpointDataReferenceEntryTransformer(jsonFactory));
 
         webService.registerResource(ApiContext.MANAGEMENT, new EdrCacheApiV3Controller(edrStore, managementTypeTransformerRegistry, validator, monitor));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, EdrCacheApiV3Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
+
     }
 }

--- a/extensions/control-plane/api/management-api/policy-definition-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/policy-definition-api/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(project(":core:common:lib:util-lib"))
     implementation(project(":core:common:lib:validator-lib"))
     implementation(project(":extensions:common:api:lib:management-api-lib"))
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
 
     implementation(libs.jakarta.rsApi)
 

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/PolicyDefinitionApiExtension.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/PolicyDefinitionApiExtension.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.connector.controlplane.api.management.policy.v3.PolicyDef
 import org.eclipse.edc.connector.controlplane.api.management.policy.validation.PolicyDefinitionValidator;
 import org.eclipse.edc.connector.controlplane.api.management.policy.validation.PolicyEvaluationPlanRequestValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.policydefinition.PolicyDefinitionService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -31,11 +32,13 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
 
 import java.util.Map;
 
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
 import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyEvaluationPlanRequest.EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE;
 import static org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
@@ -61,6 +64,9 @@ public class PolicyDefinitionApiExtension implements ServiceExtension {
     @Inject
     private TypeManager typeManager;
 
+    @Inject
+    private JsonLd jsonLd;
+
     @Override
     public String name() {
         return NAME;
@@ -81,5 +87,7 @@ public class PolicyDefinitionApiExtension implements ServiceExtension {
 
         var monitor = context.getMonitor();
         webService.registerResource(ApiContext.MANAGEMENT, new PolicyDefinitionApiV3Controller(monitor, managementApiTransformerRegistry, service, validatorRegistry));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, PolicyDefinitionApiV3Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
+
     }
 }

--- a/extensions/control-plane/api/management-api/protocol-version-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/protocol-version-api/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
 
     implementation(project(":core:common:lib:validator-lib"))
     implementation(project(":extensions:common:api:lib:management-api-lib"))
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
 
     implementation(libs.jakarta.rsApi)
 

--- a/extensions/control-plane/api/management-api/secrets-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/secrets-api/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     implementation(project(":core:common:lib:api-lib"))
     implementation(project(":core:common:lib:transform-lib"))
     implementation(project(":core:common:lib:validator-lib"))
+    implementation(project(":extensions:common:api:lib:management-api-lib"))
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
 
     implementation(libs.jakarta.rsApi)
 

--- a/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/SecretsApiExtension.java
+++ b/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/SecretsApiExtension.java
@@ -20,17 +20,22 @@ import org.eclipse.edc.connector.api.management.secret.transform.JsonObjectToSec
 import org.eclipse.edc.connector.api.management.secret.v3.SecretsApiV3Controller;
 import org.eclipse.edc.connector.api.management.secret.validation.SecretsValidator;
 import org.eclipse.edc.connector.spi.service.SecretService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
 
 import java.util.Map;
 
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 import static org.eclipse.edc.spi.types.domain.secret.Secret.EDC_SECRET_TYPE;
 
 @Extension(value = SecretsApiExtension.NAME)
@@ -50,6 +55,12 @@ public class SecretsApiExtension implements ServiceExtension {
     @Inject
     private JsonObjectValidatorRegistry validator;
 
+    @Inject
+    private JsonLd jsonLd;
+
+    @Inject
+    private TypeManager typeManager;
+
     @Override
     public String name() {
         return NAME;
@@ -66,6 +77,8 @@ public class SecretsApiExtension implements ServiceExtension {
         managementApiTransformerRegistry.register(new JsonObjectToSecretTransformer());
 
         webService.registerResource(ApiContext.MANAGEMENT, new SecretsApiV3Controller(secretService, managementApiTransformerRegistry, validator));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, SecretsApiV3Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
+
     }
 
 }

--- a/extensions/control-plane/api/management-api/transfer-process-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/transfer-process-api/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     implementation(project(":core:common:lib:util-lib"))
     implementation(project(":core:common:lib:validator-lib"))
     implementation(project(":extensions:common:api:lib:management-api-lib"))
-
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
     implementation(libs.jakarta.rsApi)
 
     testImplementation(project(":core:common:lib:transform-lib"))

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/TransferProcessApiExtension.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/TransferProcessApiExtension.java
@@ -24,18 +24,23 @@ import org.eclipse.edc.connector.controlplane.api.management.transferprocess.v3.
 import org.eclipse.edc.connector.controlplane.api.management.transferprocess.validation.TerminateTransferValidator;
 import org.eclipse.edc.connector.controlplane.api.management.transferprocess.validation.TransferRequestValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
 
 import static java.util.Collections.emptyMap;
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
 import static org.eclipse.edc.connector.controlplane.api.management.transferprocess.model.TerminateTransfer.TERMINATE_TRANSFER_TYPE;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
 @Extension(value = TransferProcessApiExtension.NAME)
 public class TransferProcessApiExtension implements ServiceExtension {
@@ -53,6 +58,12 @@ public class TransferProcessApiExtension implements ServiceExtension {
 
     @Inject
     private JsonObjectValidatorRegistry validatorRegistry;
+
+    @Inject
+    private JsonLd jsonLd;
+
+    @Inject
+    private TypeManager typeManager;
 
     @Override
     public String name() {
@@ -75,5 +86,7 @@ public class TransferProcessApiExtension implements ServiceExtension {
         validatorRegistry.register(TERMINATE_TRANSFER_TYPE, TerminateTransferValidator.instance());
 
         webService.registerResource(ApiContext.MANAGEMENT, new TransferProcessApiV3Controller(context.getMonitor(), service, managementApiTransformerRegistry, validatorRegistry));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, TransferProcessApiV3Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
+
     }
 }

--- a/extensions/data-plane-selector/data-plane-selector-api/build.gradle.kts
+++ b/extensions/data-plane-selector/data-plane-selector-api/build.gradle.kts
@@ -27,7 +27,9 @@ dependencies {
     implementation(project(":core:common:lib:util-lib"))
     implementation(project(":core:common:lib:validator-lib"))
     implementation(project(":extensions:common:json-ld"))
-
+    implementation(project(":extensions:common:api:lib:management-api-lib"))
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
+    
     implementation(libs.jakarta.rsApi)
 
     testImplementation(project(":core:common:junit"))

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorApiExtension.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorApiExtension.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.dataplane.selector;
 import org.eclipse.edc.connector.dataplane.selector.api.v3.DataplaneSelectorApiV3Controller;
 import org.eclipse.edc.connector.dataplane.selector.api.v4.DataplaneSelectorApiV4Controller;
 import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -25,12 +26,14 @@ import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.transform.transformer.edc.from.JsonObjectFromDataPlaneInstanceTransformer;
 import org.eclipse.edc.transform.transformer.edc.from.JsonObjectFromDataPlaneInstanceV3Transformer;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
 
 import java.util.Map;
 
 import static jakarta.json.Json.createBuilderFactory;
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
 @Extension(value = "DataPlane selector API")
@@ -46,6 +49,9 @@ public class DataPlaneSelectorApiExtension implements ServiceExtension {
     private TypeManager typeManager;
 
     @Inject
+    private JsonLd jsonLd;
+
+    @Inject
     private TypeTransformerRegistry transformerRegistry;
 
     @Override
@@ -55,11 +61,14 @@ public class DataPlaneSelectorApiExtension implements ServiceExtension {
         // V4
         managementApiTransformerRegistry.register(new JsonObjectFromDataPlaneInstanceTransformer(createBuilderFactory(Map.of()), typeManager, JSON_LD));
         webservice.registerResource(ApiContext.MANAGEMENT, new DataplaneSelectorApiV4Controller(selectionService, managementApiTransformerRegistry));
+        webservice.registerDynamicResource(ApiContext.MANAGEMENT, DataplaneSelectorApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
 
         // V3
         var managementApiTransformerRegistryV3 = managementApiTransformerRegistry.forContext("v3");
         managementApiTransformerRegistryV3.register(new JsonObjectFromDataPlaneInstanceV3Transformer(createBuilderFactory(Map.of()), typeManager, JSON_LD));
         webservice.registerResource(ApiContext.MANAGEMENT, new DataplaneSelectorApiV3Controller(selectionService, managementApiTransformerRegistryV3));
+
+        webservice.registerDynamicResource(ApiContext.MANAGEMENT, DataplaneSelectorApiV3Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
 
     }
 }

--- a/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/validation/SchemaType.java
+++ b/spi/common/web-spi/src/main/java/org/eclipse/edc/web/spi/validation/SchemaType.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.web.spi.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface SchemaType {
+
+    /**
+     * The schema type to validate against.
+     */
+    String[] value();
+
+}

--- a/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/Asset.java
+++ b/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/Asset.java
@@ -44,7 +44,8 @@ public class Asset extends Entity {
     public static final String PROPERTY_IS_CATALOG = EDC_NAMESPACE + "isCatalog";
     public static final String EDC_ASSET_TYPE_TERM = "Asset";
     public static final String EDC_ASSET_TYPE = EDC_NAMESPACE + EDC_ASSET_TYPE_TERM;
-    public static final String EDC_CATALOG_ASSET_TYPE = EDC_NAMESPACE + "CatalogAsset";
+    public static final String EDC_CATALOG_ASSET_TYPE_TERM = "CatalogAsset";
+    public static final String EDC_CATALOG_ASSET_TYPE = EDC_NAMESPACE + EDC_CATALOG_ASSET_TYPE_TERM;
     public static final String EDC_ASSET_PROPERTIES = EDC_NAMESPACE + "properties";
     public static final String EDC_ASSET_PRIVATE_PROPERTIES = EDC_NAMESPACE + "privateProperties";
     public static final String EDC_ASSET_DATA_ADDRESS = EDC_NAMESPACE + "dataAddress";

--- a/system-tests/management-api/management-api-test-runner/build.gradle.kts
+++ b/system-tests/management-api/management-api-test-runner/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 
     //we need the JacksonJsonLd util class
     testImplementation(project(":core:common:lib:json-ld-lib"))
+    testImplementation(project(":core:common:lib:api-lib"))
     testImplementation(project(":extensions:common:json-ld"))
 
     testImplementation(libs.restAssured)

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ManagementEndToEndExtension.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ManagementEndToEndExtension.java
@@ -38,6 +38,26 @@ public abstract class ManagementEndToEndExtension extends RuntimePerClassExtensi
         this.context = context;
     }
 
+    static Config runtimeConfig() {
+        var managementPort = getFreePort();
+        var protocolPort = getFreePort();
+
+        var settings = new HashMap<String, String>() {
+            {
+                put("web.http.path", "/");
+                put("web.http.port", String.valueOf(getFreePort()));
+                put("web.http.protocol.path", "/protocol");
+                put("web.http.protocol.port", String.valueOf(protocolPort));
+                put("web.http.control.port", String.valueOf(getFreePort()));
+                put("edc.dsp.callback.address", "http://localhost:" + protocolPort + "/protocol");
+                put("web.http.management.path", "/management");
+                put("web.http.management.port", String.valueOf(managementPort));
+            }
+        };
+
+        return ConfigFactory.fromMap(settings);
+    }
+
     @Override
     public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
         var type = parameterContext.getParameter().getParameterizedType();
@@ -61,7 +81,7 @@ public abstract class ManagementEndToEndExtension extends RuntimePerClassExtensi
         return this;
     }
 
-    static class InMemory extends ManagementEndToEndExtension {
+    public static class InMemory extends ManagementEndToEndExtension {
 
         protected InMemory() {
             super(new ManagementEndToEndTestContext(runtime()));
@@ -73,9 +93,9 @@ public abstract class ManagementEndToEndExtension extends RuntimePerClassExtensi
         }
     }
 
-    static class Postgres extends ManagementEndToEndExtension {
+    public static class Postgres extends ManagementEndToEndExtension {
 
-        protected Postgres(PostgresqlEndToEndExtension postgres) {
+        public Postgres(PostgresqlEndToEndExtension postgres) {
             super(new ManagementEndToEndTestContext(runtime().configurationProvider(postgres::config)));
         }
 
@@ -86,25 +106,5 @@ public abstract class ManagementEndToEndExtension extends RuntimePerClassExtensi
                     .configurationProvider(ManagementEndToEndExtension::runtimeConfig);
         }
 
-    }
-
-    static Config runtimeConfig() {
-        var managementPort = getFreePort();
-        var protocolPort = getFreePort();
-
-        var settings = new HashMap<String, String>() {
-            {
-                put("web.http.path", "/");
-                put("web.http.port", String.valueOf(getFreePort()));
-                put("web.http.protocol.path", "/protocol");
-                put("web.http.protocol.port", String.valueOf(protocolPort));
-                put("web.http.control.port", String.valueOf(getFreePort()));
-                put("edc.dsp.callback.address", "http://localhost:" + protocolPort + "/protocol");
-                put("web.http.management.path", "/management");
-                put("web.http.management.port", String.valueOf(managementPort));
-            }
-        };
-
-        return ConfigFactory.fromMap(settings);
     }
 }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/SerdeEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/SerdeEndToEndTest.java
@@ -18,6 +18,7 @@ import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
+import org.eclipse.edc.api.model.IdResponse;
 import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.model.NegotiationState;
 import org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyEvaluationPlanRequest;
 import org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyValidationResult;
@@ -86,6 +87,7 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.MANAGEMENT_API_CONTEXT;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.MANAGEMENT_API_SCOPE;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.assetObject;
+import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.catalogAsset;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.catalogRequestObject;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.contractDefinitionObject;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.contractRequestObject;
@@ -353,6 +355,17 @@ public class SerdeEndToEndTest {
         }
 
         @Test
+        void ser_IdResponse() {
+            var response = IdResponse.Builder.newInstance().id("test-id").createdAt(1234).build();
+            var compactResult = serialize(response);
+
+            assertThat(compactResult).isNotNull();
+            assertThat(compactResult.getString(TYPE)).isEqualTo("IdResponse");
+            assertThat(compactResult.getString(ID)).isEqualTo(response.getId());
+            assertThat(compactResult.getInt("createdAt")).isEqualTo(response.getCreatedAt());
+        }
+
+        @Test
         void de_DatasetRequest() {
             var inputObject = datasetRequestObject(jsonLdContext());
             var request = deserialize(inputObject, DatasetRequest.class);
@@ -585,6 +598,7 @@ public class SerdeEndToEndTest {
 
                 return Stream.of(
                         Arguments.of(assetObject(jsonLdContext), Asset.class, null),
+                        Arguments.of(catalogAsset(jsonLdContext), Asset.class, null),
                         Arguments.of(contractDefinitionObject(jsonLdContext), ContractDefinition.class, null),
                         Arguments.of(secretObject(jsonLdContext), Secret.class, null),
                         Arguments.of(querySpecObject(jsonLdContext), QuerySpec.class, null),
@@ -632,7 +646,7 @@ public class SerdeEndToEndTest {
         @ArgumentsSource(JsonInputProvider.class)
         @WithContext(EDC_CONNECTOR_MANAGEMENT_CONTEXT)
         void serde(JsonObject inputObject, Class<?> klass, Function<JsonObject, JsonObject> mapper) {
-            if (!klass.equals(DataPlaneInstance.class)) {
+            if (!klass.equals(DataPlaneInstance.class) && !inputObject.getString(TYPE).equals("CatalogAsset")) {
                 verifySerde(inputObject, klass, mapper);
             }
         }
@@ -653,6 +667,12 @@ public class SerdeEndToEndTest {
         @Disabled
         void ser_DataPlaneInstance() {
             super.ser_DataPlaneInstance();
+        }
+
+        @Override
+        @Disabled
+        void ser_IdResponse() {
+            super.ser_IdResponse();
         }
     }
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
@@ -100,6 +100,30 @@ public class TestFunctions {
                 .build();
     }
 
+    public static JsonObject catalogAsset(String context) {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder(context).build())
+                .add(TYPE, "CatalogAsset")
+                .add(ID, TEST_ASSET_ID)
+                .add("properties", createObjectBuilder()
+                        .add("name", TEST_ASSET_NAME)
+                        .add("id", TEST_ASSET_ID)
+                        .add("description", TEST_ASSET_DESCRIPTION)
+                        .add("version", TEST_ASSET_VERSION)
+                        .add("contenttype", TEST_ASSET_CONTENTTYPE)
+                        .add("isCatalog", true)
+                        .build())
+                .add("privateProperties", createObjectBuilder()
+                        .add("name", TEST_ASSET_NAME)
+                        .add("id", TEST_ASSET_ID)
+                        .add("description", TEST_ASSET_DESCRIPTION)
+                        .add("version", TEST_ASSET_VERSION)
+                        .add("contenttype", TEST_ASSET_CONTENTTYPE)
+                        .build())
+                .add("dataAddress", createObjectBuilder().add("@type", "DataAddress").add("type", "address-type"))
+                .build();
+    }
+
     public static JsonObject dataAddressObject(String context) {
         return createObjectBuilder()
                 .add(CONTEXT, createContextBuilder(context).build())

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
@@ -1,0 +1,467 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi.v4;
+
+import io.restassured.http.ContentType;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObjectBuilder;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.asset.spi.index.AssetIndex;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
+import org.eclipse.edc.test.e2e.managementapi.ManagementEndToEndExtension;
+import org.eclipse.edc.test.e2e.managementapi.ManagementEndToEndTestContext;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Asset V4alpha endpoints end-to-end tests
+ */
+public class AssetApiV4EndToEndTest {
+
+    abstract static class Tests {
+
+
+        @Test
+        void getAssetById(ManagementEndToEndTestContext context, AssetIndex assetIndex) {
+            var id = UUID.randomUUID().toString();
+            var asset = createAsset().id(id)
+                    .dataAddress(createDataAddress().type("addressType").build())
+                    .build();
+            assetIndex.create(asset);
+
+            var body = context.baseRequest()
+                    .get("/v4alpha/assets/" + id)
+                    .then()
+                    .statusCode(200)
+                    .extract().body().jsonPath();
+
+            assertThat(body).isNotNull();
+            assertThat(body.getString(ID)).isEqualTo(id);
+            assertThat(body.getMap("properties"))
+                    .hasSize(5)
+                    .containsEntry("name", "test-asset")
+                    .containsEntry("description", "test description")
+                    .containsEntry("contenttype", "application/json")
+                    .containsEntry("version", "0.4.2");
+            assertThat(body.getMap("'dataAddress'"))
+                    .containsEntry("type", "addressType");
+            assertThat(body.getMap("'dataAddress'.'complex'"))
+                    .containsEntry("simple", "value")
+                    .containsKey("nested");
+            assertThat(body.getMap("'dataAddress'.'complex'.'nested'"))
+                    .containsEntry("innerValue", "value");
+        }
+
+        @Test
+        void createAsset_shouldBeStored(ManagementEndToEndTestContext context, AssetIndex assetIndex) {
+            var id = UUID.randomUUID().toString();
+            var assetJson = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "Asset")
+                    .add(ID, id)
+                    .add("properties", createPropertiesBuilder().add("isCatalog", "true").build())
+                    .add("privateProperties", createObjectBuilder()
+                            .add("anotherProp", "anotherVal")
+                            .build())
+                    .add("dataAddress", createObjectBuilder()
+                            .add(TYPE, "DataAddress")
+                            .add("type", "test-type")
+                            .add("complex", createObjectBuilder()
+                                    .add("simple", "value")
+                                    .add("nested", createObjectBuilder()
+                                            .add("innerValue", "value"))
+                                    .build())
+                            .build())
+                    .build();
+
+            context.baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(assetJson)
+                    .post("/v4alpha/assets")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body(ID, is(id));
+
+            var asset = assetIndex.findById(id);
+            assertThat(asset).isNotNull();
+            assertThat(asset.isCatalog()).isTrue();
+            assertThat(asset.getPrivateProperty(EDC_NAMESPACE + "anotherProp")).isEqualTo("anotherVal");
+            assertThat(asset.getDataAddress().getProperty("complex"))
+                    .asInstanceOf(MAP)
+                    .containsEntry(EDC_NAMESPACE + "simple", List.of(Map.of(VALUE, "value")))
+                    .containsEntry(EDC_NAMESPACE + "nested", List.of(Map.of(EDC_NAMESPACE + "innerValue", List.of(Map.of(VALUE, "value")))));
+        }
+
+        @Test
+        void createAsset_shouldFail_whenBodyIsNotValid(ManagementEndToEndTestContext context) {
+            var assetJson = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "Asset")
+                    .add(ID, " ")
+                    .add("properties", createPropertiesBuilder().build())
+                    .build();
+
+            context.baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(assetJson)
+                    .post("/v4alpha/assets")
+                    .then()
+                    .log().ifError()
+                    .statusCode(400);
+        }
+
+        @Test
+        void createAsset_withoutPrefix_shouldAddEdcNamespace(ManagementEndToEndTestContext context, AssetIndex assetIndex) {
+            var id = UUID.randomUUID().toString();
+            var assetJson = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "Asset")
+                    .add(ID, id)
+                    .add("properties", createPropertiesBuilder()
+                            .add("unprefixed-key", "test-value").build())
+                    .add("dataAddress", createObjectBuilder()
+                            .add(TYPE, "DataAddress")
+                            .add("type", "test-type")
+                            .add("unprefixed-key", "test-value")
+                            .build())
+                    .build();
+
+            context.baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(assetJson)
+                    .post("/v4alpha/assets")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body(ID, is(id));
+
+            var asset = assetIndex.findById(id);
+            assertThat(asset).isNotNull();
+            //make sure unprefixed keys are caught and prefixed with the EDC_NAMESPACE ns.
+            assertThat(asset.getProperties().keySet())
+                    .hasSize(6)
+                    .allMatch(key -> key.startsWith(EDC_NAMESPACE));
+
+            var dataAddress = assetIndex.resolveForAsset(asset.getId());
+            assertThat(dataAddress).isNotNull();
+            assertThat(dataAddress.getProperties().keySet())
+                    .hasSize(2)
+                    .allMatch(key -> key.startsWith(EDC_NAMESPACE));
+        }
+
+        @Test
+        void createAsset_whenCatalogAsset_shouldSetProperty(ManagementEndToEndTestContext context, AssetIndex assetIndex) {
+            var id = UUID.randomUUID().toString();
+            var assetJson = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "CatalogAsset")
+                    .add(ID, id)
+                    .add("properties", createPropertiesBuilder().build())
+                    .add("dataAddress", createObjectBuilder()
+                            .add(TYPE, "DataAddress")
+                            .add("type", "test-type")
+                            .build())
+                    .build();
+
+            context.baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(assetJson)
+                    .post("/v4alpha/assets")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body(ID, is(id));
+
+            var asset = assetIndex.findById(id);
+            assertThat(asset).isNotNull();
+            assertThat(asset.isCatalog()).isTrue();
+        }
+
+        @Test
+        void createAsset_whenCatalogInPrivateProps_shouldReturnCatalogType(ManagementEndToEndTestContext context, AssetIndex index) {
+            var id = UUID.randomUUID().toString();
+            var assetJson = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "Asset")
+                    .add(ID, id)
+                    .add("properties", createPropertiesBuilder().add("isCatalog", "true").build())
+                    .add("dataAddress", createObjectBuilder()
+                            .add(TYPE, "DataAddress")
+                            .add("type", "test-type")
+                            .build())
+                    .build();
+
+            // create the asset
+            context.baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(assetJson)
+                    .post("/v4alpha/assets")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body(ID, is(id));
+
+            // verify the property was set
+            var asset = index.findById(id);
+            assertThat(asset.isCatalog()).isTrue();
+
+            // query the asset, assert that @type: CatalogAsset
+            var assets = context.baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(context.query(criterion("id", "=", id)))
+                    .post("/v3/assets/request")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .extract().body().as(JsonArray.class);
+
+            assertThat(assets).isNotNull().hasSize(1);
+            assertThat(Asset.EDC_CATALOG_ASSET_TYPE).contains(assets.get(0).asJsonObject().getString(TYPE));
+        }
+
+        @Test
+        void queryAsset_byContentType(ManagementEndToEndTestContext context, AssetIndex assetIndex) {
+            //insert one asset into the index
+            var id = UUID.randomUUID().toString();
+            var asset = Asset.Builder.newInstance().id(id).contentType("application/octet-stream").dataAddress(createDataAddress().build()).build();
+            assetIndex.create(asset);
+            // not matching asset
+            assetIndex.create(Asset.Builder.newInstance().id(UUID.randomUUID().toString()).dataAddress(createDataAddress().build()).build());
+
+            var query = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "QuerySpec")
+                    .add("filterExpression", createArrayBuilder()
+                            .add(createObjectBuilder()
+                                    .add(TYPE, "Criterion")
+                                    .add("operandLeft", EDC_NAMESPACE + "id")
+                                    .add("operator", "=")
+                                    .add("operandRight", id))
+                            .add(createObjectBuilder()
+                                    .add(TYPE, "Criterion")
+                                    .add("operandLeft", EDC_NAMESPACE + "contenttype")
+                                    .add("operator", "=")
+                                    .add("operandRight", "application/octet-stream"))
+                    ).build();
+
+            context.baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(query)
+                    .post("/v4alpha/assets/request")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body("size()", is(1));
+        }
+
+        @Test
+        void queryAsset_byCustomStringProperty(ManagementEndToEndTestContext context, AssetIndex assetIndex) {
+            assetIndex.create(Asset.Builder.newInstance()
+                    .id("test-asset")
+                    .contentType("application/octet-stream")
+                    .property("myProp", "myVal")
+                    .dataAddress(createDataAddress().build())
+                    .build());
+
+            context.baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(context.queryV2(criterion("myProp", "=", "myVal")))
+                    .post("/v4alpha/assets/request")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body("size()", is(1));
+        }
+
+        @Test
+        void queryAsset_byCustomComplexProperty(ManagementEndToEndTestContext context) {
+            var id = UUID.randomUUID().toString();
+            var assetJson = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "Asset")
+                    .add(ID, id)
+                    .add("properties", createPropertiesBuilder()
+                            .add("nested", createPropertiesBuilder()
+                                    .add("@id", "test-nested-id")))
+                    .add("dataAddress", createObjectBuilder()
+                            .add(TYPE, "DataAddress")
+                            .add("type", "test-type")
+                            .add("unprefixed-key", "test-value")
+                            .build())
+                    .build();
+
+            context.baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(assetJson)
+                    .post("/v4alpha/assets")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body(ID, is(id));
+
+            var query = context.queryV2(
+                    criterion("'%sid".formatted(EDC_NAMESPACE), "=", id),
+                    criterion("'%snested'.@id".formatted(EDC_NAMESPACE), "=", "test-nested-id")
+            );
+
+            context.baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(query)
+                    .post("/v4alpha/assets/request")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body("size()", is(1));
+        }
+
+        @Test
+        void queryAsset_byCatalogProperty(ManagementEndToEndTestContext context, AssetIndex assetIndex) {
+            var id = UUID.randomUUID().toString();
+            assetIndex.create(Asset.Builder.newInstance()
+                    .property(Asset.PROPERTY_IS_CATALOG, true)
+                    .id(id)
+                    .contentType("application/octet-stream")
+                    .dataAddress(createDataAddress().build())
+                    .build());
+
+            var assets = context.baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(context.queryV2(
+                            criterion(EDC_NAMESPACE + "isCatalog", "=", "true"),
+                            criterion("id", "=", id)))
+                    .post("/v4alpha/assets/request")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .extract().body().as(JsonArray.class);
+
+            assertThat(assets).isNotNull().hasSize(1);
+            assertThat(Asset.EDC_CATALOG_ASSET_TYPE).contains(assets.get(0).asJsonObject().getString(TYPE));
+
+        }
+
+        @Test
+        void updateAsset(ManagementEndToEndTestContext context, AssetIndex assetIndex) {
+            var asset = createAsset().build();
+            assetIndex.create(asset);
+
+            var assetJson = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "Asset")
+                    .add(ID, asset.getId())
+                    .add("properties", createPropertiesBuilder()
+                            .add("some-new-property", "some-new-value").build())
+                    .add("dataAddress", createObjectBuilder()
+                            .add(TYPE, "DataAddress")
+                            .add("type", "addressType")
+                            .add("complex", createObjectBuilder().add("nested", "value").build()))
+                    .build();
+
+            context.baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(assetJson)
+                    .put("/v4alpha/assets")
+                    .then()
+                    .log().all()
+                    .statusCode(204)
+                    .body(notNullValue());
+
+            var dbAsset = assetIndex.findById(asset.getId());
+            assertThat(dbAsset).isNotNull();
+            assertThat(dbAsset.getProperties()).containsEntry(EDC_NAMESPACE + "some-new-property", "some-new-value");
+            assertThat(dbAsset.getDataAddress().getType()).isEqualTo("addressType");
+            assertThat(dbAsset.getDataAddress().getProperty(EDC_NAMESPACE + "complex"))
+                    .asInstanceOf(MAP)
+                    .containsEntry(EDC_NAMESPACE + "nested", List.of(Map.of(VALUE, "value")));
+        }
+
+        private DataAddress.Builder createDataAddress() {
+            return DataAddress.Builder.newInstance().type("test-type")
+                    .property(EDC_NAMESPACE + "complex", Map.of(
+                            EDC_NAMESPACE + "simple", "value",
+                            EDC_NAMESPACE + "nested", Map.of(EDC_NAMESPACE + "innerValue", "value")
+                    ));
+        }
+
+        private Asset.Builder createAsset() {
+            return Asset.Builder.newInstance()
+                    .id(UUID.randomUUID().toString())
+                    .name("test-asset")
+                    .description("test description")
+                    .contentType("application/json")
+                    .version("0.4.2")
+                    .dataAddress(createDataAddress().build());
+        }
+
+        private JsonObjectBuilder createPropertiesBuilder() {
+            return createObjectBuilder()
+                    .add("name", "test-asset")
+                    .add("description", "test description")
+                    .add("version", "0.4.2")
+                    .add("contentType", "application/json");
+        }
+
+        private JsonArray jsonLdContext() {
+            return createArrayBuilder()
+                    .add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2)
+                    .build();
+        }
+    }
+
+    @Nested
+    @EndToEndTest
+    @ExtendWith(ManagementEndToEndExtension.InMemory.class)
+    class InMemory extends Tests {
+    }
+
+    @Nested
+    @PostgresqlIntegrationTest
+    class Postgres extends Tests {
+
+        @RegisterExtension
+        @Order(0)
+        static PostgresqlEndToEndExtension postgres = new PostgresqlEndToEndExtension();
+
+        @RegisterExtension
+        static ManagementEndToEndExtension runtime = new ManagementEndToEndExtension.Postgres(postgres);
+
+    }
+
+}

--- a/system-tests/management-api/management-api-test-runtime/build.gradle.kts
+++ b/system-tests/management-api/management-api-test-runtime/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation(project(":extensions:common:iam:iam-mock"))
     implementation(project(":extensions:common:json-ld"))
     implementation(project(":extensions:common:api:control-api-configuration"))
+    implementation(project(":extensions:common:api:management-api-schema-validator"))
     implementation(project(":extensions:control-plane:api:management-api"))
     implementation(project(":extensions:control-plane:api:management-api:secrets-api"))
     implementation(project(":extensions:data-plane:data-plane-signaling:data-plane-signaling-client"))


### PR DESCRIPTION
## What this PR changes/adds

adds asset mgmt api v4alpha. 

Since it's the first PR after introducing the #5153 it does not contains only asset v4alpha controller but also additional
implementations for:

- Supporting optional  validation on the input object before expansion in `JerseyJsonLdInterceptor` (used for v4 controllers)
- For backward compatibility with current controllers, a `JerseyJsonLdInterceptor` is registered a dynamic resource on each controller of the mgmt API v3
- Introduced a `SchemaType` annotation that should be used to annotate the expected schema of an input `JsonObject`
- Add missing `CatalogAsset` type in JSON-LD context and JSON-schema
- For now the old validation on expanded object is still in place for Asset type. It will get removed once the schema validator is bundled in the management api (currently an add-on extension)

 This is marked as breaking-change since it requires to register a JerseyJsonLdInterceptor for custom controllers.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of  #5137 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
