### PR TITLE
fix: DSP TCK runtime

### DIFF
--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/PostgresEdcCompatibilityDockerTest.java
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/src/test/java/org/eclipse/edc/tck/dsp/PostgresEdcCompatibilityDockerTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.tck.dsp;
 
-import org.eclipse.edc.junit.annotations.NightlyTest;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
 import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.eclipse.edc.tck.dsp.CompatibilityTests.ALLOWED_FAILURES;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 
-@NightlyTest
+@PostgresqlIntegrationTest
 @Testcontainers
 public class PostgresEdcCompatibilityDockerTest {
 

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/identity/TckIdentityExtension.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/identity/TckIdentityExtension.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.tck.dsp.identity;
 
+import org.eclipse.edc.protocol.spi.DefaultParticipantIdExtractionFunction;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.iam.AudienceResolver;
 import org.eclipse.edc.spi.iam.IdentityService;
@@ -34,6 +35,11 @@ public class TckIdentityExtension implements ServiceExtension {
     @Provider
     public IdentityService identityService() {
         return new NoopIdentityService();
+    }
+    
+    @Provider
+    public DefaultParticipantIdExtractionFunction defaultParticipantIdExtractionFunction() {
+        return claimToken -> claimToken.getStringClaim("client_id");
     }
 
     @Provider


### PR DESCRIPTION
## What this PR changes/adds

After merging [this PR](https://github.com/eclipse-edc/Connector/pull/5154), the DSP TCK test is failing due to a missing service. This PR provides this service as part of the `tck-extension` and changes the TCK test from nightly to e2e test, so that issues like this one can be discovered more quickly in the future. 

## Why it does that

Fix pipeline


## Who will sponsor this feature?

me
