### PR TITLE
feat: more v4alpha controllers

### DIFF
--- a/extensions/common/api/lib/management-api-lib/src/main/java/org/eclipse/edc/api/management/schema/ManagementApiJsonSchema.java
+++ b/extensions/common/api/lib/management-api-lib/src/main/java/org/eclipse/edc/api/management/schema/ManagementApiJsonSchema.java
@@ -27,6 +27,7 @@ public interface ManagementApiJsonSchema {
         String POLICY_DEFINITION = EDC_MGMT_V4_SCHEMA_PREFIX + "/policy-definition-schema.json";
         String CONTRACT_DEFINITION = EDC_MGMT_V4_SCHEMA_PREFIX + "/contract-definition-schema.json";
         String DATAPLANE_INSTANCE = EDC_MGMT_V4_SCHEMA_PREFIX + "/dataplane-instance-schema.json";
+        String DATA_ADDRESS = EDC_MGMT_V4_SCHEMA_PREFIX + "/data-address-schema.json#/definitions/DataAddressRoot";
         String EDR_ENTRY = EDC_MGMT_V4_SCHEMA_PREFIX + "/edr-entry-schema.json";
         String POLICY_EVALUATION_REQUEST = EDC_MGMT_V4_SCHEMA_PREFIX + "/policy-evaluation-plan-request-schema.json";
         String POLICY_EVALUATION_PLAN = EDC_MGMT_V4_SCHEMA_PREFIX + "/policy-evaluation-plan-schema.json";

--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -8,7 +8,7 @@
   {
     "version": "4.0.0-alpha",
     "urlPath": "/v4alpha",
-    "lastUpdated": "2025-08-01T14:26:00Z",
+    "lastUpdated": "2025-08-19T14:26:00Z",
     "maturity": "alpha"
   }
 ]

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/data-address-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/data-address-schema.json
@@ -24,6 +24,25 @@
         "@type",
         "type"
       ]
+    },
+    "DataAddressRoot": {
+      "type": "object",
+      "allOf": [
+        {
+          "properties": {
+            "@context": {
+              "$ref": "https://w3id.org/edc/connector/management/schema/v4/context-schema.json"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/DataAddress"
+        }
+      ],
+      "required": [
+        "@context",
+        "@type"
+      ]
     }
   }
 }

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/ContractDefinitionApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/ContractDefinitionApiExtension.java
@@ -20,6 +20,7 @@ import jakarta.json.Json;
 import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.transform.JsonObjectFromContractDefinitionTransformer;
 import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.transform.JsonObjectToContractDefinitionTransformer;
 import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.v3.ContractDefinitionApiV3Controller;
+import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.v4.ContractDefinitionApiV4Controller;
 import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.validation.ContractDefinitionValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.contractdefinition.ContractDefinitionService;
 import org.eclipse.edc.jsonld.spi.JsonLd;
@@ -38,6 +39,7 @@ import org.eclipse.edc.web.spi.configuration.ApiContext;
 import java.util.Map;
 
 import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE_V4;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
@@ -84,6 +86,9 @@ public class ContractDefinitionApiExtension implements ServiceExtension {
 
         webService.registerResource(ApiContext.MANAGEMENT, new ContractDefinitionApiV3Controller(managementApiTransformerRegistry, service, context.getMonitor(), validatorRegistry));
         webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractDefinitionApiV3Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
+
+        webService.registerResource(ApiContext.MANAGEMENT, new ContractDefinitionApiV4Controller(managementApiTransformerRegistry, service, context.getMonitor(), validatorRegistry));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractDefinitionApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, "v4"));
 
     }
 }

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v4/ContractDefinitionApiV4.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v4/ContractDefinitionApiV4.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.contractdefinition.v4;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
+import org.eclipse.edc.api.model.ApiCoreSchema;
+
+@OpenAPIDefinition(info = @Info(version = "v4alpha"))
+@Tag(name = "Contract Definition v4alpha")
+public interface ContractDefinitionApiV4 {
+
+    @Operation(description = "Returns all contract definitions according to a query",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.QUERY_SPEC))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The contract definitions matching the query",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.CONTRACT_DEFINITION)))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    JsonArray queryContractDefinitionsV4(JsonObject querySpecJson);
+
+    @Operation(description = "Gets an contract definition with the given ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The contract definition",
+                            content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.CONTRACT_DEFINITION))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "An contract agreement with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    JsonObject getContractDefinitionV4(String id);
+
+    @Operation(description = "Creates a new contract definition",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.CONTRACT_DEFINITION))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "contract definition was created successfully. Returns the Contract Definition Id and created timestamp",
+                            content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.ID_RESPONSE))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "409", description = "Could not create contract definition, because a contract definition with that ID already exists",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))}
+    )
+    JsonObject createContractDefinitionV4(JsonObject createObject);
+
+    @Operation(description = "Removes a contract definition with the given ID if possible. " +
+            "DANGER ZONE: Note that deleting contract definitions can have unexpected results, especially for contract offers that have been sent out or ongoing or contract negotiations.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Contract definition was deleted successfully"),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "A contract definition with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    void deleteContractDefinitionV4(String id);
+
+    @Operation(description = "Updated a contract definition with the given ID. The supplied JSON structure must be a valid JSON-LD object",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.CONTRACT_DEFINITION))),
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Contract definition was updated successfully"),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "A contract definition with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    void updateContractDefinitionV4(JsonObject updateObject);
+
+}

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v4/ContractDefinitionApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v4/ContractDefinitionApiV4Controller.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.contractdefinition.v4;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.BaseContractDefinitionApiController;
+import org.eclipse.edc.connector.controlplane.services.spi.contractdefinition.ContractDefinitionService;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.spi.validation.SchemaType;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_TYPE_TERM;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v4alpha/contractdefinitions")
+public class ContractDefinitionApiV4Controller extends BaseContractDefinitionApiController implements ContractDefinitionApiV4 {
+    public ContractDefinitionApiV4Controller(TypeTransformerRegistry transformerRegistry, ContractDefinitionService service, Monitor monitor, JsonObjectValidatorRegistry validatorRegistry) {
+        super(transformerRegistry, service, monitor, validatorRegistry);
+    }
+
+    @POST
+    @Path("/request")
+    @Override
+    public JsonArray queryContractDefinitionsV4(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson) {
+        return queryContractDefinitions(querySpecJson);
+    }
+
+    @GET
+    @Path("{id}")
+    @Override
+    public JsonObject getContractDefinitionV4(@PathParam("id") String id) {
+        return getContractDefinition(id);
+    }
+
+    @POST
+    @Override
+    public JsonObject createContractDefinitionV4(@SchemaType(CONTRACT_DEFINITION_TYPE_TERM) JsonObject createObject) {
+        return createContractDefinition(createObject);
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Override
+    public void deleteContractDefinitionV4(@PathParam("id") String id) {
+        deleteContractDefinition(id);
+    }
+
+    @PUT
+    @Override
+    public void updateContractDefinitionV4(@SchemaType(CONTRACT_DEFINITION_TYPE_TERM) JsonObject updateObject) {
+        updateContractDefinition(updateObject);
+    }
+}

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v4/ContractDefinitionApiV4ControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v4/ContractDefinitionApiV4ControllerTest.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.contractdefinition.v4;
+
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.BaseContractDefinitionApiControllerTest;
+
+import static io.restassured.RestAssured.given;
+
+class ContractDefinitionApiV4ControllerTest extends BaseContractDefinitionApiControllerTest {
+    @Override
+    protected RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port + "/v4alpha/contractdefinitions")
+                .when();
+
+    }
+
+    @Override
+    protected Object controller() {
+        return new ContractDefinitionApiV4Controller(transformerRegistry, service, monitor, validatorRegistry);
+    }
+}

--- a/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/EdrCacheApiExtension.java
+++ b/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/EdrCacheApiExtension.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.controlplane.api.management.edr;
 import jakarta.json.Json;
 import org.eclipse.edc.connector.controlplane.api.management.edr.transform.JsonObjectFromEndpointDataReferenceEntryTransformer;
 import org.eclipse.edc.connector.controlplane.api.management.edr.v3.EdrCacheApiV3Controller;
+import org.eclipse.edc.connector.controlplane.api.management.edr.v4.EdrCacheApiV4Controller;
 import org.eclipse.edc.edr.spi.store.EndpointDataReferenceStore;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -34,6 +35,7 @@ import org.eclipse.edc.web.spi.configuration.ApiContext;
 import java.util.Map;
 
 import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE_V4;
 import static org.eclipse.edc.connector.controlplane.api.management.edr.EdrCacheApiExtension.NAME;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
@@ -73,6 +75,9 @@ public class EdrCacheApiExtension implements ServiceExtension {
 
         webService.registerResource(ApiContext.MANAGEMENT, new EdrCacheApiV3Controller(edrStore, managementTypeTransformerRegistry, validator, monitor));
         webService.registerDynamicResource(ApiContext.MANAGEMENT, EdrCacheApiV3Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
+
+        webService.registerResource(ApiContext.MANAGEMENT, new EdrCacheApiV4Controller(edrStore, managementTypeTransformerRegistry, validator, monitor));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, EdrCacheApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validator, "v4"));
 
     }
 }

--- a/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/v4/EdrCacheApiV4.java
+++ b/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/v4/EdrCacheApiV4.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.edr.v4;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
+import org.eclipse.edc.api.model.ApiCoreSchema;
+
+@OpenAPIDefinition(info = @Info(version = "v4alpha"))
+@Tag(name = "EDR Cache v4alpha")
+public interface EdrCacheApiV4 {
+
+    @Operation(description = "Request all Edr entries according to a particular query",
+            requestBody = @RequestBody(
+                    content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.QUERY_SPEC))
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The edr entries matching the query",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.EDR_ENTRY)))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            })
+    JsonArray requestEdrEntriesV4(JsonObject querySpecJson);
+
+    @Operation(description = "Gets the EDR data address with the given transfer process ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The data address",
+                            content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.DATA_ADDRESS))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "An EDR data address with the given transfer process ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    JsonObject getEdrEntryDataAddressV4(String transferProcessId);
+
+    @Operation(description = "Removes an EDR entry given the transfer process ID",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "EDR entry was deleted successfully"),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "An EDR entry with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            })
+    void removeEdrEntryV4(String transferProcessId);
+
+}

--- a/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/v4/EdrCacheApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/edr-cache-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/edr/v4/EdrCacheApiV4Controller.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.edr.v4;
+
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import org.eclipse.edc.connector.controlplane.api.management.edr.BaseEdrCacheApiController;
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceStore;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.spi.validation.SchemaType;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v4alpha/edrs")
+public class EdrCacheApiV4Controller extends BaseEdrCacheApiController implements EdrCacheApiV4 {
+    public EdrCacheApiV4Controller(EndpointDataReferenceStore edrStore, TypeTransformerRegistry transformerRegistry, JsonObjectValidatorRegistry validator, Monitor monitor) {
+        super(edrStore, transformerRegistry, validator, monitor);
+    }
+
+    @POST
+    @Path("/request")
+    @Override
+    public JsonArray requestEdrEntriesV4(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson) {
+        return requestEdrEntries(querySpecJson);
+    }
+
+    @GET
+    @Path("{transferProcessId}/dataaddress")
+    @Override
+    public JsonObject getEdrEntryDataAddressV4(@PathParam("transferProcessId") String transferProcessId) {
+        return getEdrEntryDataAddress(transferProcessId);
+    }
+
+    @DELETE
+    @Path("{transferProcessId}")
+    @Override
+    public void removeEdrEntryV4(@PathParam("transferProcessId") String transferProcessId) {
+        removeEdrEntry(transferProcessId);
+    }
+}

--- a/extensions/control-plane/api/management-api/edr-cache-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/edr/v4/EdrCacheApiV4ControllerTest.java
+++ b/extensions/control-plane/api/management-api/edr-cache-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/edr/v4/EdrCacheApiV4ControllerTest.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.edr.v4;
+
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.connector.controlplane.api.management.edr.BaseEdrCacheApiControllerTest;
+import org.eclipse.edc.junit.annotations.ApiTest;
+
+import static io.restassured.RestAssured.given;
+import static org.mockito.Mockito.mock;
+
+@ApiTest
+public class EdrCacheApiV4ControllerTest extends BaseEdrCacheApiControllerTest {
+
+
+    @Override
+    protected Object controller() {
+        return new EdrCacheApiV4Controller(edrStore, transformerRegistry, validator, mock());
+    }
+
+
+    protected RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port + "/v4alpha")
+                .when();
+    }
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/PolicyDefinitionApiExtension.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/PolicyDefinitionApiExtension.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.connector.controlplane.api.management.policy.transform.Js
 import org.eclipse.edc.connector.controlplane.api.management.policy.transform.JsonObjectToPolicyDefinitionTransformer;
 import org.eclipse.edc.connector.controlplane.api.management.policy.transform.JsonObjectToPolicyEvaluationPlanRequestTransformer;
 import org.eclipse.edc.connector.controlplane.api.management.policy.v3.PolicyDefinitionApiV3Controller;
+import org.eclipse.edc.connector.controlplane.api.management.policy.v4.PolicyDefinitionApiV4Controller;
 import org.eclipse.edc.connector.controlplane.api.management.policy.validation.PolicyDefinitionValidator;
 import org.eclipse.edc.connector.controlplane.api.management.policy.validation.PolicyEvaluationPlanRequestValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.policydefinition.PolicyDefinitionService;
@@ -39,6 +40,7 @@ import org.eclipse.edc.web.spi.configuration.ApiContext;
 import java.util.Map;
 
 import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE_V4;
 import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyEvaluationPlanRequest.EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE;
 import static org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
@@ -88,6 +90,8 @@ public class PolicyDefinitionApiExtension implements ServiceExtension {
         var monitor = context.getMonitor();
         webService.registerResource(ApiContext.MANAGEMENT, new PolicyDefinitionApiV3Controller(monitor, managementApiTransformerRegistry, service, validatorRegistry));
         webService.registerDynamicResource(ApiContext.MANAGEMENT, PolicyDefinitionApiV3Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
-
+        
+        webService.registerResource(ApiContext.MANAGEMENT, new PolicyDefinitionApiV4Controller(monitor, managementApiTransformerRegistry, service, validatorRegistry));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, PolicyDefinitionApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, "v4"));
     }
 }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/model/PolicyEvaluationPlanRequest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/model/PolicyEvaluationPlanRequest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.controlplane.api.management.policy.model;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 
 public record PolicyEvaluationPlanRequest(String policyScope) {
-    public static final String EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE = EDC_NAMESPACE + "PolicyEvaluationPlanRequest";
+    public static final String EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE_TERM = "PolicyEvaluationPlanRequest";
+    public static final String EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE = EDC_NAMESPACE + EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE_TERM;
     public static final String EDC_POLICY_EVALUATION_PLAN_REQUEST_POLICY_SCOPE = EDC_NAMESPACE + "policyScope";
 }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v4/PolicyDefinitionApiV4.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v4/PolicyDefinitionApiV4.java
@@ -1,0 +1,117 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.policy.v4;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
+import org.eclipse.edc.api.model.ApiCoreSchema;
+
+@OpenAPIDefinition(info = @Info(version = "v4alpha"))
+@Tag(name = "Policy Definition v4alpha")
+public interface PolicyDefinitionApiV4 {
+
+    @Operation(description = "Returns all policy definitions according to a query",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.QUERY_SPEC))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The policy definitions matching the query",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.POLICY_DEFINITION)))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))}
+    )
+    JsonArray queryPolicyDefinitionsV4(JsonObject querySpecJson);
+
+    @Operation(description = "Gets a policy definition with the given ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The  policy definition",
+                            content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.POLICY_DEFINITION))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "An  policy definition with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    JsonObject getPolicyDefinitionV4(String id);
+
+    @Operation(description = "Creates a new policy definition",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.POLICY_DEFINITION))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "policy definition was created successfully. Returns the Policy Definition Id and created timestamp",
+                            content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.ID_RESPONSE))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "409", description = "Could not create policy definition, because a contract definition with that ID already exists",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))}
+    )
+    JsonObject createPolicyDefinitionV4(JsonObject policyDefinition);
+
+    @Operation(description = "Removes a policy definition with the given ID if possible. Deleting a policy definition is " +
+            "only possible if that policy definition is not yet referenced by a contract definition, in which case an error is returned. " +
+            "DANGER ZONE: Note that deleting policy definitions can have unexpected results, do this at your own risk!",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Policy definition was deleted successfully"),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "An policy definition with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "409", description = "The policy definition cannot be deleted, because it is referenced by a contract definition",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    void deletePolicyDefinitionV4(String id);
+
+    @Operation(description = "Updates an existing Policy, If the Policy is not found, an error is reported",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.POLICY_DEFINITION))),
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "policy definition was updated successfully."),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "policy definition could not be updated, because it does not exists",
+                            content = @Content(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))
+            }
+    )
+    void updatePolicyDefinitionV4(String id, JsonObject policyDefinition);
+
+    @Operation(description = "Validates an existing Policy, If the Policy is not found, an error is reported",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Returns the validation result", content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.POLICY_VALIDATION_RESULT))),
+                    @ApiResponse(responseCode = "404", description = "policy definition could not be validated, because it does not exists",
+                            content = @Content(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))
+            }
+    )
+    JsonObject validatePolicyDefinitionV4(String id);
+
+
+    @Operation(description = "Creates an execution plane for an existing Policy, If the Policy is not found, an error is reported",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.POLICY_EVALUATION_REQUEST))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Returns the evaluation plan", content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.POLICY_EVALUATION_PLAN))),
+                    @ApiResponse(responseCode = "404", description = "An evaluation plan could not be created, because the policy definition does not exists",
+                            content = @Content(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))
+            }
+    )
+    JsonObject createExecutionPlanV4(String id, JsonObject input);
+
+
+}

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v4/PolicyDefinitionApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v4/PolicyDefinitionApiV4Controller.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2025 Metaform Systems, Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,11 +8,11 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Metaform Systems, Inc. - initial API and implementation
  *
  */
 
-package org.eclipse.edc.connector.controlplane.api.management.policy.v3;
+package org.eclipse.edc.connector.controlplane.api.management.policy.v4;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
@@ -29,15 +29,19 @@ import org.eclipse.edc.connector.controlplane.services.spi.policydefinition.Poli
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.spi.validation.SchemaType;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyEvaluationPlanRequest.EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE_TERM;
+import static org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_TYPE_TERM;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 
 @Consumes(APPLICATION_JSON)
 @Produces(APPLICATION_JSON)
-@Path("/v3/policydefinitions")
-public class PolicyDefinitionApiV3Controller extends BasePolicyDefinitionApiController implements PolicyDefinitionApiV3 {
+@Path("/v4alpha/policydefinitions")
+public class PolicyDefinitionApiV4Controller extends BasePolicyDefinitionApiController implements PolicyDefinitionApiV4 {
 
-    public PolicyDefinitionApiV3Controller(Monitor monitor, TypeTransformerRegistry transformerRegistry, PolicyDefinitionService service,
+    public PolicyDefinitionApiV4Controller(Monitor monitor, TypeTransformerRegistry transformerRegistry, PolicyDefinitionService service,
                                            JsonObjectValidatorRegistry validatorRegistry) {
         super(monitor, transformerRegistry, service, validatorRegistry);
     }
@@ -45,48 +49,48 @@ public class PolicyDefinitionApiV3Controller extends BasePolicyDefinitionApiCont
     @POST
     @Path("request")
     @Override
-    public JsonArray queryPolicyDefinitionsV3(JsonObject querySpecJson) {
+    public JsonArray queryPolicyDefinitionsV4(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson) {
         return queryPolicyDefinitions(querySpecJson);
     }
 
     @GET
     @Path("{id}")
     @Override
-    public JsonObject getPolicyDefinitionV3(@PathParam("id") String id) {
+    public JsonObject getPolicyDefinitionV4(@PathParam("id") String id) {
         return getPolicyDefinition(id);
     }
 
     @POST
     @Override
-    public JsonObject createPolicyDefinitionV3(JsonObject request) {
+    public JsonObject createPolicyDefinitionV4(@SchemaType(EDC_POLICY_DEFINITION_TYPE_TERM) JsonObject request) {
         return createPolicyDefinition(request);
     }
 
     @DELETE
     @Path("{id}")
     @Override
-    public void deletePolicyDefinitionV3(@PathParam("id") String id) {
+    public void deletePolicyDefinitionV4(@PathParam("id") String id) {
         deletePolicyDefinition(id);
     }
 
     @PUT
     @Path("{id}")
     @Override
-    public void updatePolicyDefinitionV3(@PathParam("id") String id, JsonObject input) {
+    public void updatePolicyDefinitionV4(@PathParam("id") String id, @SchemaType(EDC_POLICY_DEFINITION_TYPE_TERM) JsonObject input) {
         updatePolicyDefinition(id, input);
     }
 
     @POST
     @Path("{id}/validate")
     @Override
-    public JsonObject validatePolicyDefinitionV3(@PathParam("id") String id) {
+    public JsonObject validatePolicyDefinitionV4(@PathParam("id") String id) {
         return validatePolicyDefinition(id);
     }
 
     @POST
     @Path("{id}/evaluationplan")
     @Override
-    public JsonObject createExecutionPlaneV3(@PathParam("id") String id, JsonObject request) {
+    public JsonObject createExecutionPlanV4(@PathParam("id") String id, @SchemaType(EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE_TERM) JsonObject request) {
         return createExecutionPlan(id, request);
     }
 }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/BasePolicyDefinitionApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/BasePolicyDefinitionApiControllerTest.java
@@ -18,9 +18,12 @@ import io.restassured.specification.RequestSpecification;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.api.model.IdResponse;
+import org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyEvaluationPlanRequest;
+import org.eclipse.edc.connector.controlplane.api.management.policy.model.PolicyValidationResult;
 import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.controlplane.services.spi.policydefinition.PolicyDefinitionService;
 import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
@@ -421,6 +424,136 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
                 .statusCode(200)
                 .contentType(JSON)
                 .body("size()", is(0));
+    }
+
+    @Test
+    void validate_shouldReturnNotFound_whenNotFound() {
+        when(service.findById(any())).thenReturn(null);
+
+        baseRequest()
+                .contentType(JSON)
+                .post("/id/validate")
+                .then()
+                .statusCode(404);
+    }
+
+
+    @Test
+    void validate_shouldReturnValid_whenValidationSucceed() {
+
+        var policyDefinition = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
+
+        when(service.findById(any())).thenReturn(policyDefinition);
+        when(service.validate(policyDefinition.getPolicy())).thenReturn(ServiceResult.success());
+        when(transformerRegistry.transform(any(PolicyValidationResult.class), eq(JsonObject.class))).then(answer -> {
+            PolicyValidationResult result = answer.getArgument(0);
+            var response = Json.createObjectBuilder()
+                    .add("isValid", result.isValid())
+                    .add("errors", Json.createArrayBuilder(result.errors()))
+                    .build();
+            return Result.success(response);
+        });
+
+        baseRequest()
+                .contentType(JSON)
+                .post("/id/validate")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("isValid", is(true))
+                .body("errors.size()", is(0));
+    }
+
+    @Test
+    void validate_shouldReturnInvalidValid_whenValidationFails() {
+
+        var policyDefinition = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
+
+
+        when(service.findById(any())).thenReturn(policyDefinition);
+        when(service.validate(policyDefinition.getPolicy())).thenReturn(ServiceResult.badRequest(List.of("error1", "error2")));
+        when(transformerRegistry.transform(any(PolicyValidationResult.class), eq(JsonObject.class))).then(answer -> {
+            PolicyValidationResult result = answer.getArgument(0);
+            var response = Json.createObjectBuilder()
+                    .add("isValid", result.isValid())
+                    .add("errors", Json.createArrayBuilder(result.errors()))
+                    .build();
+            return Result.success(response);
+        });
+
+        baseRequest()
+                .contentType(JSON)
+                .post("/id/validate")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("isValid", is(false))
+                .body("errors.size()", is(2));
+    }
+
+    @Test
+    void createEvaluationPlan() {
+
+        var policyScope = "scope";
+        var policyDefinition = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
+        var plan = PolicyEvaluationPlan.Builder.newInstance().build();
+        var response = Json.createObjectBuilder().build();
+        var body = Json.createObjectBuilder().add("policyScope", policyScope).build();
+
+        when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
+        when(service.findById(any())).thenReturn(policyDefinition);
+        when(service.createEvaluationPlan(policyScope, policyDefinition.getPolicy())).thenReturn(ServiceResult.success(plan));
+
+        when(transformerRegistry.transform(any(JsonObject.class), eq(PolicyEvaluationPlanRequest.class)))
+                .thenReturn(Result.success(new PolicyEvaluationPlanRequest(policyScope)));
+
+        when(transformerRegistry.transform(any(PolicyEvaluationPlan.class), eq(JsonObject.class))).thenReturn(Result.success(response));
+
+        baseRequest()
+                .contentType(JSON)
+                .body(body)
+                .post("/id/evaluationplan")
+                .then()
+                .statusCode(200)
+                .contentType(JSON);
+    }
+
+    @Test
+    void createEvaluationPlan_fails_whenPolicyNotFound() {
+
+        var policyScope = "scope";
+        var body = Json.createObjectBuilder().add("policyScope", policyScope).build();
+
+        when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
+        when(service.findById(any())).thenReturn(null);
+        when(transformerRegistry.transform(any(JsonObject.class), eq(PolicyEvaluationPlanRequest.class)))
+                .thenReturn(Result.success(new PolicyEvaluationPlanRequest(policyScope)));
+
+        baseRequest()
+                .contentType(JSON)
+                .body(body)
+                .post("/id/evaluationplan")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void createEvaluationPlan_fails_whenRequestValidation() {
+
+        var policyScope = "scope";
+        var body = Json.createObjectBuilder().add("policyScope", policyScope).build();
+
+        when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.failure(violation("failure", "failure path")));
+        when(service.findById(any())).thenReturn(null);
+        when(transformerRegistry.transform(any(JsonObject.class), eq(PolicyEvaluationPlanRequest.class)))
+                .thenReturn(Result.success(new PolicyEvaluationPlanRequest(policyScope)));
+
+        baseRequest()
+                .contentType(JSON)
+                .body(body)
+                .post("/id/evaluationplan")
+                .then()
+                .statusCode(400);
     }
 
     protected abstract RequestSpecification baseRequest();

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/v4/PolicyDefinitionApiV4ControllerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/v4/PolicyDefinitionApiV4ControllerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2025 Metaform Systems, Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,28 +8,28 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Metaform Systems, Inc. - initial API and implementation
  *
  */
 
-package org.eclipse.edc.connector.controlplane.api.management.policy.v3;
+package org.eclipse.edc.connector.controlplane.api.management.policy.v4;
 
 import io.restassured.specification.RequestSpecification;
 import org.eclipse.edc.connector.controlplane.api.management.policy.BasePolicyDefinitionApiControllerTest;
 
 import static io.restassured.RestAssured.given;
 
-public class PolicyDefinitionApiV3ControllerTest extends BasePolicyDefinitionApiControllerTest {
+public class PolicyDefinitionApiV4ControllerTest extends BasePolicyDefinitionApiControllerTest {
 
     @Override
     protected Object controller() {
-        return new PolicyDefinitionApiV3Controller(monitor, transformerRegistry, service, validatorRegistry);
+        return new PolicyDefinitionApiV4Controller(monitor, transformerRegistry, service, validatorRegistry);
     }
 
     @Override
     protected RequestSpecification baseRequest() {
         return given()
-                .baseUri("http://localhost:%d/v3/policydefinitions".formatted(port))
+                .baseUri("http://localhost:%d/v4alpha/policydefinitions".formatted(port))
                 .port(port);
     }
 

--- a/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/SecretsApiExtension.java
+++ b/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/SecretsApiExtension.java
@@ -18,6 +18,7 @@ import jakarta.json.Json;
 import org.eclipse.edc.connector.api.management.secret.transform.JsonObjectFromSecretTransformer;
 import org.eclipse.edc.connector.api.management.secret.transform.JsonObjectToSecretTransformer;
 import org.eclipse.edc.connector.api.management.secret.v3.SecretsApiV3Controller;
+import org.eclipse.edc.connector.api.management.secret.v4.SecretsApiV4Controller;
 import org.eclipse.edc.connector.api.management.secret.validation.SecretsValidator;
 import org.eclipse.edc.connector.spi.service.SecretService;
 import org.eclipse.edc.jsonld.spi.JsonLd;
@@ -35,6 +36,7 @@ import org.eclipse.edc.web.spi.configuration.ApiContext;
 import java.util.Map;
 
 import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE_V4;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 import static org.eclipse.edc.spi.types.domain.secret.Secret.EDC_SECRET_TYPE;
 
@@ -78,6 +80,9 @@ public class SecretsApiExtension implements ServiceExtension {
 
         webService.registerResource(ApiContext.MANAGEMENT, new SecretsApiV3Controller(secretService, managementApiTransformerRegistry, validator));
         webService.registerDynamicResource(ApiContext.MANAGEMENT, SecretsApiV3Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
+
+        webService.registerResource(ApiContext.MANAGEMENT, new SecretsApiV4Controller(secretService, managementApiTransformerRegistry, validator));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, SecretsApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validator, "v4"));
 
     }
 

--- a/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/v4/SecretsApiV4.java
+++ b/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/v4/SecretsApiV4.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.secret.v4;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
+import org.eclipse.edc.api.model.ApiCoreSchema;
+
+@OpenAPIDefinition(
+        info = @Info(description = "This contains the secret management API, which allows to add, remove and update secrets in the Vault.", title = "Secret API", version = "v4alpha"))
+@Tag(name = "Secret v4alpha")
+public interface SecretsApiV4 {
+
+    @Operation(description = "Creates a new secret.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.SECRET))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Secret was created successfully. Returns the secret Id and created timestamp",
+                            content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.ID_RESPONSE))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "409", description = "Could not create secret, because a secret with that ID already exists",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))}
+    )
+    JsonObject createSecretV4(JsonObject secret);
+
+    @Operation(description = "Gets a secret with the given ID",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The secret",
+                            content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.SECRET))),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "A secret with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    JsonObject getSecretV4(String id);
+
+    @Operation(description = "Removes a secret with the given ID if possible.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Secret was deleted successfully"),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "A secret with the given ID does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            })
+    void removeSecretV4(String id);
+
+    @Operation(description = "Updates a secret with the given ID if it exists. If the secret is not found, no further action is taken. ",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.SECRET))),
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Secret was updated successfully"),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed, e.g. id was null",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "Secret could not be updated, because it does not exist.")
+            })
+    void updateSecretV4(JsonObject secret);
+
+}

--- a/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/v4/SecretsApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/v4/SecretsApiV4Controller.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.secret.v4;
+
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import org.eclipse.edc.connector.api.management.secret.BaseSecretsApiController;
+import org.eclipse.edc.connector.spi.service.SecretService;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.spi.validation.SchemaType;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.spi.types.domain.secret.Secret.EDC_SECRET_TYPE_TERM;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v4alpha/secrets")
+public class SecretsApiV4Controller extends BaseSecretsApiController implements SecretsApiV4 {
+
+    public SecretsApiV4Controller(SecretService service, TypeTransformerRegistry transformerRegistry, JsonObjectValidatorRegistry validator) {
+        super(service, transformerRegistry, validator);
+    }
+
+    @POST
+    @Override
+    public JsonObject createSecretV4(@SchemaType(EDC_SECRET_TYPE_TERM) JsonObject secretJson) {
+        return createSecret(secretJson);
+    }
+
+    @GET
+    @Path("{id}")
+    @Override
+    public JsonObject getSecretV4(@PathParam("id") String id) {
+        return getSecret(id);
+    }
+
+    @DELETE
+    @Path("{id}")
+    @Override
+    public void removeSecretV4(@PathParam("id") String id) {
+        removeSecret(id);
+    }
+
+    @PUT
+    @Override
+    public void updateSecretV4(@SchemaType(EDC_SECRET_TYPE_TERM) JsonObject secretJson) {
+        updateSecret(secretJson);
+    }
+}

--- a/extensions/control-plane/api/management-api/secrets-api/src/test/java/org/eclipse/edc/connector/api/management/secret/v4/SecretsApiV4ControllerTest.java
+++ b/extensions/control-plane/api/management-api/secrets-api/src/test/java/org/eclipse/edc/connector/api/management/secret/v4/SecretsApiV4ControllerTest.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.secret.v4;
+
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.connector.api.management.secret.BaseSecretsApiControllerTest;
+
+import static io.restassured.RestAssured.given;
+
+class SecretsApiV4ControllerTest extends BaseSecretsApiControllerTest {
+    @Override
+    protected Object controller() {
+        return new SecretsApiV4Controller(service, transformerRegistry, validator);
+    }
+
+    @Override
+    protected RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port + "/v4alpha")
+                .when();
+    }
+}

--- a/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorApiExtension.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorApiExtension.java
@@ -34,6 +34,7 @@ import java.util.Map;
 
 import static jakarta.json.Json.createBuilderFactory;
 import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE;
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE_V4;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
 @Extension(value = "DataPlane selector API")
@@ -61,7 +62,7 @@ public class DataPlaneSelectorApiExtension implements ServiceExtension {
         // V4
         managementApiTransformerRegistry.register(new JsonObjectFromDataPlaneInstanceTransformer(createBuilderFactory(Map.of()), typeManager, JSON_LD));
         webservice.registerResource(ApiContext.MANAGEMENT, new DataplaneSelectorApiV4Controller(selectionService, managementApiTransformerRegistry));
-        webservice.registerDynamicResource(ApiContext.MANAGEMENT, DataplaneSelectorApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
+        webservice.registerDynamicResource(ApiContext.MANAGEMENT, DataplaneSelectorApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
 
         // V3
         var managementApiTransformerRegistryV3 = managementApiTransformerRegistry.forContext("v3");

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractDefinitionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractDefinitionApiV4EndToEndTest.java
@@ -1,0 +1,286 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi.v4;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.connector.controlplane.contract.spi.offer.store.ContractDefinitionStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
+import org.eclipse.edc.test.e2e.managementapi.ManagementEndToEndExtension;
+import org.eclipse.edc.test.e2e.managementapi.ManagementEndToEndTestContext;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+public class ContractDefinitionApiV4EndToEndTest {
+
+    abstract static class Tests {
+
+        @Test
+        void queryContractDefinitions_noQuerySpec(ManagementEndToEndTestContext context, ContractDefinitionStore store) {
+            var id = UUID.randomUUID().toString();
+            store.save(createContractDefinition(id).build());
+
+            var body = context.baseRequest()
+                    .contentType(JSON)
+                    .post("/v4alpha/contractdefinitions/request")
+                    .then()
+                    .statusCode(200)
+                    .body("size()", greaterThan(0))
+                    .extract().body().as(JsonArray.class);
+
+            var assetsSelector = body.stream().map(JsonValue::asJsonObject)
+                    .filter(it -> it.getString(ID).equals(id))
+                    .map(it -> it.getJsonArray("assetsSelector"))
+                    .findAny();
+
+            assertThat(assetsSelector).isPresent().get().asInstanceOf(LIST).hasSize(2);
+        }
+
+        @Test
+        void queryPolicyDefinitionWithSimplePrivateProperties(ManagementEndToEndTestContext context) {
+            var id = UUID.randomUUID().toString();
+            var requestJson = createDefinitionBuilder(id)
+                    .add("privateProperties", createObjectBuilder()
+                            .add("newKey", createObjectBuilder().add(ID, "newValue"))
+                            .build())
+                    .build();
+
+            context.baseRequest()
+                    .contentType(JSON)
+                    .body(requestJson)
+                    .post("/v4alpha/contractdefinitions")
+                    .then()
+                    .statusCode(200)
+                    .body("@id", equalTo(id));
+
+            var matchingQuery = context.queryV2(
+                    criterion("id", "=", id),
+                    criterion("privateProperties.'%snewKey'.@id".formatted(EDC_NAMESPACE), "=", "newValue")
+            );
+
+            context.baseRequest()
+                    .body(matchingQuery)
+                    .contentType(JSON)
+                    .post("/v4alpha/contractdefinitions/request")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body("size()", is(1));
+
+
+            var nonMatchingQuery = context.queryV2(
+                    criterion("id", "=", id),
+                    criterion("privateProperties.'%snewKey'.@id".formatted(EDC_NAMESPACE), "=", "anything-else")
+            );
+
+            context.baseRequest()
+                    .body(nonMatchingQuery)
+                    .contentType(JSON)
+                    .post("/v4alpha/contractdefinitions/request")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body("size()", is(0));
+        }
+
+        @Test
+        void queryContractDefinitions_sortByCreatedDate(ManagementEndToEndTestContext context, ContractDefinitionStore store) {
+            var id1 = UUID.randomUUID().toString();
+            var id2 = UUID.randomUUID().toString();
+            var id3 = UUID.randomUUID().toString();
+            var createdAtTime = new AtomicLong(1000L);
+            Stream.of(id1, id2, id3).forEach(id -> store.save(createContractDefinition(id).createdAt(createdAtTime.getAndIncrement()).build()));
+
+            var query = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "QuerySpec")
+                    .add("sortField", "createdAt")
+                    .add("sortOrder", "DESC")
+                    .add("limit", 100)
+                    .add("offset", 0)
+                    .build();
+
+            var result = context.baseRequest()
+                    .contentType(JSON)
+                    .body(query)
+                    .post("/v4alpha/contractdefinitions/request")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body("size()", is(3))
+                    .extract()
+                    .as(List.class);
+
+            assertThat(result)
+                    .extracting(cd -> ((LinkedHashMap<?, ?>) cd).get(ID))
+                    .containsExactlyElementsOf(List.of(id3, id2, id1));
+        }
+
+        @Test
+        void shouldCreateAndRetrieve(ManagementEndToEndTestContext context, ContractDefinitionStore store) {
+            var id = UUID.randomUUID().toString();
+            var requestJson = createDefinitionBuilder(id)
+                    .build();
+
+            context.baseRequest()
+                    .contentType(JSON)
+                    .body(requestJson)
+                    .post("/v4alpha/contractdefinitions")
+                    .then()
+                    .statusCode(200)
+                    .body("@id", equalTo(id));
+
+            var actual = store.findById(id);
+
+            assertThat(actual.getId()).matches(id);
+        }
+
+        @Test
+        void delete(ManagementEndToEndTestContext context, ContractDefinitionStore store) {
+            var id = UUID.randomUUID().toString();
+            var entity = createContractDefinition(id).build();
+            store.save(entity);
+
+            context.baseRequest()
+                    .delete("/v4alpha/contractdefinitions/" + id)
+                    .then()
+                    .statusCode(204);
+
+            var actual = store.findById(id);
+
+            assertThat(actual).isNull();
+        }
+
+        @Test
+        void update_whenExists(ManagementEndToEndTestContext context, ContractDefinitionStore store) {
+            var id = UUID.randomUUID().toString();
+            var entity = createContractDefinition(id).build();
+            store.save(entity);
+
+            var updated = createDefinitionBuilder(id)
+                    .add("accessPolicyId", "new-policy")
+                    .build();
+
+            context.baseRequest()
+                    .contentType(JSON)
+                    .body(updated)
+                    .put("/v4alpha/contractdefinitions")
+                    .then()
+                    .statusCode(204);
+
+            var actual = store.findById(id);
+
+            assertThat(actual.getAccessPolicyId()).isEqualTo("new-policy");
+        }
+
+        @Test
+        void update_whenNotExists(ManagementEndToEndTestContext context) {
+            var updated = createDefinitionBuilder(UUID.randomUUID().toString())
+                    .add("accessPolicyId", "new-policy")
+                    .build();
+
+            context.baseRequest()
+                    .contentType(JSON)
+                    .body(updated)
+                    .put("/v4alpha/contractdefinitions")
+                    .then()
+                    .statusCode(404);
+        }
+
+        private JsonObjectBuilder createDefinitionBuilder(String id) {
+            return createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "ContractDefinition")
+                    .add(ID, id)
+                    .add("accessPolicyId", UUID.randomUUID().toString())
+                    .add("contractPolicyId", UUID.randomUUID().toString())
+                    .add("assetsSelector", createArrayBuilder()
+                            .add(createCriterionBuilder("foo", "=", "bar"))
+                            .add(createCriterionBuilder("bar", "=", "baz")).build());
+        }
+
+        private JsonObjectBuilder createCriterionBuilder(String left, String operator, String right) {
+            return createObjectBuilder()
+                    .add(TYPE, "Criterion")
+                    .add("operandLeft", left)
+                    .add("operator", operator)
+                    .add("operandRight", right);
+        }
+
+        private ContractDefinition.Builder createContractDefinition(String id) {
+            return ContractDefinition.Builder.newInstance()
+                    .id(id)
+                    .accessPolicyId(UUID.randomUUID().toString())
+                    .contractPolicyId(UUID.randomUUID().toString())
+                    .assetsSelectorCriterion(criterion("foo", "=", "bar"))
+                    .assetsSelectorCriterion(criterion("bar", "=", "baz"));
+        }
+
+        private JsonArray jsonLdContext() {
+            return createArrayBuilder()
+                    .add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2)
+                    .build();
+        }
+    }
+
+    @Nested
+    @EndToEndTest
+    @ExtendWith(ManagementEndToEndExtension.InMemory.class)
+    class InMemory extends Tests {
+
+    }
+
+    @Nested
+    @PostgresqlIntegrationTest
+    class Postgres extends Tests {
+
+        @RegisterExtension
+        @Order(0)
+        static PostgresqlEndToEndExtension postgres = new PostgresqlEndToEndExtension();
+
+        @RegisterExtension
+        static ManagementEndToEndExtension runtime = new ManagementEndToEndExtension.Postgres(postgres);
+
+    }
+
+}

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/DataPlaneSelectorApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/DataPlaneSelectorApiV4EndToEndTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Cofinity-X
+ *  Copyright (c) 2025 Metaform Systems, Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,11 +8,11 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Cofinity-X - initial API and implementation
+ *       Metaform Systems, Inc. - initial API and implementation
  *
  */
 
-package org.eclipse.edc.test.e2e.managementapi;
+package org.eclipse.edc.test.e2e.managementapi.v4;
 
 import io.restassured.http.ContentType;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
@@ -20,38 +20,38 @@ import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceS
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
 import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
+import org.eclipse.edc.test.e2e.managementapi.ManagementEndToEndExtension;
+import org.eclipse.edc.test.e2e.managementapi.ManagementEndToEndTestContext;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 
-public class DataPlaneSelectorApiEndToEndTest {
+public class DataPlaneSelectorApiV4EndToEndTest {
 
     private abstract static class Tests {
 
         @Test
-        void getAllDataPlaneInstancesV3(ManagementEndToEndTestContext context, DataPlaneInstanceStore store) {
+        void getAllDataPlaneInstancesV4(ManagementEndToEndTestContext context, DataPlaneInstanceStore store) {
             var instance = DataPlaneInstance.Builder.newInstance().url("http://localhost/any").build();
             store.save(instance);
 
-            var responseBody = context.baseRequest()
-                    .get("/v3/dataplanes")
+            context.baseRequest()
+                    .get("/v4alpha/dataplanes")
                     .then()
                     .log().ifValidationFails()
                     .statusCode(200)
                     .contentType(ContentType.JSON)
-                    .body("size()", greaterThan(0))
-                    .extract().body().jsonPath();
+                    .body("size()", equalTo(1))
+                    .body("[0].'@context'", contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .body("[0].'@id'", equalTo(instance.getId()))
+                    .body("[0].url", equalTo(instance.getUrl().toString()));
 
-            var map = responseBody.getMap("find { it.id = '%s' }".formatted(instance.getId()));
-            assertThat(map).isNotNull().satisfies(actual -> {
-                assertThat(actual).containsEntry("url", instance.getUrl().toString());
-                assertThat(actual).containsKeys("allowedDestTypes", "turnCount");
-            });
         }
     }
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/EdrApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/EdrApiV4EndToEndTest.java
@@ -1,0 +1,199 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi.v4;
+
+import jakarta.json.JsonArray;
+import org.eclipse.edc.edr.spi.store.EndpointDataReferenceStore;
+import org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
+import org.eclipse.edc.test.e2e.managementapi.ManagementEndToEndExtension;
+import org.eclipse.edc.test.e2e.managementapi.ManagementEndToEndTestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class EdrApiV4EndToEndTest {
+
+    abstract static class Tests {
+
+
+        @BeforeEach
+        void beforeEach(EndpointDataReferenceStore store) {
+            var all = store.query(QuerySpec.max()).getContent();
+            all.forEach(edr -> store.delete(edr.getTransferProcessId()));
+        }
+
+        @Test
+        void queryEdrEntries_noQuerySpec(ManagementEndToEndTestContext context, EndpointDataReferenceStore store) {
+            var id = UUID.randomUUID().toString();
+            var entry = createEdrEntry(id).build();
+            store.save(entry, createDataAddress());
+
+            context.baseRequest()
+                    .contentType(JSON)
+                    .post("/v4alpha/edrs/request")
+                    .then()
+                    .statusCode(200)
+                    .body("size()", equalTo(1))
+                    .body("[0].'@id'", equalTo(entry.getId()))
+                    .body("[0].transferProcessId", equalTo(entry.getTransferProcessId()))
+                    .body("[0].agreementId", equalTo(entry.getAgreementId()))
+                    .body("[0].assetId", equalTo(entry.getAssetId()))
+                    .body("[0].contractNegotiationId", equalTo(entry.getContractNegotiationId()))
+                    .body("[0].providerId", equalTo(entry.getProviderId()));
+        }
+
+        @Test
+        void queryEdrEntries_sortByCreatedDate(ManagementEndToEndTestContext context, EndpointDataReferenceStore store) {
+            var id1 = UUID.randomUUID().toString();
+            var id2 = UUID.randomUUID().toString();
+            var id3 = UUID.randomUUID().toString();
+            var createdAtTime = new AtomicLong(1000L);
+            Stream.of(id1, id2, id3).forEach(id -> store.save(createEdrEntry(id).createdAt(createdAtTime.getAndIncrement()).build(), createDataAddress()));
+
+            var query = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "QuerySpec")
+                    .add("sortField", "createdAt")
+                    .add("sortOrder", "DESC")
+                    .add("limit", 100)
+                    .add("offset", 0)
+                    .build();
+
+            var result = context.baseRequest()
+                    .contentType(JSON)
+                    .body(query)
+                    .post("/v4alpha/edrs/request")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body("size()", is(3))
+                    .extract()
+                    .as(List.class);
+
+            assertThat(result)
+                    .extracting(cd -> ((LinkedHashMap<?, ?>) cd).get(ID))
+                    .containsExactlyElementsOf(List.of(id3, id2, id1));
+        }
+
+
+        @Test
+        void shouldRetrieveEdrDataAddress(ManagementEndToEndTestContext context, EndpointDataReferenceStore store) {
+            var id = UUID.randomUUID().toString();
+            store.save(createEdrEntry(id).build(), createDataAddress());
+
+            var actual = store.findById(id);
+
+            assertThat(actual.getId()).matches(id);
+
+            context.baseRequest()
+                    .contentType(JSON)
+                    .get("/v4alpha/edrs/%s/dataaddress".formatted(id))
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body(CONTEXT, contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .body(TYPE, is("DataAddress"))
+                    .body("type", is("TestType"));
+        }
+
+        @Test
+        void delete(ManagementEndToEndTestContext context, EndpointDataReferenceStore store) {
+            var id = UUID.randomUUID().toString();
+            var entity = createEdrEntry(id).build();
+            store.save(entity, createDataAddress());
+
+            context.baseRequest()
+                    .delete("/v4alpha/edrs/" + id)
+                    .then()
+                    .statusCode(204);
+
+            var actual = store.findById(id);
+
+            assertThat(actual).isNull();
+        }
+
+
+        private EndpointDataReferenceEntry.Builder createEdrEntry(String id) {
+            return EndpointDataReferenceEntry.Builder.newInstance()
+                    .id(id)
+                    .agreementId("agreement-" + id)
+                    .transferProcessId(id)
+                    .assetId("asset-" + id)
+                    .contractNegotiationId("negotiation-" + id)
+                    .providerId("provider-" + id)
+                    .createdAt(System.currentTimeMillis());
+        }
+
+        private DataAddress createDataAddress() {
+            return DataAddress.Builder.newInstance().type("TestType")
+                    .property("key1", "value1")
+                    .property("key2", "value2")
+                    .build();
+        }
+
+        private JsonArray jsonLdContext() {
+            return createArrayBuilder()
+                    .add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2)
+                    .build();
+        }
+    }
+
+    @Nested
+    @EndToEndTest
+    @ExtendWith(ManagementEndToEndExtension.InMemory.class)
+    class InMemory extends Tests {
+
+    }
+
+    @Nested
+    @PostgresqlIntegrationTest
+    class Postgres extends Tests {
+
+        @RegisterExtension
+        @Order(0)
+        static PostgresqlEndToEndExtension postgres = new PostgresqlEndToEndExtension();
+
+        @RegisterExtension
+        static ManagementEndToEndExtension runtime = new ManagementEndToEndExtension.Postgres(postgres);
+
+    }
+
+}

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/PolicyDefinitionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/PolicyDefinitionApiV4EndToEndTest.java
@@ -1,0 +1,451 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi.v4;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
+import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
+import org.eclipse.edc.test.e2e.managementapi.ManagementEndToEndExtension;
+import org.eclipse.edc.test.e2e.managementapi.ManagementEndToEndTestContext;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+public class PolicyDefinitionApiV4EndToEndTest {
+
+    abstract static class Tests {
+
+        @Test
+        void shouldStorePolicyDefinition(ManagementEndToEndTestContext context) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "PolicyDefinition")
+                    .add("policy", sampleOdrlPolicy())
+                    .build();
+
+            var id = context.baseRequest()
+                    .body(requestBody)
+                    .contentType(JSON)
+                    .post("/v4alpha/policydefinitions")
+                    .then()
+                    .log().ifValidationFails()
+                    .contentType(JSON)
+                    .statusCode(200)
+                    .extract().jsonPath().getString(ID);
+
+            context.baseRequest()
+                    .get("/v4alpha/policydefinitions/" + id)
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body(ID, is(id))
+                    .body(CONTEXT, contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .body("policy.permission[0].constraint[0].leftOperand", is("inForceDate"))
+                    .body("policy.permission[0].constraint[0].operator", is("gteq"))
+                    .body("policy.permission[0].constraint[0].rightOperand", is("contractAgreement+0s"))
+                    .body("policy.prohibition[0].action", is("use"))
+                    .body("policy.obligation[0].action", is("use"));
+        }
+
+        @Test
+        void shouldStorePolicyDefinitionWithPrivateProperties(ManagementEndToEndTestContext context, PolicyDefinitionStore store) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "PolicyDefinition")
+                    .add("policy", sampleOdrlPolicy())
+                    .add("privateProperties", createObjectBuilder()
+                            .add("newKey", "newValue")
+                            .build())
+                    .build();
+
+            var id = context.baseRequest()
+                    .body(requestBody)
+                    .contentType(JSON)
+                    .post("/v4alpha/policydefinitions")
+                    .then()
+                    .contentType(JSON)
+                    .extract().jsonPath().getString(ID);
+
+            var result = store.findById(id);
+
+            assertThat(result).isNotNull()
+                    .extracting(PolicyDefinition::getPolicy).isNotNull()
+                    .extracting(Policy::getPermissions).asList().hasSize(1);
+            Map<String, Object> privateProp = new HashMap<>();
+            privateProp.put("https://w3id.org/edc/v0.0.1/ns/newKey", "newValue");
+            assertThat(result).isNotNull()
+                    .extracting(PolicyDefinition::getPrivateProperties).isEqualTo(privateProp);
+
+            context.baseRequest()
+                    .get("/v4alpha/policydefinitions/" + id)
+                    .then()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body(ID, is(id))
+                    .body(CONTEXT, contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .log().all()
+                    .body("policy.permission[0].constraint[0].operator", is("gteq"));
+        }
+
+        @Test
+        void queryPolicyDefinitionWithSimplePrivateProperties(ManagementEndToEndTestContext context) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "PolicyDefinition")
+                    .add("policy", sampleOdrlPolicy())
+                    .add("privateProperties", createObjectBuilder()
+                            .add("newKey", createObjectBuilder().add(ID, "newValue"))
+                            .build())
+                    .build();
+
+            var id = context.baseRequest()
+                    .body(requestBody)
+                    .contentType(JSON)
+                    .post("/v4alpha/policydefinitions")
+                    .then()
+                    .contentType(JSON)
+                    .extract().jsonPath().getString(ID);
+
+            var matchingQuery = context.queryV2(
+                    criterion("id", "=", id),
+                    criterion("privateProperties.'https://w3id.org/edc/v0.0.1/ns/newKey'.@id", "=", "newValue")
+            );
+
+            context.baseRequest()
+                    .body(matchingQuery)
+                    .contentType(JSON)
+                    .post("/v4alpha/policydefinitions/request")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body("size()", is(1));
+
+
+            var nonMatchingQuery = context.queryV2(
+                    criterion("id", "=", id),
+                    criterion("privateProperties.'https://w3id.org/edc/v0.0.1/ns/newKey'.@id", "=", "somethingElse")
+            );
+
+            context.baseRequest()
+                    .body(nonMatchingQuery)
+                    .contentType(JSON)
+                    .post("/v4alpha/policydefinitions/request")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body("size()", is(0));
+        }
+
+        @Test
+        void shouldUpdate(ManagementEndToEndTestContext context, PolicyDefinitionStore store) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "PolicyDefinition")
+                    .add("policy", sampleOdrlPolicy())
+                    .build();
+
+            var id = context.baseRequest()
+                    .body(requestBody)
+                    .contentType(JSON)
+                    .post("/v4alpha/policydefinitions")
+                    .then()
+                    .statusCode(200)
+                    .extract().jsonPath().getString(ID);
+
+            context.baseRequest()
+                    .contentType(JSON)
+                    .get("/v4alpha/policydefinitions/" + id)
+                    .then()
+                    .statusCode(200);
+
+            context.baseRequest()
+                    .contentType(JSON)
+                    .body(createObjectBuilder(requestBody)
+                            .add(ID, id)
+                            .add("privateProperties", createObjectBuilder().add("privateProperty", "value"))
+                            .build())
+                    .put("/v4alpha/policydefinitions/" + id)
+                    .then()
+                    .statusCode(204);
+
+            assertThat(store.findById(id))
+                    .extracting(PolicyDefinition::getPrivateProperties)
+                    .asInstanceOf(MAP)
+                    .isNotEmpty();
+        }
+
+        @Test
+        void shouldDelete(ManagementEndToEndTestContext context) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "PolicyDefinition")
+                    .add("policy", sampleOdrlPolicy())
+                    .build();
+
+            var id = context.baseRequest()
+                    .body(requestBody)
+                    .contentType(JSON)
+                    .post("/v4alpha/policydefinitions")
+                    .then()
+                    .statusCode(200)
+                    .extract().jsonPath().getString(ID);
+
+            context.baseRequest()
+                    .delete("/v4alpha/policydefinitions/" + id)
+                    .then()
+                    .statusCode(204);
+
+            context.baseRequest()
+                    .get("/v4alpha/policydefinitions/" + id)
+                    .then()
+                    .statusCode(404);
+        }
+
+        @Test
+        void shouldDeleteWithProperties(ManagementEndToEndTestContext context) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "PolicyDefinition")
+                    .add("policy", sampleOdrlPolicy())
+                    .add("privateProperties", createObjectBuilder()
+                            .add("newKey", "newValue")
+                            .build())
+                    .build();
+
+            var id = context.baseRequest()
+                    .body(requestBody)
+                    .contentType(JSON)
+                    .post("/v4alpha/policydefinitions")
+                    .then()
+                    .statusCode(200)
+                    .extract().jsonPath().getString(ID);
+
+            context.baseRequest()
+                    .delete("/v4alpha/policydefinitions/" + id)
+                    .then()
+                    .statusCode(204);
+
+            context.baseRequest()
+                    .get("/v4alpha/policydefinitions/" + id)
+                    .then()
+                    .statusCode(404);
+        }
+
+        @Test
+        void shouldValidatePolicy(ManagementEndToEndTestContext context) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "PolicyDefinition")
+                    .add("policy", sampleInvalidOdrlPolicy())
+                    .build();
+
+            context.baseRequest()
+                    .body(requestBody)
+                    .contentType(JSON)
+                    .post("/v4alpha/policydefinitions")
+                    .then()
+                    .statusCode(400)
+                    .body("size()", is(2))
+                    .body("[0].message", startsWith("leftOperand 'https://w3id.org/edc/v0.0.1/ns/left' is not bound to any scopes"))
+                    .body("[1].message", startsWith("leftOperand 'https://w3id.org/edc/v0.0.1/ns/left' is not bound to any functions"));
+        }
+
+        @Test
+        void shouldCreateEvaluationPlan(ManagementEndToEndTestContext context) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "PolicyDefinition")
+                    .add("policy", sampleOdrlPolicy())
+                    .build();
+
+            var id = context.baseRequest()
+                    .body(requestBody)
+                    .contentType(JSON)
+                    .post("/v4alpha/policydefinitions")
+                    .then()
+                    .statusCode(200)
+                    .extract().jsonPath().getString(ID);
+
+            var planBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "PolicyEvaluationPlanRequest")
+                    .add("policyScope", "catalog")
+                    .build();
+
+            context.baseRequest()
+                    .contentType(JSON)
+                    .body(planBody)
+                    .post("/v4alpha/policydefinitions/" + id + "/evaluationplan")
+                    .then()
+                    .statusCode(200)
+                    .body("preValidators.size()", is(0))
+                    .body("permissionSteps[0].isFiltered", is(false))
+                    .body("permissionSteps[0].filteringReasons.size()", is(0))
+                    .body("permissionSteps[0].constraintSteps[0].'@type'", is("AtomicConstraintStep"))
+                    .body("permissionSteps[0].constraintSteps[0].isFiltered", is(true))
+                    .body("permissionSteps[0].constraintSteps[0].filteringReasons.size()", is(2))
+                    .body("permissionSteps[0].constraintSteps[0].functionName", nullValue())
+                    .body("permissionSteps[0].constraintSteps[0].functionParams.size()", is(3))
+                    .body("prohibitionSteps[0].isFiltered", is(false))
+                    .body("prohibitionSteps[0].filteringReasons", notNullValue())
+                    .body("prohibitionSteps[0].constraintSteps.size()", is(0))
+                    .body("obligationSteps[0].isFiltered", is(false))
+                    .body("obligationSteps[0].filteringReasons.size()", is(0))
+                    .body("obligationSteps[0].constraintSteps.size()", is(0))
+                    .body("postValidators.size()", is(0));
+
+        }
+
+        @Test
+        void shouldNotUpdatePolicyDefinition_whenValidationFails(ManagementEndToEndTestContext context) {
+            var validRequestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "PolicyDefinition")
+                    .add("policy", emptyOdrlPolicy())
+                    .build();
+
+            var id = context.baseRequest()
+                    .body(validRequestBody)
+                    .contentType(JSON)
+                    .post("/v4alpha/policydefinitions")
+                    .then()
+                    .contentType(JSON)
+                    .extract().jsonPath().getString(ID);
+
+            context.baseRequest()
+                    .contentType(JSON)
+                    .get("/v4alpha/policydefinitions/" + id)
+                    .then()
+                    .statusCode(200);
+
+            var inValidRequestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "PolicyDefinition")
+                    .add("policy", sampleInvalidOdrlPolicy())
+                    .build();
+
+            context.baseRequest()
+                    .contentType(JSON)
+                    .body(inValidRequestBody)
+                    .put("/v4alpha/policydefinitions/" + id)
+                    .then()
+                    .statusCode(400)
+                    .contentType(JSON)
+                    .body("size()", is(2))
+                    .body("[0].message", startsWith("leftOperand 'https://w3id.org/edc/v0.0.1/ns/left' is not bound to any scopes"))
+                    .body("[1].message", startsWith("leftOperand 'https://w3id.org/edc/v0.0.1/ns/left' is not bound to any functions"));
+        }
+
+        private JsonObject emptyOdrlPolicy() {
+            return createObjectBuilder()
+                    .add(TYPE, "Set")
+                    .build();
+        }
+
+        private JsonObject sampleInvalidOdrlPolicy() {
+            return createObjectBuilder()
+                    .add(TYPE, "Set")
+                    .add("permission", createArrayBuilder()
+                            .add(createObjectBuilder()
+                                    .add("action", "use")
+                                    .add("constraint", createArrayBuilder().add(createObjectBuilder()
+                                                    .add("leftOperand", "https://w3id.org/edc/v0.0.1/ns/left")
+                                                    .add("operator", "eq")
+                                                    .add("rightOperand", "value"))
+                                            .build()))
+                            .build())
+                    .build();
+        }
+
+        private JsonObject sampleOdrlPolicy() {
+            return createObjectBuilder()
+                    .add(TYPE, "Set")
+                    .add("permission", createArrayBuilder()
+                            .add(createObjectBuilder()
+                                    .add("action", "use")
+                                    .add("constraint", createArrayBuilder().add(createObjectBuilder()
+                                                    .add("leftOperand", "inForceDate")
+                                                    .add("operator", "gteq")
+                                                    .add("rightOperand", "contractAgreement+0s"))
+                                            .build()))
+                            .build())
+                    .add("prohibition", createArrayBuilder()
+                            .add(createObjectBuilder()
+                                    .add("action", "use")
+                            ))
+                    .add("obligation", createArrayBuilder()
+                            .add(createObjectBuilder()
+                                    .add("action", "use")
+                            )
+                    )
+                    .build();
+        }
+
+        private JsonArray jsonLdContext() {
+            return createArrayBuilder()
+                    .add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2)
+                    .build();
+        }
+
+    }
+
+    @Nested
+    @EndToEndTest
+    @ExtendWith(ManagementEndToEndExtension.InMemory.class)
+    class InMemory extends Tests {
+
+    }
+
+    @Nested
+    @PostgresqlIntegrationTest
+    class Postgres extends Tests {
+
+        @RegisterExtension
+        @Order(0)
+        static PostgresqlEndToEndExtension postgres = new PostgresqlEndToEndExtension();
+
+        @RegisterExtension
+        static ManagementEndToEndExtension runtime = new ManagementEndToEndExtension.Postgres(postgres);
+
+    }
+
+}

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/SecretsApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/SecretsApiV4EndToEndTest.java
@@ -1,0 +1,137 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi.v4;
+
+import io.restassured.http.ContentType;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.test.e2e.managementapi.ManagementEndToEndExtension;
+import org.eclipse.edc.test.e2e.managementapi.ManagementEndToEndTestContext;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.UUID;
+
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
+import static org.eclipse.edc.spi.types.domain.secret.Secret.EDC_SECRET_TYPE_TERM;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class SecretsApiV4EndToEndTest {
+
+    abstract static class Tests {
+
+        @Test
+        void getSecretById(ManagementEndToEndTestContext context, Vault vault) {
+            var id = UUID.randomUUID().toString();
+            var value = "secret-value";
+            vault.storeSecret(id, value);
+
+            context.baseRequest()
+                    .get("/v4alpha/secrets/" + id)
+                    .then()
+                    .statusCode(200)
+                    .body(notNullValue())
+                    .body(CONTEXT, contains(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .body(ID, equalTo(id))
+                    .body("value", equalTo(value));
+        }
+
+        @Test
+        void createSecret_shouldBeStored(ManagementEndToEndTestContext context, Vault vault) {
+            var id = UUID.randomUUID().toString();
+            var value = "secret-value";
+            var secretJson = createObjectBuilder()
+                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(TYPE, EDC_SECRET_TYPE_TERM)
+                    .add(ID, id)
+                    .add("value", value)
+                    .build();
+
+            context.baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(secretJson)
+                    .post("/v4alpha/secrets")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body(ID, is(id));
+
+            assertThat(vault.resolveSecret(id))
+                    .isNotNull()
+                    .isEqualTo(value);
+        }
+
+        @Test
+        void createSecret_shouldFail_whenBodyIsNotValid(ManagementEndToEndTestContext context) {
+            var secretJson = createObjectBuilder()
+                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(TYPE, EDC_SECRET_TYPE_TERM)
+                    .add(ID, " ")
+                    .add("value", "secret-value")
+                    .build();
+
+            context.baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(secretJson)
+                    .post("/v4alpha/secrets")
+                    .then()
+                    .log().ifError()
+                    .statusCode(400);
+        }
+
+        @Test
+        void updateSecret(ManagementEndToEndTestContext context, Vault vault) {
+            var id = UUID.randomUUID().toString();
+            var newValue = "new-value";
+            vault.storeSecret(id, "secret-value");
+
+            var secretJson = createObjectBuilder()
+                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(TYPE, EDC_SECRET_TYPE_TERM)
+                    .add(ID, id)
+                    .add("value", newValue)
+                    .build();
+
+            context.baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(secretJson)
+                    .put("/v4alpha/secrets")
+                    .then()
+                    .log().all()
+                    .statusCode(204)
+                    .body(notNullValue());
+
+            var vaultSecret = vault.resolveSecret(id);
+            assertThat(vaultSecret).isNotNull().isEqualTo(newValue);
+        }
+
+    }
+
+    @Nested
+    @EndToEndTest
+    @ExtendWith(ManagementEndToEndExtension.InMemory.class)
+    class InMemory extends Tests {
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Add v4alpha controllers for

- PolicyDefinition
- ContractDefinition
- Secret
- DataPlaneSelector
- Edr

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Relates #5137 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
