### PR TITLE
feat: participant context aware contracts 

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/build.gradle.kts
+++ b/core/control-plane/control-plane-aggregate-services/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
     implementation(project(":spi:control-plane:control-plane-spi"))
     implementation(project(":spi:control-plane:secrets-spi"))
     implementation(project(":core:common:lib:util-lib"))
+    implementation(project(":spi:common:participant-context-single-spi"))
+
 
     implementation(libs.opentelemetry.instrumentation.annotations)
 

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -68,6 +68,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcess
 import org.eclipse.edc.connector.secret.spi.observe.SecretObservableImpl;
 import org.eclipse.edc.connector.spi.service.SecretService;
 import org.eclipse.edc.participant.spi.ParticipantAgentService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.policy.context.request.spi.RequestCatalogPolicyContext;
 import org.eclipse.edc.policy.context.request.spi.RequestContractNegotiationPolicyContext;
 import org.eclipse.edc.policy.context.request.spi.RequestTransferProcessPolicyContext;
@@ -185,6 +186,9 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Inject
     private TransferTypeParser transferTypeParser;
 
+    @Inject
+    private SingleParticipantContextSupplier participantContextSupplier;
+
     @Override
     public String name() {
         return NAME;
@@ -245,7 +249,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     public ContractNegotiationProtocolService contractNegotiationProtocolService() {
         return new ContractNegotiationProtocolServiceImpl(contractNegotiationStore,
                 transactionContext, contractValidationService, consumerOfferResolver, protocolTokenValidator(), contractNegotiationObservable,
-                monitor, telemetry);
+                monitor, telemetry, participantContextSupplier);
     }
 
     @Provider

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -35,6 +35,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.validation.ValidatedC
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
 import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolTokenValidator;
 import org.eclipse.edc.participant.spi.ParticipantAgent;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.policy.context.request.spi.RequestContractNegotiationPolicyContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
@@ -64,6 +65,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     private final ContractNegotiationObservable observable;
     private final Monitor monitor;
     private final Telemetry telemetry;
+    private final SingleParticipantContextSupplier participantContextSupplier;
 
     public ContractNegotiationProtocolServiceImpl(ContractNegotiationStore store,
                                                   TransactionContext transactionContext,
@@ -71,7 +73,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
                                                   ConsumerOfferResolver consumerOfferResolver,
                                                   ProtocolTokenValidator protocolTokenValidator,
                                                   ContractNegotiationObservable observable,
-                                                  Monitor monitor, Telemetry telemetry) {
+                                                  Monitor monitor, Telemetry telemetry, SingleParticipantContextSupplier participantContextSupplier) {
         this.store = store;
         this.transactionContext = transactionContext;
         this.validationService = validationService;
@@ -80,6 +82,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
         this.observable = observable;
         this.monitor = monitor;
         this.telemetry = telemetry;
+        this.participantContextSupplier = participantContextSupplier;
     }
 
     @Override
@@ -203,7 +206,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
                 .negotiationId(id)
                 .protocol(protocol)
                 .build();
-        
+
         return transactionContext.execute(() -> getNegotiation(id)
                 .compose(contractNegotiation -> verifyRequest(tokenRepresentation, contractNegotiation.getLastContractOffer().getPolicy(), message)
                         .compose(agent -> validateRequest(agent, contractNegotiation)
@@ -233,6 +236,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
                 .protocol(message.getProtocol())
                 .traceContext(telemetry.getCurrentTraceContext())
                 .type(type)
+                .participantContextId(participantContextSupplier.get().getParticipantContextId())
                 .build();
 
         return ServiceResult.success(negotiation);

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -305,8 +305,13 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     @NotNull
     private ServiceResult<ContractNegotiation> agreedAction(ContractAgreementMessage message, ContractNegotiation negotiation) {
         if (negotiation.getType().equals(CONSUMER) && negotiation.canBeAgreedConsumer()) {
+
+            var agreement = message.getContractAgreement().toBuilder()
+                    .participantContextId(negotiation.getParticipantContextId())
+                    .build();
+
             negotiation.protocolMessageReceived(message.getId());
-            negotiation.setContractAgreement(message.getContractAgreement());
+            negotiation.setContractAgreement(agreement);
             negotiation.transitionAgreed();
             update(negotiation);
             observable.invokeForEach(l -> l.agreed(negotiation));

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Con
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.connector.controlplane.services.query.QueryValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.command.CommandHandlerRegistry;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
@@ -83,8 +84,8 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
     }
 
     @Override
-    public ContractNegotiation initiateNegotiation(ContractRequest request) {
-        return transactionContext.execute(() -> consumerManager.initiate(request).getContent());
+    public ContractNegotiation initiateNegotiation(ParticipantContext participantContext, ContractRequest request) {
+        return transactionContext.execute(() -> consumerManager.initiate(participantContext, request).getContent());
     }
 
     @Override

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/asset/AssetEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/asset/AssetEventDispatchTest.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceS
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.spi.ProtocolWebhook;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
@@ -56,6 +57,7 @@ public class AssetEventDispatchTest {
         extension.registerServiceMock(DataPlaneInstanceStore.class, mock());
         extension.registerServiceMock(IdentityService.class, mock());
         extension.registerServiceMock(DataPlaneClientFactory.class, mock());
+        extension.registerServiceMock(SingleParticipantContextSupplier.class, mock());
         extension.setConfiguration(Map.of(
                 "web.http.port", String.valueOf(getFreePort()),
                 "web.http.path", "/api"

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractdefinition/ContractDefinitionEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractdefinition/ContractDefinitionEventDispatchTest.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceS
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.spi.ProtocolWebhook;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
@@ -54,6 +55,7 @@ public class ContractDefinitionEventDispatchTest {
         extension.registerServiceMock(DataPlaneInstanceStore.class, mock(DataPlaneInstanceStore.class));
         extension.registerServiceMock(IdentityService.class, mock());
         extension.registerServiceMock(DataPlaneClientFactory.class, mock());
+        extension.registerServiceMock(SingleParticipantContextSupplier.class, mock());
         extension.setConfiguration(Map.of(
                 "web.http.port", String.valueOf(getFreePort()),
                 "web.http.path", "/api"

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -152,7 +152,12 @@ class ContractNegotiationProtocolServiceImplTest {
         var participantAgent = participantAgent();
         var tokenRepresentation = tokenRepresentation();
 
-        var contractAgreement = mock(ContractAgreement.class);
+        var contractAgreement = ContractAgreement.Builder.newInstance()
+                .providerId("providerId")
+                .consumerId("consumerId")
+                .assetId("assetId")
+                .policy(Policy.Builder.newInstance().build())
+                .build();
         var message = ContractAgreementMessage.Builder.newInstance()
                 .protocol("protocol")
                 .counterPartyAddress("http://any")
@@ -173,8 +178,7 @@ class ContractNegotiationProtocolServiceImplTest {
         verify(store).findById("processId");
         verify(store).findByIdAndLease("processId");
         verify(store).save(argThat(negotiation ->
-                negotiation.getState() == AGREED.code() &&
-                        negotiation.getContractAgreement() == contractAgreement
+                negotiation.getState() == AGREED.code() && negotiation.getContractAgreement().equals(contractAgreement)
         ));
         verify(validationService).validateConfirmed(eq(participantAgent), eq(contractAgreement), any(ContractOffer.class));
         verify(listener).agreed(any());
@@ -481,7 +485,12 @@ class ContractNegotiationProtocolServiceImplTest {
                             .counterPartyAddress("http://any")
                             .consumerPid("consumerPid")
                             .providerPid("providerPid")
-                            .contractAgreement(mock(ContractAgreement.class))
+                            .contractAgreement(ContractAgreement.Builder.newInstance()
+                                    .assetId("assetId")
+                                    .consumerId("consumerId")
+                                    .providerId("providerId")
+                                    .policy(Policy.Builder.newInstance().build())
+                                    .build())
                             .build(), CONSUMER, ACCEPTED),
                     Arguments.of(accepted, ContractNegotiationEventMessage.Builder.newInstance()
                             .type(ContractNegotiationEventMessage.Type.ACCEPTED)

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -35,6 +35,8 @@ import org.eclipse.edc.connector.controlplane.contract.spi.validation.ValidatedC
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
 import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolTokenValidator;
 import org.eclipse.edc.participant.spi.ParticipantAgent;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
@@ -96,7 +98,7 @@ import static org.mockito.Mockito.when;
 class ContractNegotiationProtocolServiceImplTest {
 
     private static final String CONSUMER_ID = "consumer";
-
+    protected final SingleParticipantContextSupplier participantContextSupplier = () -> new ParticipantContext("participantId");
     private final ContractNegotiationStore store = mock();
     private final TransactionContext transactionContext = spy(new NoopTransactionContext());
     private final ContractValidationService validationService = mock();
@@ -110,7 +112,7 @@ class ContractNegotiationProtocolServiceImplTest {
         var observable = new ContractNegotiationObservableImpl();
         observable.registerListener(listener);
         service = new ContractNegotiationProtocolServiceImpl(store, transactionContext, validationService,
-                consumerOfferResolver, protocolTokenValidator, observable, mock(), mock());
+                consumerOfferResolver, protocolTokenValidator, observable, mock(), mock(), participantContextSupplier);
     }
 
     @Test

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionEventDispatchTest.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceS
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.spi.ProtocolWebhook;
 import org.eclipse.edc.spi.event.EventRouter;
@@ -55,6 +56,8 @@ public class PolicyDefinitionEventDispatchTest {
         extension.registerServiceMock(DataPlaneInstanceStore.class, mock());
         extension.registerServiceMock(IdentityService.class, mock());
         extension.registerServiceMock(DataPlaneClientFactory.class, mock());
+        extension.registerServiceMock(SingleParticipantContextSupplier.class, mock());
+
         extension.setConfiguration(Map.of(
                 "web.http.port", String.valueOf(getFreePort()),
                 "web.http.path", "/api")

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/secret/SecretEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/secret/SecretEventDispatchTest.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.secret.spi.event.SecretEvent;
 import org.eclipse.edc.connector.spi.service.SecretService;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.spi.ProtocolWebhook;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
@@ -51,6 +52,7 @@ public class SecretEventDispatchTest {
         extension.registerServiceMock(DataPlaneInstanceStore.class, mock());
         extension.registerServiceMock(IdentityService.class, mock());
         extension.registerServiceMock(DataPlaneClientFactory.class, mock());
+        extension.registerServiceMock(SingleParticipantContextSupplier.class, mock());
         extension.setConfiguration(Map.of(
                 "web.http.port", String.valueOf(getFreePort()),
                 "web.http.path", "/api"

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessEventDispatchTest.java
@@ -40,6 +40,7 @@ import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.participant.spi.ParticipantAgentService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.spi.EdcException;
@@ -98,7 +99,9 @@ public class TransferProcessEventDispatchTest {
             .registerServiceMock(PolicyArchive.class, mock())
             .registerServiceMock(ContractNegotiationStore.class, mock())
             .registerServiceMock(ParticipantAgentService.class, mock())
-            .registerServiceMock(DataPlaneClientFactory.class, mock());
+            .registerServiceMock(DataPlaneClientFactory.class, mock())
+            .registerServiceMock(SingleParticipantContextSupplier.class, mock());
+
 
     private final EventSubscriber eventSubscriber = mock();
 

--- a/core/control-plane/control-plane-contract-manager/build.gradle.kts
+++ b/core/control-plane/control-plane-contract-manager/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
     testImplementation(project(":core:common:junit"))
     testImplementation(project(":core:common:lib:query-lib"))
     testImplementation(project(":core:common:lib:store-lib"))
+    testImplementation(project(":spi:common:participant-context-single-spi"))
+
 //    testImplementation(project(":core:common:lib:policy-engine-lib"))
     testImplementation(libs.awaitility)
 }

--- a/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Con
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.protocol.ContractNegotiationAck;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.statemachine.StateMachineManager;
 
@@ -58,7 +59,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
      */
     @WithSpan
     @Override
-    public StatusResult<ContractNegotiation> initiate(ContractRequest request) {
+    public StatusResult<ContractNegotiation> initiate(ParticipantContext participantContext, ContractRequest request) {
         var id = UUID.randomUUID().toString();
         var negotiation = ContractNegotiation.Builder.newInstance()
                 .id(id)
@@ -67,6 +68,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
                 .counterPartyAddress(request.getCounterPartyAddress())
                 .callbackAddresses(request.getCallbackAddresses())
                 .traceContext(telemetry.getCurrentTraceContext())
+                .participantContextId(participantContext.getParticipantContextId())
                 .type(CONSUMER)
                 .build();
 

--- a/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -147,6 +147,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                             .consumerId(negotiation.getCounterPartyId())
                             .policy(contractPolicy)
                             .assetId(lastOffer.getAssetId())
+                            .participantContextId(negotiation.getParticipantContextId())
                             .build();
                 });
 

--- a/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -29,6 +29,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Con
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.protocol.ContractNegotiationAck;
 import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.spi.EdcException;
@@ -128,7 +129,7 @@ class ConsumerContractNegotiationManagerImplTest {
                         .build()))
                 .build();
 
-        var result = manager.initiate(request);
+        var result = manager.initiate(new ParticipantContext("participantContextId"), request);
 
         assertThat(result.succeeded()).isTrue();
         verify(store).save(argThat(negotiation ->

--- a/core/control-plane/control-plane-core/build.gradle.kts
+++ b/core/control-plane/control-plane-core/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
     implementation(project(":core:common:lib:util-lib"))
     implementation(project(":core:common:lib:policy-engine-lib"))
     implementation(project(":core:common:lib:query-lib"))
+    // TODO remove when refactored the protocol layer #5199
+    implementation(project(":core:common::participant-context-single-core"))
 
     testImplementation(testFixtures(project(":spi:control-plane:asset-spi")))
     testImplementation(testFixtures(project(":spi:control-plane:contract-spi")))

--- a/extensions/control-plane/api/management-api/contract-definition-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/contract-definition-api/build.gradle.kts
@@ -20,7 +20,8 @@ plugins {
 dependencies {
     api(project(":spi:control-plane:control-plane-spi"))
     api(project(":spi:common:transaction-spi"))
-
+    api(project(":spi:common:participant-context-single-spi"))
+    
     implementation(project(":extensions:common:api:lib:management-api-lib"))
     implementation(project(":core:common:lib:api-lib"))
     implementation(project(":core:common:lib:validator-lib"))

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/ContractDefinitionApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/ContractDefinitionApiExtension.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.
 import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.validation.ContractDefinitionValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.contractdefinition.ContractDefinitionService;
 import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
@@ -70,6 +71,9 @@ public class ContractDefinitionApiExtension implements ServiceExtension {
     @Inject
     private JsonLd jsonLd;
 
+    @Inject
+    private SingleParticipantContextSupplier participantContextSupplier;
+
     @Override
     public String name() {
         return NAME;
@@ -85,10 +89,10 @@ public class ContractDefinitionApiExtension implements ServiceExtension {
 
         var managementApiTransformerRegistry = transformerRegistry.forContext("management-api");
 
-        webService.registerResource(ApiContext.MANAGEMENT, new ContractDefinitionApiV3Controller(managementApiTransformerRegistry, service, context.getMonitor(), validatorRegistry));
+        webService.registerResource(ApiContext.MANAGEMENT, new ContractDefinitionApiV3Controller(managementApiTransformerRegistry, service, context.getMonitor(), validatorRegistry, participantContextSupplier));
         webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractDefinitionApiV3Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
 
-        webService.registerResource(ApiContext.MANAGEMENT, new ContractDefinitionApiV4Controller(managementApiTransformerRegistry, service, context.getMonitor(), validatorRegistry));
+        webService.registerResource(ApiContext.MANAGEMENT, new ContractDefinitionApiV4Controller(managementApiTransformerRegistry, service, context.getMonitor(), validatorRegistry, participantContextSupplier));
         webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractDefinitionApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
 
     }

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v3/ContractDefinitionApiV3Controller.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v3/ContractDefinitionApiV3Controller.java
@@ -26,6 +26,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.BaseContractDefinitionApiController;
 import org.eclipse.edc.connector.controlplane.services.spi.contractdefinition.ContractDefinitionService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
@@ -36,8 +37,9 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 @Produces(APPLICATION_JSON)
 @Path("/v3/contractdefinitions")
 public class ContractDefinitionApiV3Controller extends BaseContractDefinitionApiController implements ContractDefinitionApiV3 {
-    public ContractDefinitionApiV3Controller(TypeTransformerRegistry transformerRegistry, ContractDefinitionService service, Monitor monitor, JsonObjectValidatorRegistry validatorRegistry) {
-        super(transformerRegistry, service, monitor, validatorRegistry);
+    public ContractDefinitionApiV3Controller(TypeTransformerRegistry transformerRegistry, ContractDefinitionService service, Monitor monitor,
+                                             JsonObjectValidatorRegistry validatorRegistry, SingleParticipantContextSupplier participantContextSupplier) {
+        super(transformerRegistry, service, monitor, validatorRegistry, participantContextSupplier);
     }
 
     @POST

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v4/ContractDefinitionApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v4/ContractDefinitionApiV4Controller.java
@@ -26,6 +26,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.BaseContractDefinitionApiController;
 import org.eclipse.edc.connector.controlplane.services.spi.contractdefinition.ContractDefinitionService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
@@ -39,8 +40,9 @@ import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 @Produces(APPLICATION_JSON)
 @Path("/v4alpha/contractdefinitions")
 public class ContractDefinitionApiV4Controller extends BaseContractDefinitionApiController implements ContractDefinitionApiV4 {
-    public ContractDefinitionApiV4Controller(TypeTransformerRegistry transformerRegistry, ContractDefinitionService service, Monitor monitor, JsonObjectValidatorRegistry validatorRegistry) {
-        super(transformerRegistry, service, monitor, validatorRegistry);
+    public ContractDefinitionApiV4Controller(TypeTransformerRegistry transformerRegistry, ContractDefinitionService service, Monitor monitor,
+                                             JsonObjectValidatorRegistry validatorRegistry, SingleParticipantContextSupplier participantContextSupplier) {
+        super(transformerRegistry, service, monitor, validatorRegistry, participantContextSupplier);
     }
 
     @POST

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/BaseContractDefinitionApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/BaseContractDefinitionApiControllerTest.java
@@ -23,6 +23,8 @@ import org.eclipse.edc.api.model.IdResponse;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.controlplane.services.spi.contractdefinition.ContractDefinitionService;
 import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
@@ -66,9 +68,10 @@ public abstract class BaseContractDefinitionApiControllerTest extends RestContro
     protected final ContractDefinitionService service = mock();
     protected final TypeTransformerRegistry transformerRegistry = mock();
     protected final JsonObjectValidatorRegistry validatorRegistry = mock();
+    protected final SingleParticipantContextSupplier participantContextSupplier = () -> new ParticipantContext("participantId");
 
     @ParameterizedTest
-    @ValueSource(strings = { "", "{}" })
+    @ValueSource(strings = {"", "{}"})
     void queryAllContractDefinitions(String body) {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(service.search(any())).thenReturn(ServiceResult.success(List.of(createContractDefinition().build())));

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v3/ContractDefinitionApiV3ControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v3/ContractDefinitionApiV3ControllerTest.java
@@ -30,6 +30,6 @@ class ContractDefinitionApiV3ControllerTest extends BaseContractDefinitionApiCon
 
     @Override
     protected Object controller() {
-        return new ContractDefinitionApiV3Controller(transformerRegistry, service, monitor, validatorRegistry);
+        return new ContractDefinitionApiV3Controller(transformerRegistry, service, monitor, validatorRegistry, participantContextSupplier);
     }
 }

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v4/ContractDefinitionApiV4ControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v4/ContractDefinitionApiV4ControllerTest.java
@@ -30,6 +30,6 @@ class ContractDefinitionApiV4ControllerTest extends BaseContractDefinitionApiCon
 
     @Override
     protected Object controller() {
-        return new ContractDefinitionApiV4Controller(transformerRegistry, service, monitor, validatorRegistry);
+        return new ContractDefinitionApiV4Controller(transformerRegistry, service, monitor, validatorRegistry, participantContextSupplier);
     }
 }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 dependencies {
     api(project(":spi:control-plane:control-plane-spi"))
     api(project(":spi:common:transaction-spi"))
+    api(project(":spi:common:participant-context-single-spi"))
 
     implementation(project(":extensions:common:api:lib:management-api-lib"))
     implementation(project(":core:common:lib:api-lib"))

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiController.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.command.Termina
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -45,13 +46,15 @@ public class BaseContractNegotiationApiController {
     protected final TypeTransformerRegistry transformerRegistry;
     protected final Monitor monitor;
     protected final JsonObjectValidatorRegistry validatorRegistry;
+    protected final SingleParticipantContextSupplier participantContextSupplier;
 
     public BaseContractNegotiationApiController(ContractNegotiationService service, TypeTransformerRegistry transformerRegistry,
-                                                Monitor monitor, JsonObjectValidatorRegistry validatorRegistry) {
+                                                Monitor monitor, JsonObjectValidatorRegistry validatorRegistry, SingleParticipantContextSupplier participantContextSupplier) {
         this.service = service;
         this.transformerRegistry = transformerRegistry;
         this.monitor = monitor;
         this.validatorRegistry = validatorRegistry;
+        this.participantContextSupplier = participantContextSupplier;
     }
 
     public JsonArray queryNegotiations(JsonObject querySpecJson) {
@@ -107,7 +110,7 @@ public class BaseContractNegotiationApiController {
         var contractRequest = transformerRegistry.transform(requestObject, ContractRequest.class)
                 .orElseThrow(InvalidRequestException::new);
 
-        var contractNegotiation = service.initiateNegotiation(contractRequest);
+        var contractNegotiation = service.initiateNegotiation(participantContextSupplier.get(), contractRequest);
 
         var responseDto = IdResponse.Builder.newInstance()
                 .id(contractNegotiation.getId())

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiExtension.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation
 import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.validation.TerminateNegotiationValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -69,6 +70,9 @@ public class ContractNegotiationApiExtension implements ServiceExtension {
     @Inject
     private TypeManager typeManager;
 
+    @Inject
+    private SingleParticipantContextSupplier participantContextSupplier;
+
     @Override
     public String name() {
         return NAME;
@@ -90,11 +94,11 @@ public class ContractNegotiationApiExtension implements ServiceExtension {
         validatorRegistry.register(CONTRACT_REQUEST_TYPE, ContractRequestValidator.instance());
         validatorRegistry.register(TERMINATE_NEGOTIATION_TYPE, TerminateNegotiationValidator.instance());
 
-        webService.registerResource(ApiContext.MANAGEMENT, new ContractNegotiationApiV3Controller(service, managementApiTransformerRegistry, monitor, validatorRegistry));
+        webService.registerResource(ApiContext.MANAGEMENT, new ContractNegotiationApiV3Controller(service, managementApiTransformerRegistry, monitor, validatorRegistry, participantContextSupplier));
         webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractNegotiationApiV3Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE));
 
 
-        webService.registerResource(ApiContext.MANAGEMENT, new ContractNegotiationApiV4Controller(service, managementApiTransformerRegistry, monitor, validatorRegistry));
+        webService.registerResource(ApiContext.MANAGEMENT, new ContractNegotiationApiV4Controller(service, managementApiTransformerRegistry, monitor, validatorRegistry, participantContextSupplier));
         webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractNegotiationApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
     }
 }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3Controller.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3Controller.java
@@ -25,6 +25,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.BaseContractNegotiationApiController;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
@@ -35,8 +36,9 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 @Produces(APPLICATION_JSON)
 @Path("/v3/contractnegotiations")
 public class ContractNegotiationApiV3Controller extends BaseContractNegotiationApiController implements ContractNegotiationApiV3 {
-    public ContractNegotiationApiV3Controller(ContractNegotiationService service, TypeTransformerRegistry transformerRegistry, Monitor monitor, JsonObjectValidatorRegistry validatorRegistry) {
-        super(service, transformerRegistry, monitor, validatorRegistry);
+    public ContractNegotiationApiV3Controller(ContractNegotiationService service, TypeTransformerRegistry transformerRegistry, Monitor monitor,
+                                              JsonObjectValidatorRegistry validatorRegistry, SingleParticipantContextSupplier participantContextSupplier) {
+        super(service, transformerRegistry, monitor, validatorRegistry, participantContextSupplier);
     }
 
     @POST

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v4/ContractNegotiationApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v4/ContractNegotiationApiV4Controller.java
@@ -25,6 +25,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.BaseContractNegotiationApiController;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
@@ -39,8 +40,9 @@ import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 @Produces(APPLICATION_JSON)
 @Path("/v4alpha/contractnegotiations")
 public class ContractNegotiationApiV4Controller extends BaseContractNegotiationApiController implements ContractNegotiationApiV4 {
-    public ContractNegotiationApiV4Controller(ContractNegotiationService service, TypeTransformerRegistry transformerRegistry, Monitor monitor, JsonObjectValidatorRegistry validatorRegistry) {
-        super(service, transformerRegistry, monitor, validatorRegistry);
+    public ContractNegotiationApiV4Controller(ContractNegotiationService service, TypeTransformerRegistry transformerRegistry, Monitor monitor,
+                                              JsonObjectValidatorRegistry validatorRegistry, SingleParticipantContextSupplier participantContextSupplier) {
+        super(service, transformerRegistry, monitor, validatorRegistry, participantContextSupplier);
     }
 
     @POST

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
@@ -26,6 +26,8 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Con
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
@@ -69,6 +71,7 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
     protected final ContractNegotiationService service = mock();
     protected final TypeTransformerRegistry transformerRegistry = mock();
     protected final JsonObjectValidatorRegistry validatorRegistry = mock();
+    protected final SingleParticipantContextSupplier participantContextSupplier = () -> new ParticipantContext("participantId");
 
     @Test
     void getAll() {
@@ -340,7 +343,7 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
                         .build()));
 
         when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
-        when(service.initiateNegotiation(any(ContractRequest.class))).thenReturn(contractNegotiation);
+        when(service.initiateNegotiation(any(ParticipantContext.class), any(ContractRequest.class))).thenReturn(contractNegotiation);
 
         when(transformerRegistry.transform(any(IdResponse.class), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
 
@@ -352,7 +355,7 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
                 .statusCode(200)
                 .body(ID, is(contractNegotiation.getId()));
 
-        verify(service).initiateNegotiation(any());
+        verify(service).initiateNegotiation(any(), any());
         verify(transformerRegistry).transform(any(JsonObject.class), eq(ContractRequest.class));
         verify(transformerRegistry).transform(any(IdResponse.class), eq(JsonObject.class));
         verifyNoMoreInteractions(transformerRegistry, service);

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3ControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v3/ContractNegotiationApiV3ControllerTest.java
@@ -25,7 +25,7 @@ class ContractNegotiationApiV3ControllerTest extends BaseContractNegotiationApiC
 
     @Override
     protected Object controller() {
-        return new ContractNegotiationApiV3Controller(service, transformerRegistry, monitor, validatorRegistry);
+        return new ContractNegotiationApiV3Controller(service, transformerRegistry, monitor, validatorRegistry, participantContextSupplier);
     }
 
     protected RequestSpecification baseRequest() {

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v4/ContractNegotiationApiV4ControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v4/ContractNegotiationApiV4ControllerTest.java
@@ -25,7 +25,7 @@ class ContractNegotiationApiV4ControllerTest extends BaseContractNegotiationApiC
 
     @Override
     protected Object controller() {
-        return new ContractNegotiationApiV4Controller(service, transformerRegistry, monitor, validatorRegistry);
+        return new ContractNegotiationApiV4Controller(service, transformerRegistry, monitor, validatorRegistry, participantContextSupplier);
     }
 
     protected RequestSpecification baseRequest() {

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractdefinition/SqlContractDefinitionStore.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractdefinition/SqlContractDefinitionStore.java
@@ -46,12 +46,11 @@ import static java.lang.String.format;
 
 public class SqlContractDefinitionStore extends AbstractSqlStore implements ContractDefinitionStore {
 
-    private final ContractDefinitionStatements statements;
     public static final TypeReference<List<Criterion>> CRITERION_LIST = new TypeReference<>() {
     };
-
     private static final TypeReference<Map<String, Object>> PRIVATE_PROPERTIES_TYPE = new TypeReference<>() {
     };
+    private final ContractDefinitionStatements statements;
 
     public SqlContractDefinitionStore(DataSourceRegistry dataSourceRegistry, String dataSourceName,
                                       TransactionContext transactionContext, ContractDefinitionStatements statements,
@@ -148,6 +147,7 @@ public class SqlContractDefinitionStore extends AbstractSqlStore implements Cont
                 .contractPolicyId(resultSet.getString(statements.getContractPolicyIdColumn()))
                 .assetsSelector(fromJson(resultSet.getString(statements.getAssetsSelectorColumn()), CRITERION_LIST))
                 .privateProperties(fromJson(resultSet.getString(statements.getPrivatePropertiesColumn()), PRIVATE_PROPERTIES_TYPE))
+                .participantContextId(resultSet.getString(statements.getParticipantContextIdColumn()))
                 .build();
     }
 
@@ -159,7 +159,8 @@ public class SqlContractDefinitionStore extends AbstractSqlStore implements Cont
                     definition.getContractPolicyId(),
                     toJson(definition.getAssetsSelector()),
                     definition.getCreatedAt(),
-                    toJson(definition.getPrivateProperties()));
+                    toJson(definition.getPrivateProperties()),
+                    definition.getParticipantContextId());
         });
     }
 

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractdefinition/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractdefinition/schema/BaseSqlDialectStatements.java
@@ -48,6 +48,7 @@ public class BaseSqlDialectStatements implements ContractDefinitionStatements {
                 .jsonColumn(getAssetsSelectorColumn())
                 .column(getCreatedAtColumn())
                 .jsonColumn(getPrivatePropertiesColumn())
+                .column(getParticipantContextIdColumn())
                 .insertInto(getContractDefinitionTable());
     }
 

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractdefinition/schema/ContractDefinitionStatements.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractdefinition/schema/ContractDefinitionStatements.java
@@ -55,6 +55,10 @@ public interface ContractDefinitionStatements extends SqlStatements {
         return "private_properties";
     }
 
+    default String getParticipantContextIdColumn() {
+        return "participant_context_id";
+    }
+
     String getDeleteByIdTemplate();
 
     String getFindByTemplate();

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractdefinition/schema/postgres/ContractDefinitionMapping.java
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractdefinition/schema/postgres/ContractDefinitionMapping.java
@@ -33,5 +33,7 @@ public class ContractDefinitionMapping extends TranslationMapping {
         add("contractPolicy", statements.getContractPolicyIdColumn());
         add("assetsSelector", new JsonFieldTranslator(statements.getAssetsSelectorAlias()));
         add("privateProperties", new JsonFieldTranslator(statements.getPrivatePropertiesColumn()));
+        add("privateProperties", new JsonFieldTranslator(statements.getPrivatePropertiesColumn()));
+        add("participantContextId", statements.getParticipantContextIdColumn());
     }
 }

--- a/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/resources/contract-definition-schema.sql
+++ b/extensions/control-plane/store/sql/contract-definition-store-sql/src/main/resources/contract-definition-schema.sql
@@ -23,5 +23,6 @@ CREATE TABLE IF NOT EXISTS edc_contract_definitions
     contract_policy_id     VARCHAR NOT NULL,
     assets_selector        JSON    NOT NULL,
     private_properties     JSON,
+    participant_context_id VARCHAR NOT NULL,
     PRIMARY KEY (contract_definition_id)
 );

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -150,7 +150,8 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
                         negotiation.getCreatedAt(),
                         negotiation.getUpdatedAt(),
                         negotiation.isPending(),
-                        toJson(negotiation.getProtocolMessages()));
+                        toJson(negotiation.getProtocolMessages()),
+                        negotiation.getParticipantContextId());
 
                 return leaseContext.withConnection(connection).breakLease(negotiation.getId());
             } catch (SQLException e) {
@@ -287,6 +288,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
                 .updatedAt(resultSet.getLong(statements.getUpdatedAtColumn()))
                 .pending(resultSet.getBoolean(statements.getPendingColumn()))
                 .protocolMessages(fromJson(resultSet.getString(statements.getProtocolMessagesColumn()), ProtocolMessages.class))
+                .participantContextId(resultSet.getString(statements.getParticipantContextIdColumn()))
                 .build();
     }
 

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -126,7 +126,8 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
                             contractAgreement.getConsumerId(),
                             contractAgreement.getContractSigningDate(),
                             contractAgreement.getAssetId(),
-                            toJson(contractAgreement.getPolicy())
+                            toJson(contractAgreement.getPolicy()),
+                            contractAgreement.getParticipantContextId()
                     );
                 }
 
@@ -246,6 +247,7 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
                 .assetId(resultSet.getString(statements.getAssetIdColumn()))
                 .contractSigningDate(resultSet.getLong(statements.getSigningDateColumn()))
                 .policy(fromJson(resultSet.getString(statements.getPolicyColumn()), Policy.class))
+                .participantContextId(resultSet.getString(statements.getAgreementParticipantContextIdColumn()))
                 .build();
     }
 

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
@@ -141,6 +141,7 @@ public class BaseSqlDialectStatements implements ContractNegotiationStatements {
                 .column(getSigningDateColumn())
                 .column(getAssetIdColumn())
                 .jsonColumn(getPolicyColumn())
+                .column(getAgreementParticipantContextIdColumn())
                 .upsertInto(getContractAgreementTable(), getContractAgreementIdColumn());
     }
 

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/BaseSqlDialectStatements.java
@@ -91,6 +91,7 @@ public class BaseSqlDialectStatements implements ContractNegotiationStatements {
                 .column(getUpdatedAtColumn())
                 .column(getPendingColumn())
                 .jsonColumn(getProtocolMessagesColumn())
+                .column(getParticipantContextIdColumn())
                 .insertInto(getContractNegotiationTable());
     }
 
@@ -121,6 +122,7 @@ public class BaseSqlDialectStatements implements ContractNegotiationStatements {
                 .column(getUpdatedAtColumn())
                 .column(getPendingColumn())
                 .jsonColumn(getProtocolMessagesColumn())
+                .column(getParticipantContextIdColumn())
                 .upsertInto(getContractNegotiationTable(), getIdColumn());
     }
 

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/ContractNegotiationStatements.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/ContractNegotiationStatements.java
@@ -126,6 +126,10 @@ public interface ContractNegotiationStatements extends StatefulEntityStatements,
         return "participant_context_id";
     }
 
+    default String getAgreementParticipantContextIdColumn() {
+        return "agr_participant_context_id";
+    }
+
     SqlQueryStatement createNegotiationsQuery(QuerySpec querySpec);
 
     SqlQueryStatement createNegotiationNextNotLeaseQuery(QuerySpec querySpec);

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/ContractNegotiationStatements.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/ContractNegotiationStatements.java
@@ -122,6 +122,10 @@ public interface ContractNegotiationStatements extends StatefulEntityStatements,
         return "protocol_messages";
     }
 
+    default String getParticipantContextIdColumn() {
+        return "participant_context_id";
+    }
+
     SqlQueryStatement createNegotiationsQuery(QuerySpec querySpec);
 
     SqlQueryStatement createNegotiationNextNotLeaseQuery(QuerySpec querySpec);

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/postgres/ContractAgreementMapping.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/postgres/ContractAgreementMapping.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.sql.translation.TranslationMapping;
 class ContractAgreementMapping extends TranslationMapping {
 
 
+    public static final String FIELD_PARTICIPANT_CONTEXT_ID = "participantContextId";
     private static final String FIELD_ID = "id";
     private static final String FIELD_PROVIDER_AGENT_ID = "providerId";
     private static final String FIELD_CONSUMER_AGENT_ID = "consumerId";
@@ -40,5 +41,6 @@ class ContractAgreementMapping extends TranslationMapping {
         add(FIELD_CONTRACT_SIGNING_DATE, statements.getSigningDateColumn());
         add(FIELD_ASSET_ID, statements.getAssetIdColumn());
         add(FIELD_POLICY, new JsonFieldTranslator("policy"));
+        add(FIELD_PARTICIPANT_CONTEXT_ID, statements.getAgreementParticipantContextIdColumn());
     }
 }

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/postgres/ContractNegotiationMapping.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/schema/postgres/ContractNegotiationMapping.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.sql.lease.StatefulEntityMapping;
  * onto the corresponding SQL schema (= column names)
  */
 class ContractNegotiationMapping extends StatefulEntityMapping {
+    public static final String FIELD_PARTICIPANT_CONTEXT_ID = "participantContextId";
     private static final String FIELD_CORRELATION_ID = "correlationId";
     private static final String FIELD_COUNTER_PARTY_ID = "counterPartyId";
     private static final String FIELD_COUNTERPARTY_ADDRESS = "counterPartyAddress";
@@ -43,6 +44,7 @@ class ContractNegotiationMapping extends StatefulEntityMapping {
         add(FIELD_PENDING, statements.getPendingColumn());
         add(FIELD_CONTRACT_AGREEMENT, new ContractAgreementMapping(statements));
         add(FIELD_TRACECONTEXT, statements.getTraceContextColumn());
+        add(FIELD_PARTICIPANT_CONTEXT_ID, statements.getParticipantContextIdColumn());
     }
 
 

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/resources/contract-negotiation-schema.sql
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/resources/contract-negotiation-schema.sql
@@ -27,7 +27,8 @@ CREATE TABLE IF NOT EXISTS edc_contract_agreement
     start_date        BIGINT,
     end_date          INTEGER,
     asset_id          VARCHAR NOT NULL,
-    policy            JSON
+    policy            JSON,
+    agr_participant_context_id VARCHAR NOT NULL
 );
 
 

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/resources/contract-negotiation-schema.sql
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/resources/contract-negotiation-schema.sql
@@ -54,7 +54,8 @@ CREATE TABLE IF NOT EXISTS edc_contract_negotiation
     callback_addresses   JSON,
     trace_context        JSON,
     pending              BOOLEAN DEFAULT FALSE,
-    protocol_messages    JSON
+    protocol_messages    JSON,
+    participant_context_id VARCHAR NOT NULL
 );
 
 COMMENT ON COLUMN edc_contract_negotiation.agreement_id IS 'ContractAgreement serialized as JSON';

--- a/spi/control-plane/contract-spi/build.gradle.kts
+++ b/spi/control-plane/contract-spi/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     api(project(":spi:common:participant-spi"))
     api(project(":spi:common:policy-engine-spi"))
     api(project(":spi:control-plane:policy-spi"))
+    api(project(":spi:common:participant-context-spi"))
 
     testImplementation(project(":tests:junit-base"))
     testImplementation(project(":core:common:lib:json-lib"))

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/negotiation/ConsumerContractNegotiationManager.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/negotiation/ConsumerContractNegotiationManager.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.controlplane.contract.spi.negotiation;
 
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.entity.StateEntityManager;
 import org.eclipse.edc.spi.response.StatusResult;
@@ -32,6 +33,6 @@ public interface ConsumerContractNegotiationManager extends StateEntityManager {
     /**
      * Initiates a contract negotiation for the given provider offer. The offer will have been obtained from a previous contract offer request sent to the provider.
      */
-    StatusResult<ContractNegotiation> initiate(ContractRequest request);
+    StatusResult<ContractNegotiation> initiate(ParticipantContext participantContext, ContractRequest request);
 
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/agreement/ContractAgreement.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/agreement/ContractAgreement.java
@@ -18,6 +18,7 @@ package org.eclipse.edc.connector.controlplane.contract.spi.types.agreement;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantResource;
 import org.eclipse.edc.policy.model.Policy;
 import org.jetbrains.annotations.NotNull;
 
@@ -31,7 +32,7 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
  * {@link ContractAgreement} to regulate data transfer between two parties.
  */
 @JsonDeserialize(builder = ContractAgreement.Builder.class)
-public class ContractAgreement {
+public class ContractAgreement implements ParticipantResource {
 
     public static final String CONTRACT_AGREEMENT_TYPE_TERM = "ContractAgreement";
     public static final String CONTRACT_AGREEMENT_TYPE = EDC_NAMESPACE + CONTRACT_AGREEMENT_TYPE_TERM;
@@ -47,6 +48,7 @@ public class ContractAgreement {
     private long contractSigningDate;
     private String assetId;
     private Policy policy;
+    private String participantContextId;
 
     private ContractAgreement() {
     }
@@ -114,6 +116,11 @@ public class ContractAgreement {
     }
 
     @Override
+    public String getParticipantContextId() {
+        return participantContextId;
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hash(id, providerId, consumerId, contractSigningDate, assetId, policy);
     }
@@ -130,6 +137,17 @@ public class ContractAgreement {
         return contractSigningDate == that.contractSigningDate &&
                 Objects.equals(id, that.id) && Objects.equals(providerId, that.providerId) && Objects.equals(consumerId, that.consumerId) &&
                 Objects.equals(assetId, that.assetId) && Objects.equals(policy, that.policy);
+    }
+
+    public Builder toBuilder() {
+        return new Builder()
+                .id(id)
+                .providerId(providerId)
+                .consumerId(consumerId)
+                .contractSigningDate(contractSigningDate)
+                .assetId(assetId)
+                .policy(policy)
+                .participantContextId(participantContextId);
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -173,6 +191,11 @@ public class ContractAgreement {
 
         public Builder policy(Policy policy) {
             this.instance.policy = policy;
+            return this;
+        }
+
+        public Builder participantContextId(String participantContextId) {
+            this.instance.participantContextId = participantContextId;
             return this;
         }
 

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractNegotiation.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractNegotiation.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantResource;
 import org.eclipse.edc.spi.entity.ProtocolMessages;
 import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
@@ -49,7 +50,7 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
  */
 @JsonTypeName("dataspaceconnector:contractnegotiation")
 @JsonDeserialize(builder = ContractNegotiation.Builder.class)
-public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
+public class ContractNegotiation extends StatefulEntity<ContractNegotiation> implements ParticipantResource {
 
     public static final String CONTRACT_NEGOTIATION_TYPE_TERM = "ContractNegotiation";
     public static final String CONTRACT_NEGOTIATION_TYPE = EDC_NAMESPACE + CONTRACT_NEGOTIATION_TYPE_TERM;
@@ -70,6 +71,7 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
     private String counterPartyId;
     private String counterPartyAddress;
     private String protocol;
+    private String participantContextId;
     private Type type = CONSUMER;
     private ContractAgreement contractAgreement;
     private List<ContractOffer> contractOffers = new ArrayList<>();
@@ -410,7 +412,8 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
                 .contractAgreement(contractAgreement)
                 .contractOffers(contractOffers)
                 .callbackAddresses(callbackAddresses)
-                .protocolMessages(protocolMessages);
+                .protocolMessages(protocolMessages)
+                .participantContextId(participantContextId);
         return copy(builder);
     }
 
@@ -473,6 +476,11 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
 
     public boolean currentStateIsOneOf(ContractNegotiationStates... states) {
         return Arrays.stream(states).map(ContractNegotiationStates::code).anyMatch(code -> code == state);
+    }
+
+    @Override
+    public String getParticipantContextId() {
+        return participantContextId;
     }
 
     public enum Type {
@@ -543,6 +551,11 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> {
         public Builder protocolMessages(ProtocolMessages protocolMessages) {
             entity.protocolMessages = protocolMessages;
             return self();
+        }
+
+        public Builder participantContextId(String participantContextId) {
+            entity.participantContextId = participantContextId;
+            return this;
         }
 
         @Override

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/offer/ContractDefinition.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/offer/ContractDefinition.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.connector.controlplane.contract.spi.types.offer;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import org.eclipse.edc.spi.entity.Entity;
+import org.eclipse.edc.participantcontext.spi.types.AbstractParticipantResource;
 import org.eclipse.edc.spi.query.Criterion;
 import org.jetbrains.annotations.NotNull;
 
@@ -42,7 +42,7 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
  * Note that the id must be a UUID.
  */
 @JsonDeserialize(builder = ContractDefinition.Builder.class)
-public class ContractDefinition extends Entity {
+public class ContractDefinition extends AbstractParticipantResource {
 
     public static final String CONTRACT_DEFINITION_TYPE_TERM = "ContractDefinition";
     public static final String CONTRACT_DEFINITION_TYPE = EDC_NAMESPACE + CONTRACT_DEFINITION_TYPE_TERM;
@@ -112,8 +112,18 @@ public class ContractDefinition extends Entity {
                 '}';
     }
 
+    public Builder toBuilder() {
+        return new Builder()
+                .id(id)
+                .accessPolicyId(accessPolicyId)
+                .contractPolicyId(contractPolicyId)
+                .assetsSelector(assetsSelector)
+                .privateProperties(privateProperties)
+                .participantContextId(participantContextId);
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder extends Entity.Builder<ContractDefinition, Builder> {
+    public static class Builder extends AbstractParticipantResource.Builder<ContractDefinition, Builder> {
 
         private Builder() {
             super(new ContractDefinition());

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -705,6 +705,21 @@ public abstract class ContractNegotiationStoreTestBase {
 
             assertThatThrownBy(() -> getContractNegotiationStore().queryAgreements(query)).isInstanceOf(IllegalArgumentException.class);
         }
+
+        @Test
+        void byParticipantContextId() {
+            range(0, 10).mapToObj(i -> "participantContext-" + i).forEach(participantContextId -> {
+                var contractId = ContractOfferId.create(UUID.randomUUID().toString(), "asset").toString();
+                var contractAgreement = createAgreementBuilder(contractId).assetId("asset").participantContextId(participantContextId).build();
+                var negotiation = createNegotiation(UUID.randomUUID().toString(), contractAgreement);
+                getContractNegotiationStore().save(negotiation);
+            });
+
+            var query = QuerySpec.Builder.newInstance().filter(criterion("participantContextId", "=", "participantContext-2")).build();
+            var all = getContractNegotiationStore().queryAgreements(query);
+
+            assertThat(all).hasSize(1);
+        }
     }
 
     @Nested

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/negotiation/store/ContractNegotiationStoreTestBase.java
@@ -56,6 +56,7 @@ import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiat
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.PROVIDER;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantResource.filterByParticipantContextId;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
 import static org.eclipse.edc.spi.query.Criterion.criterion;
 import static org.eclipse.edc.spi.result.StoreFailure.Reason.ALREADY_LEASED;
@@ -212,6 +213,7 @@ public abstract class ContractNegotiationStoreTestBase {
                     .counterPartyAddress("consumer")
                     .counterPartyId("consumerId")
                     .protocol("protocol")
+                    .participantContextId("participantContextId")
                     .build();
 
             getContractNegotiationStore().save(newNegotiation);
@@ -266,6 +268,7 @@ public abstract class ContractNegotiationStoreTestBase {
                     .counterPartyAddress("consumer")
                     .counterPartyId("consumerId")
                     .protocol("protocol")
+                    .participantContextId("participantContextId")
                     .build();
 
             // update should break lease
@@ -543,6 +546,25 @@ public abstract class ContractNegotiationStoreTestBase {
             var result = getContractNegotiationStore().queryNegotiations(query);
 
             assertThat(result).usingRecursiveFieldByFieldElementComparator().containsOnly(negotiation1);
+        }
+
+        @Test
+        void byParticipantContextId() {
+            var negotiation1 = createNegotiationBuilder("negotiation1").participantContextId("customParticipantContext").build();
+            var negotiation2 = createNegotiation("negotiation2");
+
+            getContractNegotiationStore().save(negotiation1);
+            getContractNegotiationStore().save(negotiation2);
+
+            var query = QuerySpec.Builder.newInstance()
+                    .filter(filterByParticipantContextId("customParticipantContext"))
+                    .build();
+            var result = getContractNegotiationStore().queryNegotiations(query);
+
+            assertThat(result).hasSize(1)
+                    .usingRecursiveFieldByFieldElementComparator()
+                    .containsExactly(negotiation1);
+
         }
 
         @Test

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/negotiation/store/TestFunctions.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/negotiation/store/TestFunctions.java
@@ -61,7 +61,8 @@ public class TestFunctions {
                 .consumerId("consumer")
                 .assetId(UUID.randomUUID().toString())
                 .policy(createPolicy())
-                .contractSigningDate(Instant.now().getEpochSecond());
+                .contractSigningDate(Instant.now().getEpochSecond())
+                .participantContextId("participantContextId");
     }
 
     public static ContractNegotiation.Builder createNegotiationBuilder(String id) {

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/negotiation/store/TestFunctions.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/negotiation/store/TestFunctions.java
@@ -75,6 +75,7 @@ public class TestFunctions {
                 .counterPartyId("consumerId")
                 .callbackAddresses(List.of(createCallbackAddress()))
                 .protocol("protocol")
+                .participantContextId("participantContextId")
                 .protocolMessages(new ProtocolMessages());
     }
 

--- a/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/offer/store/TestFunctions.java
+++ b/spi/control-plane/contract-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/contract/spi/testfixtures/offer/store/TestFunctions.java
@@ -32,21 +32,25 @@ public class TestFunctions {
     }
 
     public static ContractDefinition createContractDefinition(String id, String accessPolicyId, String contractPolicyId) {
-        return ContractDefinition.Builder.newInstance()
-                .id(id)
-                .accessPolicyId(accessPolicyId)
-                .contractPolicyId(contractPolicyId)
-                .createdAt(1234)
-                .build();
+        return createContractDefinitionBuilder(id, accessPolicyId, contractPolicyId, Map.of()).build();
     }
 
-    public static ContractDefinition createContractDefinition(String id, String accessPolicyId, String contractPolicyId, Map<String, Object> privateProperties) {
+    public static ContractDefinition.Builder createContractDefinitionBuilder(String id) {
+        return createContractDefinitionBuilder(id, "access", "contract", Map.of());
+    }
+
+    public static ContractDefinition.Builder createContractDefinitionBuilder(String id, String accessPolicyId, String contractPolicyId, Map<String, Object> privateProperties) {
         return ContractDefinition.Builder.newInstance()
                 .id(id)
                 .accessPolicyId(accessPolicyId)
                 .contractPolicyId(contractPolicyId)
                 .privateProperties(privateProperties)
-                .build();
+                .participantContextId("participantContextId")
+                .createdAt(1234);
+    }
+
+    public static ContractDefinition createContractDefinition(String id, String accessPolicyId, String contractPolicyId, Map<String, Object> privateProperties) {
+        return createContractDefinitionBuilder(id, accessPolicyId, contractPolicyId, privateProperties).build();
     }
 
     public static List<ContractDefinition> createContractDefinitions(int count) {

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/contractnegotiation/ContractNegotiationService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/contractnegotiation/ContractNegotiationService.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.Contr
 import org.eclipse.edc.connector.controlplane.contract.spi.types.command.TerminateNegotiationCommand;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 
@@ -61,10 +62,11 @@ public interface ContractNegotiationService {
     /**
      * Initiate contract negotiation
      *
-     * @param request the contract offer request
+     * @param participantContext the participant context
+     * @param request            the contract offer request
      * @return the contract negotiation initiated
      */
-    ContractNegotiation initiateNegotiation(ContractRequest request);
+    ContractNegotiation initiateNegotiation(ParticipantContext participantContext, ContractRequest request);
 
     /**
      * Terminate a contract negotiation

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/CatalogApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/CatalogApiEndToEndTest.java
@@ -253,6 +253,7 @@ public class CatalogApiEndToEndTest {
                     .contractPolicyId(policyId)
                     .accessPolicyId(policyId)
                     .assetsSelector(assetsSelectorCritera)
+                    .participantContextId(PARTICIPANT_CONTEXT_ID)
                     .build();
 
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractAgreementApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractAgreementApiEndToEndTest.java
@@ -111,6 +111,7 @@ public class ContractAgreementApiEndToEndTest {
                             .build()))
                     .protocol("dataspace-protocol-http")
                     .contractOffer(contractOfferBuilder().build())
+                    .participantContextId("participantContextId")
                     .state(FINALIZED.code());
         }
 
@@ -128,6 +129,7 @@ public class ContractAgreementApiEndToEndTest {
                     .consumerId(UUID.randomUUID() + "-consumer")
                     .providerId(UUID.randomUUID() + "-provider")
                     .policy(Policy.Builder.newInstance().assignee("assignee").assigner("assigner").build())
+                    .participantContextId("participantContextId")
                     .build();
         }
     }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractDefinitionApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractDefinitionApiEndToEndTest.java
@@ -251,6 +251,7 @@ public class ContractDefinitionApiEndToEndTest {
                     .id(id)
                     .accessPolicyId(UUID.randomUUID().toString())
                     .contractPolicyId(UUID.randomUUID().toString())
+                    .participantContextId("participantContextId")
                     .assetsSelectorCriterion(criterion("foo", "=", "bar"))
                     .assetsSelectorCriterion(criterion("bar", "=", "baz"));
         }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
@@ -231,6 +231,7 @@ public class ContractNegotiationApiEndToEndTest {
                             .build()))
                     .protocol("dataspace-protocol-http")
                     .state(REQUESTED.code())
+                    .participantContextId("participantContextId")
                     .contractOffer(contractOfferBuilder().build());
         }
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractNegotiationApiEndToEndTest.java
@@ -249,6 +249,7 @@ public class ContractNegotiationApiEndToEndTest {
                     .consumerId(randomUUID() + "-consumer")
                     .providerId(randomUUID() + "-provider")
                     .policy(Policy.Builder.newInstance().build())
+                    .participantContextId("participantContextId")
                     .build();
         }
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TransferProcessApiEndToEndTest.java
@@ -125,6 +125,7 @@ public class TransferProcessApiEndToEndTest {
                     .counterPartyAddress("http://counterparty")
                     .protocol("dataspace-protocol-http")
                     .contractAgreement(createContractAgreement(contractId, assetId).build())
+                    .participantContextId("participantContextId")
                     .build();
             contractNegotiationStore.save(contractNegotiation);
 
@@ -190,7 +191,7 @@ public class TransferProcessApiEndToEndTest {
         }
 
         @ParameterizedTest
-        @ValueSource(strings = { "600", "STARTED" })
+        @ValueSource(strings = {"600", "STARTED"})
         void request_byState(String state, ManagementEndToEndTestContext context, TransferProcessStore store) {
             var actualState = STARTED;
             var tp = createTransferProcessBuilder("test-tp")
@@ -304,6 +305,7 @@ public class TransferProcessApiEndToEndTest {
                     .providerId("providerId")
                     .consumerId("consumerId")
                     .policy(Policy.Builder.newInstance().target(assetId).build())
+                    .participantContextId("participantContextId")
                     .assetId(assetId);
         }
     }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CatalogApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CatalogApiV4EndToEndTest.java
@@ -281,6 +281,7 @@ public class CatalogApiV4EndToEndTest {
                     .contractPolicyId(policyId)
                     .accessPolicyId(policyId)
                     .assetsSelector(assetsSelectorCritera)
+                    .participantContextId("participantContextId")
                     .build();
 
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractAgreementApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractAgreementApiV4EndToEndTest.java
@@ -123,6 +123,7 @@ public class ContractAgreementApiV4EndToEndTest {
                             .build()))
                     .protocol("dataspace-protocol-http")
                     .contractOffer(contractOfferBuilder().build())
+                    .participantContextId("participantContextId")
                     .state(FINALIZED.code());
         }
 
@@ -140,6 +141,7 @@ public class ContractAgreementApiV4EndToEndTest {
                     .consumerId(UUID.randomUUID() + "-consumer")
                     .providerId(UUID.randomUUID() + "-provider")
                     .policy(Policy.Builder.newInstance().assignee("assignee").assigner("assigner").build())
+                    .participantContextId("participantContextId")
                     .build();
         }
     }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractDefinitionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractDefinitionApiV4EndToEndTest.java
@@ -252,6 +252,7 @@ public class ContractDefinitionApiV4EndToEndTest {
                     .id(id)
                     .accessPolicyId(UUID.randomUUID().toString())
                     .contractPolicyId(UUID.randomUUID().toString())
+                    .participantContextId("participantContextId")
                     .assetsSelectorCriterion(criterion("foo", "=", "bar"))
                     .assetsSelectorCriterion(criterion("bar", "=", "baz"));
         }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractNegotiationApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractNegotiationApiV4EndToEndTest.java
@@ -241,6 +241,7 @@ public class ContractNegotiationApiV4EndToEndTest {
                             .build()))
                     .protocol("dataspace-protocol-http")
                     .state(REQUESTED.code())
+                    .participantContextId("participantContextId")
                     .contractOffer(contractOfferBuilder().build());
         }
 
@@ -258,6 +259,7 @@ public class ContractNegotiationApiV4EndToEndTest {
                     .consumerId(randomUUID() + "-consumer")
                     .providerId(randomUUID() + "-provider")
                     .policy(Policy.Builder.newInstance().type(PolicyType.CONTRACT).build())
+                    .participantContextId("participantContextId")
                     .build();
         }
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TransferProcessApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TransferProcessApiV4EndToEndTest.java
@@ -129,6 +129,7 @@ public class TransferProcessApiV4EndToEndTest {
                     .counterPartyId("counterPartyId")
                     .counterPartyAddress("http://counterparty")
                     .protocol("dataspace-protocol-http")
+                    .participantContextId("participantContextId")
                     .contractAgreement(createContractAgreement(contractId, assetId).build())
                     .build();
             contractNegotiationStore.save(contractNegotiation);
@@ -310,6 +311,7 @@ public class TransferProcessApiV4EndToEndTest {
                     .providerId("providerId")
                     .consumerId("consumerId")
                     .policy(Policy.Builder.newInstance().target(assetId).build())
+                    .participantContextId("participantContextId")
                     .assetId(assetId);
         }
     }

--- a/system-tests/protocol-tck/tck-extension/build.gradle.kts
+++ b/system-tests/protocol-tck/tck-extension/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(project(":spi:control-plane:control-plane-spi"))
     implementation(project(":spi:common:web-spi"))
     implementation(project(":spi:data-plane:data-plane-spi"))
+    implementation(project(":spi:common:participant-context-single-spi"))
     implementation(libs.jakarta.rsApi)
     implementation(libs.nimbus.jwt)
 

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TckControllerExtension.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TckControllerExtension.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.tck.dsp.controller;
 
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
@@ -52,6 +53,9 @@ public class TckControllerExtension implements ServiceExtension {
     @Configuration
     private TckWebhookApiConfiguration apiConfiguration;
 
+    @Inject
+    private SingleParticipantContextSupplier participantContextSupplier;
+
     @Override
     public String name() {
         return NAME;
@@ -60,7 +64,7 @@ public class TckControllerExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         mappingRegistry.register(new PortMapping(PROTOCOL, apiConfiguration.port(), apiConfiguration.path()));
-        webService.registerResource(PROTOCOL, new TckWebhookController(monitor, negotiationService, transferProcessService));
+        webService.registerResource(PROTOCOL, new TckWebhookController(monitor, negotiationService, transferProcessService, participantContextSupplier));
     }
 
     @Settings

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TckWebhookController.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/controller/TckWebhookController.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractO
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.Permission;
 import org.eclipse.edc.policy.model.Policy;
@@ -47,12 +48,14 @@ public class TckWebhookController {
     private final Monitor monitor;
     private final ContractNegotiationService negotiationService;
     private final TransferProcessService transferProcessService;
+    private final SingleParticipantContextSupplier participantContextSupplier;
 
 
-    public TckWebhookController(Monitor monitor, ContractNegotiationService negotiationService, TransferProcessService transferProcessService) {
+    public TckWebhookController(Monitor monitor, ContractNegotiationService negotiationService, TransferProcessService transferProcessService, SingleParticipantContextSupplier participantContextSupplier) {
         this.monitor = monitor;
         this.negotiationService = negotiationService;
         this.transferProcessService = transferProcessService;
+        this.participantContextSupplier = participantContextSupplier;
     }
 
     @POST
@@ -73,7 +76,7 @@ public class TckWebhookController {
 
         monitor.debug("Starting contract negotiation for [provider, address, offer]: [%s, %s, %s]".formatted(request.providerId(), request.connectorAddress(), request.offerId()));
 
-        negotiationService.initiateNegotiation(contractRequest);
+        negotiationService.initiateNegotiation(participantContextSupplier.get(), contractRequest);
     }
 
     private Policy defaultPolicy(String providerId) {

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/data/DataAssembly.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/data/DataAssembly.java
@@ -358,12 +358,14 @@ public class DataAssembly {
                         .assetId("ATP0101")
                         .contractSigningDate(System.currentTimeMillis())
                         .policy(Policy.Builder.newInstance().build())
+                        .participantContextId(PARTICIPANT_CONTEXT_ID)
                         .build())
                 .type(ContractNegotiation.Type.PROVIDER)
                 .state(ContractNegotiationStates.FINALIZED.code())
                 .counterPartyId("counterPartyId")
                 .counterPartyAddress("https://test.com")
                 .protocol("test")
+                .participantContextId(PARTICIPANT_CONTEXT_ID)
                 .build();
     }
 

--- a/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/data/DataAssembly.java
+++ b/system-tests/protocol-tck/tck-extension/src/main/java/org/eclipse/edc/tck/dsp/data/DataAssembly.java
@@ -94,6 +94,7 @@ public class DataAssembly {
                 .id(CONTRACT_DEFINITION_ID)
                 .accessPolicyId(POLICY_ID)
                 .contractPolicyId(POLICY_ID)
+                .participantContextId(PARTICIPANT_CONTEXT_ID)
                 .build());
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Adds participant context support for 

- ContractDefinition
- ContractNegotiation
- ContractAgreement

## Why it does that

_Briefly state why the change was necessary._

## Further notes

A temporary solution for the protocol layer has been introduced by injecting a `SingleParticipantContextSupplier` 
into the `ContractNegotiationProtocolServiceImpl` for associating a contract negotiation with `ParticipantContext`
This will be removed once #5199  is implemented.


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Relates #5197 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
