### PR TITLE
refactor: execute deprovisioning on suspension

### DIFF
--- a/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
@@ -464,7 +464,7 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
                 .reason(process.getErrorDetail());
 
         return entityRetryProcessFactory.retryProcessor(process)
-                .doProcess(result("Suspend DataFlow", (t, c) -> suspendDataFlow(process)))
+                .doProcess(result("Suspend DataFlow", (t, c) -> terminateDataFlow(process)))
                 .doProcess(futureResult("Dispatch TransferSuspensionMessage to " + process.getCounterPartyAddress(),
                         (t, dataFlowResponse) -> {
                             if (t.suspensionWasRequestedByCounterParty()) {
@@ -550,9 +550,9 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
     }
 
     @NotNull
-    private StatusResult<Void> suspendDataFlow(TransferProcess process) {
+    private StatusResult<Void> terminateDataFlow(TransferProcess process) {
         if (process.getType() == PROVIDER) {
-            return dataFlowManager.suspend(process);
+            return dataFlowManager.terminate(process);
         } else {
             return StatusResult.success();
         }

--- a/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
+++ b/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
@@ -1003,12 +1003,12 @@ class TransferProcessManagerImplTest {
             when(transferProcessStore.nextNotLeased(anyInt(), stateIs(SUSPENDING.code()))).thenReturn(List.of(process)).thenReturn(emptyList());
             when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(SUSPENDING.code()).build());
             when(dispatcherRegistry.dispatch(any(), any())).thenReturn(completedFuture(StatusResult.success("any")));
-            when(dataFlowManager.suspend(any())).thenReturn(StatusResult.success());
+            when(dataFlowManager.terminate(any())).thenReturn(StatusResult.success());
 
             manager.start();
 
             await().untilAsserted(() -> {
-                verify(dataFlowManager).suspend(process);
+                verify(dataFlowManager).terminate(process);
                 var captor = ArgumentCaptor.forClass(TransferSuspensionMessage.class);
                 verify(dispatcherRegistry).dispatch(eq(Object.class), captor.capture());
                 var message = captor.getValue();
@@ -1052,12 +1052,12 @@ class TransferProcessManagerImplTest {
             var process = createTransferProcessBuilder(SUSPENDING_REQUESTED).type(PROVIDER).correlationId("counterPartyId").build();
             when(transferProcessStore.nextNotLeased(anyInt(), stateIs(SUSPENDING_REQUESTED.code()))).thenReturn(List.of(process)).thenReturn(emptyList());
             when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(SUSPENDING_REQUESTED.code()).build());
-            when(dataFlowManager.suspend(any())).thenReturn(StatusResult.success());
+            when(dataFlowManager.terminate(any())).thenReturn(StatusResult.success());
 
             manager.start();
 
             await().untilAsserted(() -> {
-                verify(dataFlowManager).suspend(process);
+                verify(dataFlowManager).terminate(process);
                 verifyNoInteractions(dispatcherRegistry);
                 verify(transferProcessStore, atLeastOnce()).save(argThat(p -> p.getState() == SUSPENDED.code()));
                 verify(listener).suspended(process);
@@ -1069,12 +1069,12 @@ class TransferProcessManagerImplTest {
             var process = createTransferProcessBuilder(SUSPENDING_REQUESTED).type(PROVIDER).correlationId("counterPartyId").build();
             when(transferProcessStore.nextNotLeased(anyInt(), stateIs(SUSPENDING_REQUESTED.code()))).thenReturn(List.of(process)).thenReturn(emptyList());
             when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(SUSPENDING_REQUESTED.code()).build());
-            when(dataFlowManager.suspend(any())).thenReturn(StatusResult.failure(ERROR_RETRY));
+            when(dataFlowManager.terminate(any())).thenReturn(StatusResult.failure(ERROR_RETRY));
 
             manager.start();
 
             await().untilAsserted(() -> {
-                verify(dataFlowManager).suspend(process);
+                verify(dataFlowManager).terminate(process);
                 verifyNoInteractions(dispatcherRegistry);
                 verify(transferProcessStore, atLeastOnce()).save(argThat(p -> p.getState() == SUSPENDING_REQUESTED.code()));
             });
@@ -1090,12 +1090,12 @@ class TransferProcessManagerImplTest {
             var process = createTransferProcessBuilder(SUSPENDING_REQUESTED).type(PROVIDER).correlationId("counterPartyId").build();
             when(transferProcessStore.nextNotLeased(anyInt(), stateIs(SUSPENDING_REQUESTED.code()))).thenReturn(List.of(process)).thenReturn(emptyList());
             when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(SUSPENDING_REQUESTED.code()).build());
-            when(dataFlowManager.suspend(any())).thenReturn(StatusResult.success());
+            when(dataFlowManager.terminate(any())).thenReturn(StatusResult.success());
 
             manager.start();
 
             await().untilAsserted(() -> {
-                verify(dataFlowManager).suspend(process);
+                verify(dataFlowManager).terminate(process);
                 verifyNoInteractions(dispatcherRegistry);
                 verify(transferProcessStore, atLeastOnce()).save(argThat(p -> p.getState() == SUSPENDED.code()));
                 verify(listener).suspended(process);
@@ -1112,7 +1112,6 @@ class TransferProcessManagerImplTest {
                 .thenReturn(List.of(transferProcess)).thenReturn(emptyList());
         when(dispatcherRegistry.dispatch(any(), any())).thenReturn(result);
         when(transferProcessStore.findById(transferProcess.getId())).thenReturn(transferProcess);
-        when(dataFlowManager.suspend(any())).thenReturn(StatusResult.success());
         when(dataFlowManager.terminate(any())).thenReturn(StatusResult.success());
 
         manager.start();

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/flow/DataFlowManagerImpl.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/flow/DataFlowManagerImpl.java
@@ -87,11 +87,6 @@ public class DataFlowManagerImpl implements DataFlowManager {
     }
 
     @Override
-    public @NotNull StatusResult<Void> suspend(TransferProcess transferProcess) {
-        return chooseControllerAndApply(transferProcess, controller -> controller.suspend(transferProcess));
-    }
-
-    @Override
     public Set<String> transferTypesFor(Asset asset) {
         return controllers.stream()
                 .map(it -> it.controller)

--- a/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/flow/DataFlowManagerImplTest.java
+++ b/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/flow/DataFlowManagerImplTest.java
@@ -140,26 +140,6 @@ class DataFlowManagerImplTest {
     }
 
     @Nested
-    class Suspend {
-        @Test
-        void shouldChooseControllerAndSuspend() {
-            var controller = mock(DataFlowController.class);
-            var dataDestination = DataAddress.Builder.newInstance().type("test-dest-type").build();
-            var dataAddress = DataAddress.Builder.newInstance().type("test-type").build();
-            var transferProcess = TransferProcess.Builder.newInstance().dataDestination(dataDestination).contentDataAddress(dataAddress).build();
-
-            when(controller.canHandle(any())).thenReturn(true);
-            when(controller.suspend(any())).thenReturn(StatusResult.success());
-            manager.register(controller);
-
-            var result = manager.suspend(transferProcess);
-
-            assertThat(result).isSucceeded();
-            verify(controller).suspend(transferProcess);
-        }
-    }
-
-    @Nested
     class Terminate {
         @Test
         void shouldChooseControllerAndTerminate() {

--- a/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
+++ b/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
@@ -1,6 +1,6 @@
 [
   {
-    "version": "2.0.0",
+    "version": "2.0.1",
     "urlPath": "/v1",
     "lastUpdated": "2025-07-10T12:00:00Z",
     "maturity": "stable"

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowController.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowController.java
@@ -149,20 +149,6 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
     }
 
     @Override
-    public StatusResult<Void> suspend(TransferProcess transferProcess) {
-        return Optional.ofNullable(transferProcess.getDataPlaneId())
-                .map(StatusResult::success)
-                .orElse(StatusResult.failure(FATAL_ERROR, "DataPlane id is null"))
-                .compose(this::getClientForDataplane)
-                .map(client -> client.suspend(transferProcess.getId()))
-                .orElse(f -> {
-                    var message = "Failed to select the data plane for suspending the transfer process %s. %s"
-                            .formatted(transferProcess.getId(), f.getFailureDetail());
-                    return StatusResult.failure(FATAL_ERROR, message);
-                });
-    }
-
-    @Override
     public StatusResult<Void> terminate(TransferProcess transferProcess) {
         var dataPlaneId = transferProcess.getDataPlaneId();
         if (dataPlaneId == null) {
@@ -172,7 +158,7 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
         return getClientForDataplane(dataPlaneId)
                 .map(client -> client.terminate(transferProcess.getId()))
                 .orElse(f -> {
-                    var message = "Failed to select the data plane for terminating the transfer process %s. %s"
+                    var message = "Failed to select the data plane for terminating the data flow %s. %s"
                             .formatted(transferProcess.getId(), f.getFailureDetail());
                     return StatusResult.failure(FATAL_ERROR, message);
                 });

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowControllerTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowControllerTest.java
@@ -336,7 +336,7 @@ public class DataPlaneSignalingFlowControllerTest {
 
             var result = flowController.terminate(transferProcess);
 
-            assertThat(result).isFailed().detail().contains("Failed to select the data plane for terminating the transfer process");
+            assertThat(result).isFailed().detail().contains("Failed to select the data plane for terminating the data flow");
         }
 
         @Test
@@ -353,59 +353,6 @@ public class DataPlaneSignalingFlowControllerTest {
             assertThat(result).isSucceeded();
             verifyNoInteractions(dataPlaneClient, dataPlaneClientFactory, selectorService);
         }
-    }
-
-    @Nested
-    class Suspend {
-
-        @Test
-        void shouldCallTerminate() {
-            var transferProcess = TransferProcess.Builder.newInstance()
-                    .id("transferProcessId")
-                    .contentDataAddress(testDataAddress())
-                    .dataPlaneId("dataPlaneId")
-                    .build();
-            when(dataPlaneClient.suspend(any())).thenReturn(StatusResult.success());
-            var dataPlaneInstance = dataPlaneInstanceBuilder().id("dataPlaneId").build();
-            when(dataPlaneClientFactory.createClient(any())).thenReturn(dataPlaneClient);
-            when(selectorService.findById(any())).thenReturn(ServiceResult.success(dataPlaneInstance));
-
-            var result = flowController.suspend(transferProcess);
-
-            assertThat(result).isSucceeded();
-            verify(dataPlaneClient).suspend("transferProcessId");
-            verify(dataPlaneClientFactory).createClient(dataPlaneInstance);
-        }
-
-        @Test
-        void shouldFail_whenDataPlaneDoesNotExist() {
-            var transferProcess = TransferProcess.Builder.newInstance()
-                    .id("transferProcessId")
-                    .contentDataAddress(testDataAddress())
-                    .dataPlaneId("invalid")
-                    .build();
-            when(selectorService.findById(any())).thenReturn(ServiceResult.notFound("not found"));
-
-            var result = flowController.suspend(transferProcess);
-
-            assertThat(result).isFailed().detail().contains("Failed to select the data plane for suspending the transfer process");
-            verifyNoInteractions(dataPlaneClient, dataPlaneClientFactory);
-        }
-
-        @Test
-        void shouldFail_whenDataPlaneIdIsNull() {
-            var transferProcess = TransferProcess.Builder.newInstance()
-                    .id("transferProcessId")
-                    .contentDataAddress(testDataAddress())
-                    .dataPlaneId(null)
-                    .build();
-
-            var result = flowController.suspend(transferProcess);
-
-            assertThat(result).isFailed().detail().contains("Failed to select the data plane for suspending the transfer process");
-            verifyNoInteractions(dataPlaneClient, dataPlaneClientFactory, selectorService);
-        }
-
     }
 
     @Nested

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApi.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApi.java
@@ -73,12 +73,14 @@ public interface DataPlaneSignalingApi {
 
     @Operation(description = "Suspend a data transfer.",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DataFlowSuspendMessageSchema.class))),
+            deprecated = true,
             responses = {
                     @ApiResponse(responseCode = "204", description = "Data transfer suspended"),
                     @ApiResponse(responseCode = "404", description = "Data transfer not handled by the data plane"),
                     @ApiResponse(responseCode = "409", description = "Cannot suspend the transfer"),
             }
     )
+    @Deprecated(since = "0.15.0")
     void suspend(String transferProcessId, JsonObject suspendMessage);
 
     @Operation(description = "Check if data plane is available.",

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApiController.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/main/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApiController.java
@@ -29,7 +29,6 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
@@ -96,11 +95,7 @@ public class DataPlaneSignalingApiController implements DataPlaneSignalingApi {
     @Path("/{id}/suspend")
     @Override
     public void suspend(@PathParam("id") String id, JsonObject suspendMessage) {
-        var msg = typeTransformerRegistry.transform(suspendMessage, DataFlowSuspendMessage.class)
-                .onFailure(f -> monitor.warning("Error transforming %s: %s".formatted(DataFlowSuspendMessage.class, f.getFailureDetail())))
-                .orElseThrow(InvalidRequestException::new);
-
-        dataPlaneManager.suspend(id).orElseThrow(InvalidRequestException::new);
+        terminate(id, suspendMessage);
     }
 
     @Override

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApiControllerTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/src/test/java/org/eclipse/edc/connector/dataplane/api/controller/v1/DataPlaneSignalingApiControllerTest.java
@@ -29,7 +29,6 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage;
 import org.eclipse.edc.spi.types.domain.transfer.FlowType;
 import org.eclipse.edc.spi.types.domain.transfer.TransferType;
@@ -266,15 +265,16 @@ class DataPlaneSignalingApiControllerTest extends RestControllerTestBase {
                 .statusCode(400);
     }
 
+    @Deprecated(since = "0.15.0")
     @Nested
     class Suspend {
 
         @Test
         void shouldReturn204_whenDataFlowIsSuspended() {
-            when(transformerRegistry.transform(isA(JsonObject.class), eq(DataFlowSuspendMessage.class)))
-                    .thenReturn(success(DataFlowSuspendMessage.Builder.newInstance().reason("test-reason").build()));
+            when(transformerRegistry.transform(isA(JsonObject.class), eq(DataFlowTerminateMessage.class)))
+                    .thenReturn(success(DataFlowTerminateMessage.Builder.newInstance().reason("test-reason").build()));
             var flowId = "test-id";
-            when(dataplaneManager.suspend(eq(flowId))).thenReturn(StatusResult.success());
+            when(dataplaneManager.terminate(eq(flowId), any())).thenReturn(StatusResult.success());
 
             var jsonObject = Json.createObjectBuilder().build();
             baseRequest()
@@ -287,10 +287,10 @@ class DataPlaneSignalingApiControllerTest extends RestControllerTestBase {
 
         @Test
         void shouldReturn500_whenDataFlowCannotBeSuspended() {
-            when(transformerRegistry.transform(isA(JsonObject.class), eq(DataFlowSuspendMessage.class)))
-                    .thenReturn(success(DataFlowSuspendMessage.Builder.newInstance().reason("test-reason").build()));
+            when(transformerRegistry.transform(isA(JsonObject.class), eq(DataFlowTerminateMessage.class)))
+                    .thenReturn(success(DataFlowTerminateMessage.Builder.newInstance().reason("test-reason").build()));
             var flowId = "test-id";
-            when(dataplaneManager.suspend(eq(flowId))).thenReturn(StatusResult.failure(ResponseStatus.FATAL_ERROR));
+            when(dataplaneManager.terminate(eq(flowId), any())).thenReturn(StatusResult.failure(ResponseStatus.FATAL_ERROR));
 
             var jsonObject = Json.createObjectBuilder().build();
             baseRequest()

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClient.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClient.java
@@ -32,7 +32,6 @@ import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
-import org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage;
 import org.eclipse.edc.spi.types.domain.transfer.DataFlowTerminateMessage;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.jetbrains.annotations.NotNull;
@@ -86,16 +85,6 @@ public class DataPlaneSignalingClient implements DataPlaneClient {
                 .compose(builder -> httpClient.request(builder)
                         .flatMap(result -> result.map(this::handleResponse)
                                 .orElse(failure -> failedResult(message.getProcessId(), failure))));
-    }
-
-    @Override
-    public StatusResult<Void> suspend(String transferProcessId) {
-        var url = "%s/%s/suspend".formatted(dataPlane.getUrl(), transferProcessId);
-        var message = DataFlowSuspendMessage.Builder.newInstance().build();
-        return createRequestBuilder(message, url)
-                .compose(builder -> httpClient.request(builder)
-                        .flatMap(result -> result.map(it -> StatusResult.success())
-                                .orElse(failure -> failedResult(transferProcessId, failure))));
     }
 
     @Override

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClient.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClient.java
@@ -61,11 +61,6 @@ public class EmbeddedDataPlaneClient implements DataPlaneClient {
     }
 
     @Override
-    public StatusResult<Void> suspend(String transferProcessId) {
-        return dataPlaneManager.suspend(transferProcessId);
-    }
-
-    @Override
     public StatusResult<Void> terminate(String transferProcessId) {
         return dataPlaneManager.terminate(transferProcessId);
     }

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientTest.java
@@ -483,48 +483,6 @@ class DataPlaneSignalingClientTest {
     }
 
     @Nested
-    class Suspend {
-
-        @Test
-        void shouldCallSuspendOnAllTheAvailableDataPlanes() {
-            dataPlane.stubFor(post(DATA_PLANE_PATH + "/processId/suspend")
-                    .willReturn(aResponse().withStatus(204)));
-
-            var result = dataPlaneClient.suspend("processId");
-
-            assertThat(result).isSucceeded();
-            dataPlane.verify(postRequestedFor(urlEqualTo(DATA_PLANE_PATH + "/processId/suspend")));
-        }
-
-        @Test
-        void shouldFail_whenConflictResponse() {
-            dataPlane.stubFor(post(DATA_PLANE_PATH + "/processId/suspend")
-                    .willReturn(aResponse().withStatus(409)));
-
-            var result = dataPlaneClient.suspend("processId");
-
-            assertThat(result).isFailed();
-        }
-
-        @Test
-        void verifyReturnFatalErrorIfTransformFails() {
-            TypeTransformerRegistry registry = mock();
-            var dataPlaneClient = new DataPlaneSignalingClient(httpClient, registry, JSON_LD, CONTROL_CLIENT_SCOPE, TYPE_MANAGER, "test", instance);
-
-            when(registry.transform(any(), any())).thenReturn(Result.failure("Transform Failure"));
-
-            var result = dataPlaneClient.suspend("processId");
-
-            assertThat(result.failed()).isTrue();
-            assertThat(result.getFailure().status()).isEqualTo(FATAL_ERROR);
-            assertThat(result.getFailureMessages())
-                    .anySatisfy(s -> assertThat(s)
-                            .isEqualTo("Transform Failure")
-                    );
-        }
-    }
-
-    @Nested
     class CheckAvailability {
         @Test
         void shouldSucceed_whenDataPlaneIsAvailable() {

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClientTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClientTest.java
@@ -116,16 +116,6 @@ class EmbeddedDataPlaneClientTest {
     }
 
     @Test
-    void suspend_shouldProxyCallToManager() {
-        when(dataPlaneManager.suspend(any())).thenReturn(StatusResult.success());
-
-        var result = client.suspend("dataFlowId");
-
-        assertThat(result).isSucceeded();
-        verify(dataPlaneManager).suspend("dataFlowId");
-    }
-
-    @Test
     void terminate_shouldProxyCallToManager() {
         when(dataPlaneManager.terminate(any())).thenReturn(StatusResult.success());
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowController.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowController.java
@@ -57,7 +57,9 @@ public interface DataFlowController {
      * @param transferProcess the transfer process.
      * @return success if the flow is suspended correctly, failure otherwise;
      */
-    StatusResult<Void> suspend(TransferProcess transferProcess);
+    default StatusResult<Void> suspend(TransferProcess transferProcess) {
+        return terminate(transferProcess);
+    }
 
     /**
      * Terminate a data flow.

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowManager.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowManager.java
@@ -79,9 +79,12 @@ public interface DataFlowManager {
      *
      * @param transferProcess the transfer process.
      * @return success if the transfer has been suspended correctly, failed otherwise.
+     * @deprecated the DataFlow needs to be terminated at suspension
      */
-    @NotNull
-    StatusResult<Void> suspend(TransferProcess transferProcess);
+    @Deprecated(since = "0.15.0")
+    default StatusResult<Void> suspend(TransferProcess transferProcess) {
+        return terminate(transferProcess);
+    }
 
     /**
      * Returns the transfer types available for a specific asset.

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/client/DataPlaneClient.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/client/DataPlaneClient.java
@@ -44,8 +44,12 @@ public interface DataPlaneClient {
      *
      * @param transferProcessId the transfer process id.
      * @return success if the transfer has been suspended, failure otherwise.
+     * @deprecated data flow must be terminated on suspension
      */
-    StatusResult<Void> suspend(String transferProcessId);
+    @Deprecated(since = "0.15.0")
+    default StatusResult<Void> suspend(String transferProcessId) {
+        return terminate(transferProcessId);
+    }
 
     /**
      * Terminate the transfer.

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlow.java
@@ -47,7 +47,6 @@ import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.PROVISION_N
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.PROVISION_REQUESTED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.RECEIVED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.STARTED;
-import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.SUSPENDED;
 import static org.eclipse.edc.connector.dataplane.spi.DataFlowStates.TERMINATED;
 
 /**
@@ -185,10 +184,6 @@ public class DataFlow extends StatefulEntity<DataFlow> {
         transitionTo(STARTED.code());
     }
 
-    public void transitToSuspended() {
-        transitionTo(SUSPENDED.code());
-    }
-
     public List<ProvisionResource> getResourceDefinitions() {
         return resourceDefinitions;
     }
@@ -279,6 +274,10 @@ public class DataFlow extends StatefulEntity<DataFlow> {
 
     public String getAgreementId() {
         return properties.get(AGREEMENT_ID_PROPERTY);
+    }
+
+    public void clearResourceDefinitions() {
+        resourceDefinitions.clear();
     }
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlowStates.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/DataFlowStates.java
@@ -29,6 +29,7 @@ public enum DataFlowStates {
     RECEIVED(100),
     STARTED(150),
     COMPLETED(200),
+    @Deprecated(since = "0.15.0")
     SUSPENDED(225),
     TERMINATED(250),
     FAILED(300),

--- a/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
+++ b/spi/data-plane/data-plane-spi/src/main/java/org/eclipse/edc/connector/dataplane/spi/manager/DataPlaneManager.java
@@ -78,8 +78,12 @@ public interface DataPlaneManager extends StateEntityManager {
      *
      * @param dataFlowId the data flow id.
      * @return success if data flow is terminated, failed otherwise.
+     * @deprecated data flow should be terminated on TP suspension.
      */
-    StatusResult<Void> suspend(String dataFlowId);
+    @Deprecated(since = "0.15.0")
+    default StatusResult<Void> suspend(String dataFlowId) {
+        return terminate(dataFlowId, "suspension");
+    }
 
     /**
      * Terminate the data flow and specifies a reason.


### PR DESCRIPTION
## What this PR changes/adds

Makes the Data Flow deprovision the resources on Transfer Process suspension, they will get re-provisioned on the Transfer Process resuming.

## Why it does that

While going through #5183 I noticed that the Data Flow suspension has the same logic of the Data Flow termination, but, in fact, the suspension is a concept bound to the Transfer Process, the related Data Flow gets always stopped and terminated. That's why it makes no sense to have the `SUSPENDED` status on the Data Flow.
By terminating it directly, the deprovision comes freely, then it's a matter to manage provisioning at the TP restart

## Further notes
- an E2E dedicated coverage will come up with the implementation of #5183, when the EDR token management will be moved in the provisioning phase


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5190

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
