### PR TITLE
feat: avoid explicit exclusion when control-plane and data-plane deployed together

### DIFF
--- a/extensions/common/crypto/lib/jws2020-lib/build.gradle.kts
+++ b/extensions/common/crypto/lib/jws2020-lib/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     runtimeOnly(libs.tink)
     implementation(libs.jakarta.json.api)
 
-    api("com.apicatalog:iron-verifiable-credentials:0.14.0") {
+    api(libs.iron.vc) {
         exclude("com.github.multiformats")
     }
 

--- a/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorClientExtension.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorClientExtension.java
@@ -16,12 +16,14 @@ package org.eclipse.edc.connector.dataplane.selector;
 
 import jakarta.json.Json;
 import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
+import org.eclipse.edc.connector.dataplane.selector.spi.manager.DataPlaneSelectorManager;
 import org.eclipse.edc.http.spi.ControlApiHttpClient;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -32,28 +34,30 @@ import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToDataAddressTrans
 import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToDataPlaneInstanceTransformer;
 import org.eclipse.edc.transform.transformer.edc.to.JsonValueToGenericTypeTransformer;
 
+import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
 @Extension(DataPlaneSelectorClientExtension.NAME)
+@Provides(DataPlaneSelectorService.class)
 public class DataPlaneSelectorClientExtension implements ServiceExtension {
 
     public static final String NAME = "DataPlane Selector client";
+    private static final String EDC_DPF_SELECTOR_URL = "edc.dpf.selector.url";
 
-    @Setting(description = "DataPlane selector api URL", key = "edc.dpf.selector.url")
+    @Setting(description = "DataPlane selector api URL", key = EDC_DPF_SELECTOR_URL, required = false)
     private String selectorApiUrl;
 
     @Inject
     private ControlApiHttpClient httpClient;
-
     @Inject
     private TypeManager typeManager;
-
     @Inject
     private TypeTransformerRegistry typeTransformerRegistry;
-
     @Inject
     private JsonLd jsonLd;
+    @Inject(required = false)
+    private DataPlaneSelectorManager dataPlaneSelectorManager;
 
     @Override
     public String name() {
@@ -62,17 +66,24 @@ public class DataPlaneSelectorClientExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
+        if (dataPlaneSelectorManager != null) {
+            return;
+        }
+
+        if (selectorApiUrl == null || selectorApiUrl.isBlank()) {
+            throw new EdcException(format("No setting found for key " + EDC_DPF_SELECTOR_URL));
+        }
+
         var builderFactory = Json.createBuilderFactory(emptyMap());
         typeTransformerRegistry.register(new JsonObjectFromDataPlaneInstanceTransformer(builderFactory, typeManager, JSON_LD));
         typeTransformerRegistry.register(new JsonObjectFromDataAddressTransformer(builderFactory, typeManager, JSON_LD));
         typeTransformerRegistry.register(new JsonObjectToDataPlaneInstanceTransformer());
         typeTransformerRegistry.register(new JsonObjectToDataAddressTransformer());
         typeTransformerRegistry.register(new JsonValueToGenericTypeTransformer(typeManager, JSON_LD));
+
+        var dataPlaneSelectorService = new RemoteDataPlaneSelectorService(httpClient, this.selectorApiUrl, typeManager, JSON_LD,
+                typeTransformerRegistry, jsonLd);
+        context.registerService(DataPlaneSelectorService.class, dataPlaneSelectorService);
     }
 
-    @Provider
-    public DataPlaneSelectorService dataPlaneSelectorService(ServiceExtensionContext context) {
-        return new RemoteDataPlaneSelectorService(httpClient, selectorApiUrl, typeManager, JSON_LD, typeTransformerRegistry,
-                jsonLd);
-    }
 }

--- a/system-tests/dsp-compatibility-tests/connector-under-test/build.gradle.kts
+++ b/system-tests/dsp-compatibility-tests/connector-under-test/build.gradle.kts
@@ -18,9 +18,7 @@ plugins {
 
 dependencies {
     api(project(":dist:bom:controlplane-base-bom"))
-    api(project(":dist:bom:dataplane-base-bom")) {
-        exclude(module = "data-plane-selector-client")
-    }
+    api(project(":dist:bom:dataplane-base-bom"))
     api(project(":data-protocols:dsp:dsp-2025"))
     api(project(":system-tests:protocol-tck:tck-extension"))
     runtimeOnly(libs.parsson)

--- a/system-tests/e2e-transfer-test/data-plane/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/data-plane/build.gradle.kts
@@ -17,10 +17,7 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":dist:bom:dataplane-base-bom")) {
-        exclude(module = "data-plane-selector-client")
-    }
-
+    implementation(project(":dist:bom:dataplane-base-bom"))
     implementation(project(":extensions:data-plane:data-plane-kafka"))
 }
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
@@ -501,7 +501,6 @@ class TransferPullEndToEndTest {
     @EndToEndTest
     class EmbeddedDataPlane extends Tests {
 
-
         @RegisterExtension
         static final RuntimeExtension CONSUMER_CONTROL_PLANE = new RuntimePerClassExtension(
                 Runtimes.IN_MEMORY_CONTROL_PLANE_EMBEDDED_DATA_PLANE.create("consumer-control-plane")


### PR DESCRIPTION
## What this PR changes/adds

Register `RemoteDataPlaneSelectorService` only if the data plane selector is not embedded in the current runtime.

## Why it does that

Avoid annoying exclusion of `data-plane-selector-client` when `control-plane` and `data-plane` are deployed in the same runtime

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
