### PR TITLE
feat: participant context support on DSP layer

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/build.gradle.kts
+++ b/core/control-plane/control-plane-aggregate-services/build.gradle.kts
@@ -24,8 +24,6 @@ dependencies {
     implementation(project(":spi:control-plane:control-plane-spi"))
     implementation(project(":spi:control-plane:secrets-spi"))
     implementation(project(":core:common:lib:util-lib"))
-    implementation(project(":spi:common:participant-context-single-spi"))
-
 
     implementation(libs.opentelemetry.instrumentation.annotations)
 

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -68,7 +68,6 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcess
 import org.eclipse.edc.connector.secret.spi.observe.SecretObservableImpl;
 import org.eclipse.edc.connector.spi.service.SecretService;
 import org.eclipse.edc.participant.spi.ParticipantAgentService;
-import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.policy.context.request.spi.RequestCatalogPolicyContext;
 import org.eclipse.edc.policy.context.request.spi.RequestContractNegotiationPolicyContext;
 import org.eclipse.edc.policy.context.request.spi.RequestTransferProcessPolicyContext;
@@ -186,9 +185,6 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Inject
     private TransferTypeParser transferTypeParser;
 
-    @Inject
-    private SingleParticipantContextSupplier participantContextSupplier;
-
     @Override
     public String name() {
         return NAME;
@@ -249,7 +245,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     public ContractNegotiationProtocolService contractNegotiationProtocolService() {
         return new ContractNegotiationProtocolServiceImpl(contractNegotiationStore,
                 transactionContext, contractValidationService, consumerOfferResolver, protocolTokenValidator(), contractNegotiationObservable,
-                monitor, telemetry, participantContextSupplier);
+                monitor, telemetry);
     }
 
     @Provider
@@ -271,7 +267,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     public TransferProcessProtocolService transferProcessProtocolService() {
         return new TransferProcessProtocolServiceImpl(transferProcessStore, transactionContext, contractNegotiationStore,
                 contractValidationService, protocolTokenValidator(), dataAddressValidator, transferProcessObservable, clock,
-                monitor, telemetry, participantContextSupplier);
+                monitor, telemetry);
     }
 
     @Provider

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogProtocolServiceImpl.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequestMessage;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DatasetResolver;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
 import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolTokenValidator;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.context.request.spi.RequestCatalogPolicyContext;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
@@ -56,7 +57,7 @@ public class CatalogProtocolServiceImpl implements CatalogProtocolService {
 
     @Override
     @NotNull
-    public ServiceResult<Catalog> getCatalog(CatalogRequestMessage message, TokenRepresentation tokenRepresentation) {
+    public ServiceResult<Catalog> getCatalog(ParticipantContext participantContext, CatalogRequestMessage message, TokenRepresentation tokenRepresentation) {
         return transactionContext.execute(() -> protocolTokenValidator.verify(tokenRepresentation, RequestCatalogPolicyContext::new, message)
                 .map(agent -> {
                     try (var datasets = datasetResolver.query(agent, message.getQuerySpec(), message.getProtocol())) {
@@ -73,7 +74,7 @@ public class CatalogProtocolServiceImpl implements CatalogProtocolService {
     }
 
     @Override
-    public @NotNull ServiceResult<Dataset> getDataset(String datasetId, TokenRepresentation tokenRepresentation, String protocol) {
+    public @NotNull ServiceResult<Dataset> getDataset(ParticipantContext participantContext, String datasetId, TokenRepresentation tokenRepresentation, String protocol) {
         var message = DatasetRequestMessage.Builder.newInstance()
                 .protocol(protocol)
                 .datasetId(datasetId)

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/asset/AssetEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/asset/AssetEventDispatchTest.java
@@ -24,7 +24,6 @@ import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceS
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
-import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.spi.ProtocolWebhook;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
@@ -57,7 +56,6 @@ public class AssetEventDispatchTest {
         extension.registerServiceMock(DataPlaneInstanceStore.class, mock());
         extension.registerServiceMock(IdentityService.class, mock());
         extension.registerServiceMock(DataPlaneClientFactory.class, mock());
-        extension.registerServiceMock(SingleParticipantContextSupplier.class, mock());
         extension.setConfiguration(Map.of(
                 "web.http.port", String.valueOf(getFreePort()),
                 "web.http.path", "/api"

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractdefinition/ContractDefinitionEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractdefinition/ContractDefinitionEventDispatchTest.java
@@ -24,7 +24,6 @@ import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceS
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
-import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.spi.ProtocolWebhook;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
@@ -55,7 +54,6 @@ public class ContractDefinitionEventDispatchTest {
         extension.registerServiceMock(DataPlaneInstanceStore.class, mock(DataPlaneInstanceStore.class));
         extension.registerServiceMock(IdentityService.class, mock());
         extension.registerServiceMock(DataPlaneClientFactory.class, mock());
-        extension.registerServiceMock(SingleParticipantContextSupplier.class, mock());
         extension.setConfiguration(Map.of(
                 "web.http.port", String.valueOf(getFreePort()),
                 "web.http.path", "/api"

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -34,7 +34,6 @@ import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceS
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
-import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
@@ -74,7 +73,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(RuntimePerMethodExtension.class)
 class ContractNegotiationEventDispatchTest {
     private static final String CONSUMER = "consumer";
-    protected final SingleParticipantContextSupplier participantContextSupplier = () -> new ParticipantContext("participantId");
     private final EventSubscriber eventSubscriber = mock();
     private final IdentityService identityService = mock();
     private final ClaimToken token = ClaimToken.Builder.newInstance().claim("client_id", CONSUMER).build();
@@ -94,7 +92,6 @@ class ContractNegotiationEventDispatchTest {
         extension.registerServiceMock(DataPlaneInstanceStore.class, mock());
         extension.registerServiceMock(IdentityService.class, identityService);
         extension.registerServiceMock(DataPlaneClientFactory.class, mock());
-        extension.registerServiceMock(SingleParticipantContextSupplier.class, participantContextSupplier);
 
         when(dataspaceProfileContextRegistry.getWebhook(any())).thenReturn(() -> "http://callback.address");
         when(dataspaceProfileContextRegistry.getIdExtractionFunction(any())).thenReturn(ct -> CONSUMER);
@@ -124,7 +121,7 @@ class ContractNegotiationEventDispatchTest {
         policyDefinitionStore.create(PolicyDefinition.Builder.newInstance().id("policyId").policy(policy).build());
         assetIndex.create(Asset.Builder.newInstance().id("assetId").dataAddress(DataAddress.Builder.newInstance().type("any").build()).build());
 
-        service.notifyRequested(createContractOfferRequest(policy, "assetId"), tokenRepresentation);
+        service.notifyRequested(new ParticipantContext("participantContextId"), createContractOfferRequest(policy, "assetId"), tokenRepresentation);
 
         await().untilAsserted(() -> {
             verify(eventSubscriber).on(argThat(isEnvelopeOf(ContractNegotiationRequested.class)));

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionEventDispatchTest.java
@@ -25,7 +25,6 @@ import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceS
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
-import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.spi.ProtocolWebhook;
 import org.eclipse.edc.spi.event.EventRouter;
@@ -56,7 +55,6 @@ public class PolicyDefinitionEventDispatchTest {
         extension.registerServiceMock(DataPlaneInstanceStore.class, mock());
         extension.registerServiceMock(IdentityService.class, mock());
         extension.registerServiceMock(DataPlaneClientFactory.class, mock());
-        extension.registerServiceMock(SingleParticipantContextSupplier.class, mock());
 
         extension.setConfiguration(Map.of(
                 "web.http.port", String.valueOf(getFreePort()),

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/secret/SecretEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/secret/SecretEventDispatchTest.java
@@ -22,7 +22,6 @@ import org.eclipse.edc.connector.secret.spi.event.SecretEvent;
 import org.eclipse.edc.connector.spi.service.SecretService;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
-import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.spi.ProtocolWebhook;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
@@ -52,7 +51,6 @@ public class SecretEventDispatchTest {
         extension.registerServiceMock(DataPlaneInstanceStore.class, mock());
         extension.registerServiceMock(IdentityService.class, mock());
         extension.registerServiceMock(DataPlaneClientFactory.class, mock());
-        extension.registerServiceMock(SingleParticipantContextSupplier.class, mock());
         extension.setConfiguration(Map.of(
                 "web.http.port", String.valueOf(getFreePort()),
                 "web.http.path", "/api"

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessEventDispatchTest.java
@@ -40,7 +40,6 @@ import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.participant.spi.ParticipantAgentService;
-import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
@@ -100,8 +99,7 @@ public class TransferProcessEventDispatchTest {
             .registerServiceMock(PolicyArchive.class, mock())
             .registerServiceMock(ContractNegotiationStore.class, mock())
             .registerServiceMock(ParticipantAgentService.class, mock())
-            .registerServiceMock(DataPlaneClientFactory.class, mock())
-            .registerServiceMock(SingleParticipantContextSupplier.class, mock());
+            .registerServiceMock(DataPlaneClientFactory.class, mock());
 
 
     private final EventSubscriber eventSubscriber = mock();
@@ -162,7 +160,7 @@ public class TransferProcessEventDispatchTest {
                 .dataAddress(dataAddress)
                 .build();
 
-        var startedResult = protocolService.notifyStarted(startMessage, tokenRepresentation);
+        var startedResult = protocolService.notifyStarted(new ParticipantContext("participantContextId"), startMessage, tokenRepresentation);
 
         assertThat(startedResult).isSucceeded();
         await().atMost(TIMEOUT).untilAsserted(() -> {

--- a/core/control-plane/control-plane-contract-manager/build.gradle.kts
+++ b/core/control-plane/control-plane-contract-manager/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     testImplementation(project(":core:common:junit"))
     testImplementation(project(":core:common:lib:query-lib"))
     testImplementation(project(":core:common:lib:store-lib"))
-    testImplementation(project(":spi:common:participant-context-single-spi"))
 
 //    testImplementation(project(":core:common:lib:policy-engine-lib"))
     testImplementation(libs.awaitility)

--- a/core/control-plane/control-plane-core/build.gradle.kts
+++ b/core/control-plane/control-plane-core/build.gradle.kts
@@ -33,8 +33,6 @@ dependencies {
     implementation(project(":core:common:lib:util-lib"))
     implementation(project(":core:common:lib:policy-engine-lib"))
     implementation(project(":core:common:lib:query-lib"))
-    // TODO remove when refactored the protocol layer #5199
-    implementation(project(":core:common::participant-context-single-core"))
 
     testImplementation(testFixtures(project(":spi:control-plane:asset-spi")))
     testImplementation(testFixtures(project(":spi:control-plane:contract-spi")))

--- a/data-protocols/dsp/dsp-08/dsp-catalog-08/dsp-catalog-http-api-08/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/DspCatalogApiV08Extension.java
+++ b/data-protocols/dsp/dsp-08/dsp-catalog-08/dsp-catalog-http-api-08/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/DspCatalogApiV08Extension.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DataServiceRegistry;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
 import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.catalog.http.api.controller.DspCatalogApiController08;
 import org.eclipse.edc.protocol.dsp.catalog.http.api.decorator.Base64continuationTokenSerDes;
 import org.eclipse.edc.protocol.dsp.catalog.http.api.decorator.ContinuationTokenManagerImpl;
@@ -76,6 +77,9 @@ public class DspCatalogApiV08Extension implements ServiceExtension {
     @Inject
     private JsonLd jsonLd;
 
+    @Inject
+    private SingleParticipantContextSupplier participantContextSupplier;
+
     @Override
     public String name() {
         return NAME;
@@ -85,7 +89,7 @@ public class DspCatalogApiV08Extension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         registerValidators();
 
-        webService.registerResource(ApiContext.PROTOCOL, new DspCatalogApiController08(service, dspRequestHandler, continuationTokenManager(monitor)));
+        webService.registerResource(ApiContext.PROTOCOL, new DspCatalogApiController08(service, dspRequestHandler, continuationTokenManager(monitor), participantContextSupplier));
         webService.registerDynamicResource(ApiContext.PROTOCOL, DspCatalogApiController08.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, DSP_SCOPE_V_08));
     }
 

--- a/data-protocols/dsp/dsp-08/dsp-catalog-08/dsp-catalog-http-api-08/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController08.java
+++ b/data-protocols/dsp/dsp-08/dsp-catalog-08/dsp-catalog-http-api-08/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController08.java
@@ -18,6 +18,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 
@@ -34,8 +35,8 @@ import static org.eclipse.edc.protocol.dsp.spi.type.Dsp08Constants.DSP_NAMESPACE
 @Path(BASE_PATH)
 public class DspCatalogApiController08 extends BaseDspCatalogApiController {
 
-    public DspCatalogApiController08(CatalogProtocolService service, DspRequestHandler dspRequestHandler, ContinuationTokenManager continuationTokenManager) {
-        super(service, dspRequestHandler, continuationTokenManager, DATASPACE_PROTOCOL_HTTP, DSP_NAMESPACE_V_08);
+    public DspCatalogApiController08(CatalogProtocolService service, DspRequestHandler dspRequestHandler, ContinuationTokenManager continuationTokenManager, SingleParticipantContextSupplier participantContextSupplier) {
+        super(service, dspRequestHandler, continuationTokenManager, participantContextSupplier, DATASPACE_PROTOCOL_HTTP, DSP_NAMESPACE_V_08);
     }
 
 }

--- a/data-protocols/dsp/dsp-08/dsp-catalog-08/dsp-catalog-http-api-08/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController08Test.java
+++ b/data-protocols/dsp/dsp-08/dsp-catalog-08/dsp-catalog-http-api-08/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController08Test.java
@@ -35,6 +35,6 @@ class DspCatalogApiController08Test extends DspCatalogApiControllerTestBase {
 
     @Override
     protected Object controller() {
-        return new DspCatalogApiController08(service, dspRequestHandler, continuationTokenManager);
+        return new DspCatalogApiController08(service, dspRequestHandler, continuationTokenManager, participantContextSupplier);
     }
 }

--- a/data-protocols/dsp/dsp-08/dsp-negotiation-08/dsp-negotiation-http-api-08/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/DspNegotiationApiV08Extension.java
+++ b/data-protocols/dsp/dsp-08/dsp-negotiation-08/dsp-negotiation-http-api-08/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/DspNegotiationApiV08Extension.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.protocol.dsp.negotiation.http.api;
 
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
 import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.negotiation.http.api.controller.DspNegotiationApiController08;
 import org.eclipse.edc.protocol.dsp.negotiation.validation.ContractAgreementMessageValidator;
@@ -66,6 +67,9 @@ public class DspNegotiationApiV08Extension implements ServiceExtension {
     @Inject
     private TypeManager typeManager;
 
+    @Inject
+    private SingleParticipantContextSupplier participantContextSupplier;
+
     @Override
     public String name() {
         return NAME;
@@ -75,7 +79,7 @@ public class DspNegotiationApiV08Extension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         registerValidators();
 
-        webService.registerResource(ApiContext.PROTOCOL, new DspNegotiationApiController08(protocolService, dspRequestHandler));
+        webService.registerResource(ApiContext.PROTOCOL, new DspNegotiationApiController08(protocolService, dspRequestHandler, participantContextSupplier));
         webService.registerDynamicResource(ApiContext.PROTOCOL, DspNegotiationApiController08.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, DSP_SCOPE_V_08));
     }
 

--- a/data-protocols/dsp/dsp-08/dsp-negotiation-08/dsp-negotiation-http-api-08/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController08.java
+++ b/data-protocols/dsp/dsp-08/dsp-negotiation-08/dsp-negotiation-http-api-08/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController08.java
@@ -19,6 +19,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 
 import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
@@ -36,9 +37,9 @@ public class DspNegotiationApiController08 extends BaseDspNegotiationApiControll
 
 
     public DspNegotiationApiController08(ContractNegotiationProtocolService protocolService,
-                                         DspRequestHandler dspRequestHandler) {
+                                         DspRequestHandler dspRequestHandler, SingleParticipantContextSupplier participantContextSupplier) {
 
-        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP, DSP_NAMESPACE_V_08);
+        super(protocolService, dspRequestHandler, participantContextSupplier, DATASPACE_PROTOCOL_HTTP, DSP_NAMESPACE_V_08);
     }
 
 }

--- a/data-protocols/dsp/dsp-08/dsp-negotiation-08/dsp-negotiation-http-api-08/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController08Test.java
+++ b/data-protocols/dsp/dsp-08/dsp-negotiation-08/dsp-negotiation-http-api-08/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController08Test.java
@@ -35,6 +35,6 @@ class DspNegotiationApiController08Test extends DspNegotiationApiControllerTestB
 
     @Override
     protected Object controller() {
-        return new DspNegotiationApiController08(protocolService, dspRequestHandler);
+        return new DspNegotiationApiController08(protocolService, dspRequestHandler, participantContextSupplier);
     }
 }

--- a/data-protocols/dsp/dsp-08/dsp-transfer-process-08/dsp-transfer-process-http-api-08/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/DspTransferProcessApiV08Extension.java
+++ b/data-protocols/dsp/dsp-08/dsp-transfer-process-08/dsp-transfer-process-http-api-08/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/DspTransferProcessApiV08Extension.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.protocol.dsp.transferprocess.http.api;
 
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessProtocolService;
 import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.transferprocess.http.api.controller.DspTransferProcessApiController08;
 import org.eclipse.edc.protocol.dsp.transferprocess.validation.TransferCompletionMessageValidator;
@@ -63,11 +64,14 @@ public class DspTransferProcessApiV08Extension implements ServiceExtension {
     @Inject
     private TypeManager typeManager;
 
+    @Inject
+    private SingleParticipantContextSupplier participantContextSupplier;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
         registerValidators();
 
-        webService.registerResource(ApiContext.PROTOCOL, new DspTransferProcessApiController08(transferProcessProtocolService, dspRequestHandler));
+        webService.registerResource(ApiContext.PROTOCOL, new DspTransferProcessApiController08(transferProcessProtocolService, dspRequestHandler, participantContextSupplier));
         webService.registerDynamicResource(ApiContext.PROTOCOL, DspTransferProcessApiController08.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, DSP_SCOPE_V_08));
     }
 

--- a/data-protocols/dsp/dsp-08/dsp-transfer-process-08/dsp-transfer-process-http-api-08/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController08.java
+++ b/data-protocols/dsp/dsp-08/dsp-transfer-process-08/dsp-transfer-process-http-api-08/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController08.java
@@ -19,6 +19,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessProtocolService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 
 import static org.eclipse.edc.protocol.dsp.http.spi.types.HttpMessageProtocol.DATASPACE_PROTOCOL_HTTP;
@@ -34,8 +35,8 @@ import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProc
 @Path(BASE_PATH)
 public class DspTransferProcessApiController08 extends BaseDspTransferProcessApiController {
 
-    public DspTransferProcessApiController08(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler) {
-        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP, DSP_NAMESPACE_V_08);
+    public DspTransferProcessApiController08(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler, SingleParticipantContextSupplier participantContextSupplier) {
+        super(protocolService, dspRequestHandler, participantContextSupplier, DATASPACE_PROTOCOL_HTTP, DSP_NAMESPACE_V_08);
     }
 
 }

--- a/data-protocols/dsp/dsp-08/dsp-transfer-process-08/dsp-transfer-process-http-api-08/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController08Test.java
+++ b/data-protocols/dsp/dsp-08/dsp-transfer-process-08/dsp-transfer-process-http-api-08/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController08Test.java
@@ -35,6 +35,6 @@ class DspTransferProcessApiController08Test extends DspTransferProcessApiControl
 
     @Override
     protected Object controller() {
-        return new DspTransferProcessApiController08(protocolService, dspRequestHandler);
+        return new DspTransferProcessApiController08(protocolService, dspRequestHandler, participantContextSupplier);
     }
 }

--- a/data-protocols/dsp/dsp-2024/dsp-catalog-2024/dsp-catalog-http-api-2024/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/DspCatalogApiV2024Extension.java
+++ b/data-protocols/dsp/dsp-2024/dsp-catalog-2024/dsp-catalog-http-api-2024/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/DspCatalogApiV2024Extension.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DataServiceRegistry;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
 import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.catalog.http.api.controller.DspCatalogApiController20241;
 import org.eclipse.edc.protocol.dsp.catalog.http.api.decorator.Base64continuationTokenSerDes;
 import org.eclipse.edc.protocol.dsp.catalog.http.api.decorator.ContinuationTokenManagerImpl;
@@ -77,6 +78,9 @@ public class DspCatalogApiV2024Extension implements ServiceExtension {
     @Inject
     private JsonLd jsonLd;
 
+    @Inject
+    private SingleParticipantContextSupplier participantContextSupplier;
+
     @Override
     public String name() {
         return NAME;
@@ -86,7 +90,7 @@ public class DspCatalogApiV2024Extension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         registerValidators();
 
-        webService.registerResource(ApiContext.PROTOCOL, new DspCatalogApiController20241(service, dspRequestHandler, continuationTokenManager(monitor)));
+        webService.registerResource(ApiContext.PROTOCOL, new DspCatalogApiController20241(service, dspRequestHandler, continuationTokenManager(monitor), participantContextSupplier));
         webService.registerDynamicResource(ApiContext.PROTOCOL, DspCatalogApiController20241.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, DSP_SCOPE_V_2024_1));
     }
 

--- a/data-protocols/dsp/dsp-2024/dsp-catalog-2024/dsp-catalog-http-api-2024/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController20241.java
+++ b/data-protocols/dsp/dsp-2024/dsp-catalog-2024/dsp-catalog-http-api-2024/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController20241.java
@@ -18,6 +18,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 
@@ -36,7 +37,7 @@ import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2024Constants.V_2024_1_PA
 public class DspCatalogApiController20241 extends BaseDspCatalogApiController {
 
     public DspCatalogApiController20241(CatalogProtocolService service, DspRequestHandler dspRequestHandler,
-                                        ContinuationTokenManager responseDecorator) {
-        super(service, dspRequestHandler, responseDecorator, DATASPACE_PROTOCOL_HTTP_V_2024_1, DSP_NAMESPACE_V_2024_1);
+                                        ContinuationTokenManager responseDecorator, SingleParticipantContextSupplier participantContextSupplier) {
+        super(service, dspRequestHandler, responseDecorator, participantContextSupplier, DATASPACE_PROTOCOL_HTTP_V_2024_1, DSP_NAMESPACE_V_2024_1);
     }
 }

--- a/data-protocols/dsp/dsp-2024/dsp-catalog-2024/dsp-catalog-http-api-2024/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController20241Test.java
+++ b/data-protocols/dsp/dsp-2024/dsp-catalog-2024/dsp-catalog-http-api-2024/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiController20241Test.java
@@ -36,6 +36,6 @@ class DspCatalogApiController20241Test extends DspCatalogApiControllerTestBase {
 
     @Override
     protected Object controller() {
-        return new DspCatalogApiController20241(service, dspRequestHandler, continuationTokenManager);
+        return new DspCatalogApiController20241(service, dspRequestHandler, continuationTokenManager, participantContextSupplier);
     }
 }

--- a/data-protocols/dsp/dsp-2024/dsp-negotiation-2024/dsp-negotiation-http-api-2024/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/DspNegotiationApiV2024Extension.java
+++ b/data-protocols/dsp/dsp-2024/dsp-negotiation-2024/dsp-negotiation-http-api-2024/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/DspNegotiationApiV2024Extension.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.protocol.dsp.negotiation.http.api;
 
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
 import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.negotiation.http.api.controller.DspNegotiationApiController20241;
 import org.eclipse.edc.protocol.dsp.negotiation.validation.ContractAgreementMessageValidator;
@@ -71,6 +72,9 @@ public class DspNegotiationApiV2024Extension implements ServiceExtension {
     @Inject
     private TypeManager typeManager;
 
+    @Inject
+    private SingleParticipantContextSupplier participantContextSupplier;
+
     @Override
     public String name() {
         return NAME;
@@ -80,7 +84,7 @@ public class DspNegotiationApiV2024Extension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         registerValidators();
 
-        webService.registerResource(ApiContext.PROTOCOL, new DspNegotiationApiController20241(protocolService, dspRequestHandler));
+        webService.registerResource(ApiContext.PROTOCOL, new DspNegotiationApiController20241(protocolService, dspRequestHandler, participantContextSupplier));
         webService.registerDynamicResource(ApiContext.PROTOCOL, DspNegotiationApiController20241.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, DSP_SCOPE_V_2024_1));
     }
 

--- a/data-protocols/dsp/dsp-2024/dsp-negotiation-2024/dsp-negotiation-http-api-2024/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController20241.java
+++ b/data-protocols/dsp/dsp-2024/dsp-negotiation-2024/dsp-negotiation-http-api-2024/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController20241.java
@@ -19,6 +19,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.BASE_PATH;
@@ -34,7 +35,7 @@ import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2024Constants.V_2024_1_PA
 @Path(V_2024_1_PATH + BASE_PATH)
 public class DspNegotiationApiController20241 extends BaseDspNegotiationApiController {
 
-    public DspNegotiationApiController20241(ContractNegotiationProtocolService protocolService, DspRequestHandler dspRequestHandler) {
-        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2024_1, DSP_NAMESPACE_V_2024_1);
+    public DspNegotiationApiController20241(ContractNegotiationProtocolService protocolService, DspRequestHandler dspRequestHandler, SingleParticipantContextSupplier participantContextSupplier) {
+        super(protocolService, dspRequestHandler, participantContextSupplier, DATASPACE_PROTOCOL_HTTP_V_2024_1, DSP_NAMESPACE_V_2024_1);
     }
 }

--- a/data-protocols/dsp/dsp-2024/dsp-negotiation-2024/dsp-negotiation-http-api-2024/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController20241Test.java
+++ b/data-protocols/dsp/dsp-2024/dsp-negotiation-2024/dsp-negotiation-http-api-2024/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiController20241Test.java
@@ -36,6 +36,6 @@ class DspNegotiationApiController20241Test extends DspNegotiationApiControllerTe
 
     @Override
     protected Object controller() {
-        return new DspNegotiationApiController20241(protocolService, dspRequestHandler);
+        return new DspNegotiationApiController20241(protocolService, dspRequestHandler, participantContextSupplier);
     }
 }

--- a/data-protocols/dsp/dsp-2024/dsp-transfer-process-2024/dsp-transfer-process-http-api-2024/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/DspTransferProcessApiV2024Extension.java
+++ b/data-protocols/dsp/dsp-2024/dsp-transfer-process-2024/dsp-transfer-process-http-api-2024/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/DspTransferProcessApiV2024Extension.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.protocol.dsp.transferprocess.http.api;
 
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessProtocolService;
 import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.transferprocess.http.api.controller.DspTransferProcessApiController20241;
 import org.eclipse.edc.protocol.dsp.transferprocess.validation.TransferCompletionMessageValidator;
@@ -64,11 +65,14 @@ public class DspTransferProcessApiV2024Extension implements ServiceExtension {
     @Inject
     private TypeManager typeManager;
 
+    @Inject
+    private SingleParticipantContextSupplier participantContextSupplier;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
         registerValidators();
 
-        webService.registerResource(ApiContext.PROTOCOL, new DspTransferProcessApiController20241(transferProcessProtocolService, dspRequestHandler));
+        webService.registerResource(ApiContext.PROTOCOL, new DspTransferProcessApiController20241(transferProcessProtocolService, dspRequestHandler, participantContextSupplier));
         webService.registerDynamicResource(ApiContext.PROTOCOL, DspTransferProcessApiController20241.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, DSP_SCOPE_V_2024_1));
     }
 

--- a/data-protocols/dsp/dsp-2024/dsp-transfer-process-2024/dsp-transfer-process-http-api-2024/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController20241.java
+++ b/data-protocols/dsp/dsp-2024/dsp-transfer-process-2024/dsp-transfer-process-http-api-2024/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController20241.java
@@ -19,6 +19,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessProtocolService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2024Constants.DATASPACE_PROTOCOL_HTTP_V_2024_1;
@@ -35,7 +36,7 @@ import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProc
 @Path(V_2024_1_PATH + BASE_PATH)
 public class DspTransferProcessApiController20241 extends BaseDspTransferProcessApiController {
 
-    public DspTransferProcessApiController20241(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler) {
-        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2024_1, DSP_NAMESPACE_V_2024_1);
+    public DspTransferProcessApiController20241(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler, SingleParticipantContextSupplier participantContextSupplier) {
+        super(protocolService, dspRequestHandler, participantContextSupplier, DATASPACE_PROTOCOL_HTTP_V_2024_1, DSP_NAMESPACE_V_2024_1);
     }
 }

--- a/data-protocols/dsp/dsp-2024/dsp-transfer-process-2024/dsp-transfer-process-http-api-2024/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController20241Test.java
+++ b/data-protocols/dsp/dsp-2024/dsp-transfer-process-2024/dsp-transfer-process-http-api-2024/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiController20241Test.java
@@ -36,6 +36,6 @@ class DspTransferProcessApiController20241Test extends DspTransferProcessApiCont
 
     @Override
     protected Object controller() {
-        return new DspTransferProcessApiController20241(protocolService, dspRequestHandler);
+        return new DspTransferProcessApiController20241(protocolService, dspRequestHandler, participantContextSupplier);
     }
 }

--- a/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/DspCatalogApi2025Extension.java
+++ b/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/DspCatalogApi2025Extension.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DataServiceRegistry;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
 import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.catalog.http.api.decorator.Base64continuationTokenSerDes;
 import org.eclipse.edc.protocol.dsp.catalog.http.api.decorator.ContinuationTokenManagerImpl;
 import org.eclipse.edc.protocol.dsp.catalog.http.api.v2025.controller.DspCatalogApiController20251;
@@ -78,6 +79,9 @@ public class DspCatalogApi2025Extension implements ServiceExtension {
     @Inject
     private JsonLd jsonLd;
 
+    @Inject
+    private SingleParticipantContextSupplier participantContextSupplier;
+
     @Override
     public String name() {
         return NAME;
@@ -87,7 +91,7 @@ public class DspCatalogApi2025Extension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         registerValidators();
 
-        webService.registerResource(ApiContext.PROTOCOL, new DspCatalogApiController20251(service, dspRequestHandler, continuationTokenManager(monitor)));
+        webService.registerResource(ApiContext.PROTOCOL, new DspCatalogApiController20251(service, dspRequestHandler, continuationTokenManager(monitor), participantContextSupplier));
         webService.registerDynamicResource(ApiContext.PROTOCOL, DspCatalogApiController20251.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, DSP_SCOPE_V_2025_1));
     }
 

--- a/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiController20251.java
+++ b/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiController20251.java
@@ -18,6 +18,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.catalog.http.api.controller.BaseDspCatalogApiController;
 import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
@@ -37,7 +38,7 @@ import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1_PA
 public class DspCatalogApiController20251 extends BaseDspCatalogApiController {
 
     public DspCatalogApiController20251(CatalogProtocolService service, DspRequestHandler dspRequestHandler,
-                                        ContinuationTokenManager responseDecorator) {
-        super(service, dspRequestHandler, responseDecorator, DATASPACE_PROTOCOL_HTTP_V_2025_1, DSP_NAMESPACE_V_2025_1);
+                                        ContinuationTokenManager responseDecorator, SingleParticipantContextSupplier participantContextSupplier) {
+        super(service, dspRequestHandler, responseDecorator, participantContextSupplier, DATASPACE_PROTOCOL_HTTP_V_2025_1, DSP_NAMESPACE_V_2025_1);
     }
 }

--- a/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiControllerV20251Test.java
@@ -37,6 +37,6 @@ public class DspCatalogApiControllerV20251Test extends DspCatalogApiControllerTe
 
     @Override
     protected Object controller() {
-        return new DspCatalogApiController20251(service, dspRequestHandler, continuationTokenManager);
+        return new DspCatalogApiController20251(service, dspRequestHandler, continuationTokenManager, participantContextSupplier);
     }
 }

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/DspNegotiationApi2025Extension.java
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/DspNegotiationApi2025Extension.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.protocol.dsp.negotiation.http.api.v2025;
 
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
 import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.negotiation.http.api.v2025.controller.DspNegotiationApiController20251;
 import org.eclipse.edc.protocol.dsp.negotiation.validation.ContractAgreementMessageValidator;
@@ -70,6 +71,9 @@ public class DspNegotiationApi2025Extension implements ServiceExtension {
     @Inject
     private TypeManager typeManager;
 
+    @Inject
+    private SingleParticipantContextSupplier participantContextSupplier;
+
     @Override
     public String name() {
         return NAME;
@@ -79,7 +83,7 @@ public class DspNegotiationApi2025Extension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         registerValidators();
 
-        webService.registerResource(ApiContext.PROTOCOL, new DspNegotiationApiController20251(protocolService, dspRequestHandler));
+        webService.registerResource(ApiContext.PROTOCOL, new DspNegotiationApiController20251(protocolService, dspRequestHandler, participantContextSupplier));
         webService.registerDynamicResource(ApiContext.PROTOCOL, DspNegotiationApiController20251.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, DSP_SCOPE_V_2025_1));
     }
 

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiController20251.java
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiController20251.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.negotiation.http.api.controller.BaseDspNegotiationApiController;
 
@@ -43,10 +44,9 @@ import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1_PA
 @Path(V_2025_1_PATH + BASE_PATH)
 public class DspNegotiationApiController20251 extends BaseDspNegotiationApiController {
 
-    public DspNegotiationApiController20251(ContractNegotiationProtocolService protocolService, DspRequestHandler dspRequestHandler) {
-        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2025_1, DSP_NAMESPACE_V_2025_1);
+    public DspNegotiationApiController20251(ContractNegotiationProtocolService protocolService, DspRequestHandler dspRequestHandler, SingleParticipantContextSupplier participantContextSupplier) {
+        super(protocolService, dspRequestHandler, participantContextSupplier, DATASPACE_PROTOCOL_HTTP_V_2025_1, DSP_NAMESPACE_V_2025_1);
     }
-
 
     /**
      * Consumer-specific endpoint.

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiControllerV20251Test.java
@@ -39,7 +39,7 @@ class DspNegotiationApiControllerV20251Test extends DspNegotiationApiControllerT
 
     @Override
     protected Object controller() {
-        return new DspNegotiationApiController20251(protocolService, dspRequestHandler);
+        return new DspNegotiationApiController20251(protocolService, dspRequestHandler, participantContextSupplier);
     }
 
 

--- a/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/v2025/DspTransferProcessApi2025Extension.java
+++ b/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/v2025/DspTransferProcessApi2025Extension.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.protocol.dsp.transferprocess.http.api.v2025;
 
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessProtocolService;
 import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.transferprocess.http.api.v2025.controller.DspTransferProcessApiController20251;
 import org.eclipse.edc.protocol.dsp.transferprocess.validation.TransferCompletionMessageValidator;
@@ -63,11 +64,14 @@ public class DspTransferProcessApi2025Extension implements ServiceExtension {
     @Inject
     private TypeManager typeManager;
 
+    @Inject
+    private SingleParticipantContextSupplier participantContextSupplier;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
         registerValidators();
 
-        webService.registerResource(ApiContext.PROTOCOL, new DspTransferProcessApiController20251(transferProcessProtocolService, dspRequestHandler));
+        webService.registerResource(ApiContext.PROTOCOL, new DspTransferProcessApiController20251(transferProcessProtocolService, dspRequestHandler, participantContextSupplier));
         webService.registerDynamicResource(ApiContext.PROTOCOL, DspTransferProcessApiController20251.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, DSP_SCOPE_V_2025_1));
     }
 

--- a/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/v2025/controller/DspTransferProcessApiController20251.java
+++ b/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/v2025/controller/DspTransferProcessApiController20251.java
@@ -19,6 +19,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessProtocolService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.transferprocess.http.api.controller.BaseDspTransferProcessApiController;
 
@@ -36,7 +37,7 @@ import static org.eclipse.edc.protocol.dsp.transferprocess.http.api.TransferProc
 @Path(V_2025_1_PATH + BASE_PATH)
 public class DspTransferProcessApiController20251 extends BaseDspTransferProcessApiController {
 
-    public DspTransferProcessApiController20251(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler) {
-        super(protocolService, dspRequestHandler, DATASPACE_PROTOCOL_HTTP_V_2025_1, DSP_NAMESPACE_V_2025_1);
+    public DspTransferProcessApiController20251(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler, SingleParticipantContextSupplier participantContextSupplier) {
+        super(protocolService, dspRequestHandler, participantContextSupplier, DATASPACE_PROTOCOL_HTTP_V_2025_1, DSP_NAMESPACE_V_2025_1);
     }
 }

--- a/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/v2025/controller/DspTransferProcessApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/v2025/controller/DspTransferProcessApiControllerV20251Test.java
@@ -37,7 +37,7 @@ class DspTransferProcessApiControllerV20251Test extends DspTransferProcessApiCon
 
     @Override
     protected Object controller() {
-        return new DspTransferProcessApiController20251(protocolService, dspRequestHandler);
+        return new DspTransferProcessApiController20251(protocolService, dspRequestHandler, participantContextSupplier);
     }
 
 }

--- a/data-protocols/dsp/dsp-core/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/message/DspRequestHandlerImpl.java
+++ b/data-protocols/dsp/dsp-core/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/message/DspRequestHandlerImpl.java
@@ -63,7 +63,7 @@ public class DspRequestHandlerImpl implements DspRequestHandler {
         }
         var tokenRepresentation = TokenRepresentation.Builder.newInstance().token(token).build();
 
-        var serviceResult = request.getServiceCall().apply(request.getId(), tokenRepresentation);
+        var serviceResult = request.getServiceCall().apply(request.getParticipantContextProvider().get(), request.getId(), tokenRepresentation);
         if (serviceResult.failed()) {
             monitor.debug(() -> "DSP: Service call failed: %s".formatted(serviceResult.getFailureDetail()));
             return forFailure(serviceResult.getFailure(), request);
@@ -129,7 +129,7 @@ public class DspRequestHandlerImpl implements DspRequestHandler {
         var tokenRepresentation = TokenRepresentation.Builder.newInstance().token(token).build();
 
         var input = inputTransformation.getContent();
-        var serviceResult = request.getServiceCall().apply(input, tokenRepresentation);
+        var serviceResult = request.getServiceCall().apply(request.getParticipantContextProvider().get(), input, tokenRepresentation);
         if (serviceResult.failed()) {
             monitor.debug(() -> "DSP: Service call failed: %s".formatted(serviceResult.getFailureDetail()));
             return forFailure(serviceResult.getFailure(), request);
@@ -201,7 +201,7 @@ public class DspRequestHandlerImpl implements DspRequestHandler {
         }
 
         return request.getServiceCall()
-                .apply(inputTransformation.getContent(), tokenRepresentation)
+                .apply(request.getParticipantContextProvider().get(), inputTransformation.getContent(), tokenRepresentation)
                 .map(it -> Response.ok().type(MediaType.APPLICATION_JSON_TYPE).build())
                 .orElse(failure -> {
                     monitor.debug(() -> "DSP: Service call failed: %s".formatted(failure.getFailureDetail()));

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/message/DspRequest.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/message/DspRequest.java
@@ -14,11 +14,10 @@
 
 package org.eclipse.edc.protocol.dsp.http.spi.message;
 
-import org.eclipse.edc.spi.iam.TokenRepresentation;
-import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.types.domain.message.ErrorMessage;
 
-import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
@@ -31,8 +30,9 @@ public class DspRequest<I, R, E extends ErrorMessage> {
 
     protected String token;
     protected String protocol;
-    protected BiFunction<I, TokenRepresentation, ServiceResult<R>> serviceCall;
+    protected ServiceCall<I, R> serviceCall;
     protected Supplier<? extends ErrorMessage.Builder<E, ?>> errorProvider;
+    protected ParticipantContextSupplier participantContextProvider;
 
     public DspRequest(Class<I> inputClass, Class<R> resultClass, Class<E> errorClass) {
         this.inputClass = inputClass;
@@ -56,12 +56,16 @@ public class DspRequest<I, R, E extends ErrorMessage> {
         return resultClass;
     }
 
-    public BiFunction<I, TokenRepresentation, ServiceResult<R>> getServiceCall() {
+    public ServiceCall<I, R> getServiceCall() {
         return serviceCall;
     }
 
     public Supplier<? extends ErrorMessage.Builder<E, ?>> getErrorProvider() {
         return errorProvider;
+    }
+
+    public Supplier<ParticipantContext> getParticipantContextProvider() {
+        return participantContextProvider;
     }
 
     public abstract static class Builder<I, R, M extends DspRequest<I, R, E>, E extends ErrorMessage, B extends Builder<I, R, M, E, B>> {
@@ -82,8 +86,13 @@ public class DspRequest<I, R, E extends ErrorMessage> {
             return self();
         }
 
-        public B serviceCall(BiFunction<I, TokenRepresentation, ServiceResult<R>> serviceCall) {
+        public B serviceCall(ServiceCall<I, R> serviceCall) {
             message.serviceCall = serviceCall;
+            return self();
+        }
+
+        public B participantContextProvider(ParticipantContextSupplier participantContextProvider) {
+            message.participantContextProvider = participantContextProvider;
             return self();
         }
 
@@ -96,6 +105,7 @@ public class DspRequest<I, R, E extends ErrorMessage> {
             requireNonNull(message.serviceCall);
             requireNonNull(message.protocol);
             requireNonNull(message.errorProvider);
+            requireNonNull(message.participantContextProvider);
             return message;
         }
 

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/message/ServiceCall.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/message/ServiceCall.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.http.spi.message;
+
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+@FunctionalInterface
+public interface ServiceCall<I, R> {
+
+    /**
+     * Applies the service call with the given input and token representation.
+     *
+     * @param participantContext  the participant context
+     * @param input               the input to the service call
+     * @param tokenRepresentation the token representation for authentication/authorization
+     * @return a ServiceResult containing either the result or an error
+     */
+    ServiceResult<R> apply(ParticipantContext participantContext, I input, TokenRepresentation tokenRepresentation);
+
+}

--- a/data-protocols/dsp/dsp-lib/dsp-catalog-lib/dsp-catalog-http-api-lib/build.gradle.kts
+++ b/data-protocols/dsp/dsp-lib/dsp-catalog-lib/dsp-catalog-http-api-lib/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     api(project(":data-protocols:dsp:dsp-spi"))
     api(project(":data-protocols:dsp:dsp-http-spi"))
     api(project(":spi:common:json-ld-spi"))
+    api(project(":spi:common:participant-context-single-spi"))
 
     testImplementation(project(":core:common:lib:transform-lib"))
     testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))

--- a/data-protocols/dsp/dsp-lib/dsp-catalog-lib/dsp-catalog-http-api-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiControllerTestBase.java
+++ b/data-protocols/dsp/dsp-lib/dsp-catalog-lib/dsp-catalog-http-api-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiControllerTestBase.java
@@ -25,6 +25,8 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
@@ -62,6 +64,7 @@ public abstract class DspCatalogApiControllerTestBase extends RestControllerTest
     protected final CatalogProtocolService service = mock();
     protected final DspRequestHandler dspRequestHandler = mock();
     protected final ContinuationTokenManager continuationTokenManager = mock();
+    protected final SingleParticipantContextSupplier participantContextSupplier = () -> new ParticipantContext("id");
 
     @Test
     void getDataset_shouldGetResource() {

--- a/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-http-api-lib/build.gradle.kts
+++ b/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-http-api-lib/build.gradle.kts
@@ -21,7 +21,8 @@ dependencies {
     api(project(":data-protocols:dsp:dsp-spi"))
     api(project(":data-protocols:dsp:dsp-http-spi"))
     api(project(":spi:common:json-ld-spi"))
-    
+    api(project(":spi:common:participant-context-single-spi"))
+
     testFixturesImplementation(project(":core:common:junit"))
     testFixturesImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
     testFixturesImplementation(libs.restAssured)

--- a/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-http-api-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiControllerTestBase.java
+++ b/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-http-api-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiControllerTestBase.java
@@ -26,6 +26,8 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Con
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationProtocolService;
 import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
@@ -68,6 +70,7 @@ public abstract class DspNegotiationApiControllerTestBase extends RestController
 
     protected final ContractNegotiationProtocolService protocolService = mock();
     protected final DspRequestHandler dspRequestHandler = mock();
+    protected final SingleParticipantContextSupplier participantContextSupplier = () -> new ParticipantContext("id");
 
     @Test
     void getNegotiation_shouldGetResource() {

--- a/data-protocols/dsp/dsp-lib/dsp-transfer-process-lib/dsp-transfer-process-http-api-lib/build.gradle.kts
+++ b/data-protocols/dsp/dsp-lib/dsp-transfer-process-lib/dsp-transfer-process-http-api-lib/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     api(project(":data-protocols:dsp:dsp-spi"))
     api(project(":data-protocols:dsp:dsp-http-spi"))
     api(project(":spi:common:json-ld-spi"))
+    api(project(":spi:common:participant-context-single-spi"))
 
     testFixturesImplementation(project(":core:common:junit"))
     testFixturesImplementation(testFixtures(project(":extensions:common:http:jersey-core")))

--- a/data-protocols/dsp/dsp-lib/dsp-transfer-process-lib/dsp-transfer-process-http-api-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/BaseDspTransferProcessApiController.java
+++ b/data-protocols/dsp/dsp-lib/dsp-transfer-process-lib/dsp-transfer-process-http-api-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/BaseDspTransferProcessApiController.java
@@ -30,6 +30,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.Transf
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferSuspensionMessage;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferTerminationMessage;
 import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
@@ -54,12 +55,15 @@ public abstract class BaseDspTransferProcessApiController {
 
     private final TransferProcessProtocolService protocolService;
     private final DspRequestHandler dspRequestHandler;
+    private final SingleParticipantContextSupplier participantContextSupplier;
     private final String protocol;
     private final JsonLdNamespace namespace;
-    
-    public BaseDspTransferProcessApiController(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler, String protocol, JsonLdNamespace namespace) {
+
+    public BaseDspTransferProcessApiController(TransferProcessProtocolService protocolService, DspRequestHandler dspRequestHandler,
+                                               SingleParticipantContextSupplier participantContextSupplier, String protocol, JsonLdNamespace namespace) {
         this.protocolService = protocolService;
         this.dspRequestHandler = dspRequestHandler;
+        this.participantContextSupplier = participantContextSupplier;
         this.protocol = protocol;
         this.namespace = namespace;
     }
@@ -76,9 +80,10 @@ public abstract class BaseDspTransferProcessApiController {
         var request = GetDspRequest.Builder.newInstance(TransferProcess.class, TransferError.class)
                 .id(id)
                 .token(token)
-                .serviceCall((tpId, tr) -> protocolService.findById(tpId, tr, protocol))
+                .serviceCall((ctx, tpId, tr) -> protocolService.findById(ctx, tpId, tr, protocol))
                 .protocol(protocol)
                 .errorProvider(TransferError.Builder::newInstance)
+                .participantContextProvider(participantContextSupplier)
                 .build();
 
         return dspRequestHandler.getResource(request);
@@ -101,6 +106,7 @@ public abstract class BaseDspTransferProcessApiController {
                 .serviceCall(protocolService::notifyRequested)
                 .errorProvider(TransferError.Builder::newInstance)
                 .protocol(protocol)
+                .participantContextProvider(participantContextSupplier)
                 .build();
 
         return dspRequestHandler.createResource(request);
@@ -125,6 +131,7 @@ public abstract class BaseDspTransferProcessApiController {
                 .serviceCall(protocolService::notifyStarted)
                 .errorProvider(TransferError.Builder::newInstance)
                 .protocol(protocol)
+                .participantContextProvider(participantContextSupplier)
                 .build();
 
         return dspRequestHandler.updateResource(request);
@@ -149,6 +156,7 @@ public abstract class BaseDspTransferProcessApiController {
                 .serviceCall(protocolService::notifyCompleted)
                 .errorProvider(TransferError.Builder::newInstance)
                 .protocol(protocol)
+                .participantContextProvider(participantContextSupplier)
                 .build();
 
         return dspRequestHandler.updateResource(request);
@@ -173,6 +181,7 @@ public abstract class BaseDspTransferProcessApiController {
                 .serviceCall(protocolService::notifyTerminated)
                 .errorProvider(TransferError.Builder::newInstance)
                 .protocol(protocol)
+                .participantContextProvider(participantContextSupplier)
                 .build();
 
         return dspRequestHandler.updateResource(request);
@@ -197,6 +206,7 @@ public abstract class BaseDspTransferProcessApiController {
                 .serviceCall(protocolService::notifySuspended)
                 .errorProvider(TransferError.Builder::newInstance)
                 .protocol(protocol)
+                .participantContextProvider(participantContextSupplier)
                 .build();
 
         return dspRequestHandler.updateResource(request);

--- a/data-protocols/dsp/dsp-lib/dsp-transfer-process-lib/dsp-transfer-process-http-api-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiControllerBaseTest.java
+++ b/data-protocols/dsp/dsp-lib/dsp-transfer-process-lib/dsp-transfer-process-http-api-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiControllerBaseTest.java
@@ -27,6 +27,8 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.Transf
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferSuspensionMessage;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferTerminationMessage;
 import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.dsp.http.spi.message.GetDspRequest;
 import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
@@ -62,10 +64,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public abstract class DspTransferProcessApiControllerBaseTest extends RestControllerTestBase {
-    
+
     private static final String PROCESS_ID = "testId";
     protected final TransferProcessProtocolService protocolService = mock();
     protected final DspRequestHandler dspRequestHandler = mock();
+    protected final SingleParticipantContextSupplier participantContextSupplier = () -> new ParticipantContext("id");
 
     @Test
     void getTransferProcess_shouldGetResource() {

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/controlplane/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/controlplane/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -36,6 +36,7 @@ import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
 import org.eclipse.edc.participant.spi.ParticipantAgent;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.protocol.spi.ProtocolWebhook;
@@ -135,7 +136,7 @@ public class HttpProvisionerExtensionEndToEndTest {
         when(identityService.verifyJwtToken(any(), isA(VerificationContext.class))).thenReturn(Result.success(ClaimToken.Builder.newInstance().build()));
         when(dataspaceProfileContextRegistry.getIdExtractionFunction(any())).thenReturn(ct -> "id");
 
-        var result = protocolService.notifyRequested(createTransferRequestMessage(), TokenRepresentation.Builder.newInstance().build());
+        var result = protocolService.notifyRequested(new ParticipantContext("id"), createTransferRequestMessage(), TokenRepresentation.Builder.newInstance().build());
 
         assertThat(result).isSucceeded();
         await().untilAsserted(() -> {

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/catalog/CatalogProtocolService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/catalog/CatalogProtocolService.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.controlplane.services.spi.catalog;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
 import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.ServiceResult;
@@ -35,7 +36,7 @@ public interface CatalogProtocolService {
      * @return succeeded result with the {@link Catalog}, failed result otherwise.
      */
     @NotNull
-    ServiceResult<Catalog> getCatalog(CatalogRequestMessage message, TokenRepresentation tokenRepresentation);
+    ServiceResult<Catalog> getCatalog(ParticipantContext participantContext, CatalogRequestMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Returns a dataset given its id and a {@link ClaimToken}
@@ -45,5 +46,5 @@ public interface CatalogProtocolService {
      * @return succeeded result with the {@link Dataset}, failed result otherwise.
      */
     @NotNull
-    ServiceResult<Dataset> getDataset(String datasetId, TokenRepresentation tokenRepresentation, String protocol);
+    ServiceResult<Dataset> getDataset(ParticipantContext participantContext, String datasetId, TokenRepresentation tokenRepresentation, String protocol);
 }

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/contractnegotiation/ContractNegotiationProtocolService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/contractnegotiation/ContractNegotiationProtocolService.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Con
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractOfferMessage;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequestMessage;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.jetbrains.annotations.NotNull;
@@ -39,7 +40,7 @@ public interface ContractNegotiationProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyRequested(ContractRequestMessage message, TokenRepresentation tokenRepresentation);
+    ServiceResult<ContractNegotiation> notifyRequested(ParticipantContext participantContext, ContractRequestMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the ContractNegotiation that it has been offered by the provider.
@@ -50,7 +51,7 @@ public interface ContractNegotiationProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyOffered(ContractOfferMessage message, TokenRepresentation tokenRepresentation);
+    ServiceResult<ContractNegotiation> notifyOffered(ParticipantContext participantContext, ContractOfferMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the ContractNegotiation that it has been agreed by the accepted.
@@ -61,7 +62,7 @@ public interface ContractNegotiationProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyAccepted(ContractNegotiationEventMessage message, TokenRepresentation tokenRepresentation);
+    ServiceResult<ContractNegotiation> notifyAccepted(ParticipantContext participantContext, ContractNegotiationEventMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the ContractNegotiation that it has been agreed by the provider.
@@ -72,7 +73,7 @@ public interface ContractNegotiationProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyAgreed(ContractAgreementMessage message, TokenRepresentation tokenRepresentation);
+    ServiceResult<ContractNegotiation> notifyAgreed(ParticipantContext participantContext, ContractAgreementMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the ContractNegotiation that it has been verified by the consumer.
@@ -83,7 +84,7 @@ public interface ContractNegotiationProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyVerified(ContractAgreementVerificationMessage message, TokenRepresentation tokenRepresentation);
+    ServiceResult<ContractNegotiation> notifyVerified(ParticipantContext participantContext, ContractAgreementVerificationMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the ContractNegotiation that it has been finalized by the provider.
@@ -94,7 +95,7 @@ public interface ContractNegotiationProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyFinalized(ContractNegotiationEventMessage message, TokenRepresentation tokenRepresentation);
+    ServiceResult<ContractNegotiation> notifyFinalized(ParticipantContext participantContext, ContractNegotiationEventMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the ContractNegotiation that it has been terminated by the counter-part.
@@ -104,7 +105,7 @@ public interface ContractNegotiationProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> notifyTerminated(ContractNegotiationTerminationMessage message, TokenRepresentation tokenRepresentation);
+    ServiceResult<ContractNegotiation> notifyTerminated(ParticipantContext participantContext, ContractNegotiationTerminationMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Finds a contract negotiation that has been requested by the counter-part. An existing
@@ -115,5 +116,5 @@ public interface ContractNegotiationProtocolService {
      * @return a succeeded result containing the negotiation if it was found, a failed one otherwise
      */
     @NotNull
-    ServiceResult<ContractNegotiation> findById(String id, TokenRepresentation tokenRepresentation, String protocol);
+    ServiceResult<ContractNegotiation> findById(ParticipantContext participantContext, String id, TokenRepresentation tokenRepresentation, String protocol);
 }

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/transferprocess/TransferProcessProtocolService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/transferprocess/TransferProcessProtocolService.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.Transf
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferStartMessage;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferSuspensionMessage;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferTerminationMessage;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.jetbrains.annotations.NotNull;
@@ -37,7 +38,7 @@ public interface TransferProcessProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<TransferProcess> notifyRequested(TransferRequestMessage message, TokenRepresentation tokenRepresentation);
+    ServiceResult<TransferProcess> notifyRequested(ParticipantContext participantContext, TransferRequestMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the TransferProcess that it has been started by the counter-part.
@@ -47,7 +48,7 @@ public interface TransferProcessProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<TransferProcess> notifyStarted(TransferStartMessage message, TokenRepresentation tokenRepresentation);
+    ServiceResult<TransferProcess> notifyStarted(ParticipantContext participantContext, TransferStartMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the TransferProcess that it has been completed by the counter-part.
@@ -57,7 +58,7 @@ public interface TransferProcessProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<TransferProcess> notifyCompleted(TransferCompletionMessage message, TokenRepresentation tokenRepresentation);
+    ServiceResult<TransferProcess> notifyCompleted(ParticipantContext participantContext, TransferCompletionMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the TransferProcess that it has been suspended by the counter-part.
@@ -67,7 +68,7 @@ public interface TransferProcessProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<TransferProcess> notifySuspended(TransferSuspensionMessage message, TokenRepresentation tokenRepresentation);
+    ServiceResult<TransferProcess> notifySuspended(ParticipantContext participantContext, TransferSuspensionMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Notifies the TransferProcess that it has been terminated by the counter-part.
@@ -77,7 +78,7 @@ public interface TransferProcessProtocolService {
      * @return a succeeded result if the operation was successful, a failed one otherwise
      */
     @NotNull
-    ServiceResult<TransferProcess> notifyTerminated(TransferTerminationMessage message, TokenRepresentation tokenRepresentation);
+    ServiceResult<TransferProcess> notifyTerminated(ParticipantContext participantContext, TransferTerminationMessage message, TokenRepresentation tokenRepresentation);
 
     /**
      * Finds a transfer process that has been requested by the counter-part. An existing
@@ -88,5 +89,5 @@ public interface TransferProcessProtocolService {
      * @return a succeeded result containing the transfer process if it was found, a failed one otherwise
      */
     @NotNull
-    ServiceResult<TransferProcess> findById(String id, TokenRepresentation tokenRepresentation, String protocol);
+    ServiceResult<TransferProcess> findById(ParticipantContext participantContext, String id, TokenRepresentation tokenRepresentation, String protocol);
 }

--- a/system-tests/protocol-2025-test/src/test/java/org/eclipse/edc/test/e2e/protocol/v2025/Dsp2025Runtime.java
+++ b/system-tests/protocol-2025-test/src/test/java/org/eclipse/edc/test/e2e/protocol/v2025/Dsp2025Runtime.java
@@ -33,7 +33,8 @@ public interface Dsp2025Runtime {
                 ":core:control-plane:control-plane-core",
                 ":extensions:common:http",
                 ":core:common:connector-core",
-                ":core:common:runtime-core"
+                ":core:common:runtime-core",
+                ":core:common:participant-context-single-core"
         );
 
         var modules = Stream.concat(baseModules, Arrays.stream(additionalModules)).toArray(String[]::new);

--- a/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspRuntime.java
+++ b/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspRuntime.java
@@ -34,7 +34,8 @@ public interface DspRuntime {
                 ":core:control-plane:control-plane-core",
                 ":extensions:common:http",
                 ":core:common:connector-core",
-                ":core:common:runtime-core"
+                ":core:common:runtime-core",
+                ":core:common:participant-context-single-core"
         );
 
         var modules = Stream.concat(baseModules, Arrays.stream(additionalModules)).toArray(String[]::new);

--- a/system-tests/version-api/version-api-test-runtime/build.gradle.kts
+++ b/system-tests/version-api/version-api-test-runtime/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     implementation(project(":core:common:runtime-core"))
     implementation(project(":core:common:token-core"))
     implementation(project(":core:common:edr-store-core"))
-    implementation(project(":core:common::participant-context-single-core"))
+    implementation(project(":core:common:participant-context-single-core"))
     implementation(project(":core:control-plane:control-plane-core"))
     implementation(project(":data-protocols:dsp"))
     implementation(project(":extensions:common:http"))


### PR DESCRIPTION
## What this PR changes/adds

 Participant context support on DSP layer:

- Removes `SingleParticipantContextSupplier` in the protocol layer (temp workaround of prev PR)
- Refactor all the protocol methods to take the `ParticipantContext` in input
- Refactor the `DspRequest` to take a `ParticipantContextSupplier`

## Why it does that

participant context story

## Further notes

The protocol layer has only be adapted in the method signatures. Subsequent PRs will make the usage 
of participant context for further checking on the protocol request


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5239 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
