### PR TITLE
refactor: extract CallbackAddresses interface

### DIFF
--- a/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/controlplane/callback/dispatcher/CallbackEventDispatcher.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/controlplane/callback/dispatcher/CallbackEventDispatcher.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.controlplane.services.spi.callback.CallbackEven
 import org.eclipse.edc.connector.controlplane.services.spi.callback.CallbackProtocolResolverRegistry;
 import org.eclipse.edc.connector.controlplane.services.spi.callback.CallbackRegistry;
 import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.event.CallbackAddresses;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventSubscriber;
@@ -80,9 +81,9 @@ public class CallbackEventDispatcher implements EventSubscriber {
 
     private <E extends Event> List<CallbackAddress> getCallbacks(EventEnvelope<E> eventEnvelope) {
         var staticCallbacks = callbackRegistry.resolve(eventEnvelope.getPayload().name()).stream();
-        var dynamicCallbacks =
-                eventEnvelope.getPayload().getCallbackAddresses()
-                        .stream();
+
+        var dynamicCallbacks = eventEnvelope.getPayload() instanceof CallbackAddresses callbackAddresses ?
+                callbackAddresses.getCallbackAddresses().stream() : Stream.<CallbackAddress>empty();
 
         return Stream.concat(staticCallbacks, dynamicCallbacks)
                 .filter(cb -> cb.isTransactional() == transactional)

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/CallbackAddresses.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/CallbackAddresses.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.spi.event;
+
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+
+import java.util.List;
+
+/**
+ * Define callback addresses capability
+ */
+public interface CallbackAddresses {
+
+    /**
+     * Return callback addresses
+     *
+     * @return callback addresses.
+     */
+    List<CallbackAddress> getCallbackAddresses();
+
+}

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/Event.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/Event.java
@@ -14,21 +14,11 @@
 
 package org.eclipse.edc.spi.event;
 
-import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
-
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * The Event base class for all EDC events. This represents the content of the event, and it should
  * not contain any event metadata. All the metadata such as id, timestamp, etc. are in the {@link EventEnvelope}
  */
 public abstract class Event {
-
-    public List<CallbackAddress> getCallbackAddresses() {
-        return new ArrayList<>();
-    }
-
 
     /**
      * The name of the event in dot notation.

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/event/contractnegotiation/ContractNegotiationEvent.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/event/contractnegotiation/ContractNegotiationEvent.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.controlplane.contract.spi.event.contractnegotiation;
 
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.spi.event.CallbackAddresses;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 
@@ -26,7 +27,7 @@ import java.util.Objects;
  *  Class as organizational between level to catch events of type ContractNegotiation to catch them together in an Event Subscriber
  *  Contains data related to contract negotiations
  */
-public abstract class ContractNegotiationEvent extends Event {
+public abstract class ContractNegotiationEvent extends Event implements CallbackAddresses {
 
     protected String contractNegotiationId;
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/event/TransferProcessEvent.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/event/TransferProcessEvent.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.controlplane.transfer.spi.event;
 
+import org.eclipse.edc.spi.event.CallbackAddresses;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 
@@ -25,7 +26,7 @@ import java.util.Objects;
  * Class as organizational between level to catch events of type TransferProcess to catch them together in an Event Subscriber
  * Contains data related to transfer processes
  */
-public abstract class TransferProcessEvent extends Event {
+public abstract class TransferProcessEvent extends Event implements CallbackAddresses {
 
     protected String transferProcessId;
     protected List<CallbackAddress> callbackAddresses = new ArrayList<>();


### PR DESCRIPTION
## What this PR changes/adds

Extract `CallbackAddresses` interface, to provide the capability only to the event types that really require it.

## Why it does that

Refactor

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5226

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
