### PR TITLE
fix: terminate consumer negotiation right away if request fails

### DIFF
--- a/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -100,7 +100,6 @@ class ConsumerContractNegotiationManagerImplTest {
 
     @BeforeEach
     void setUp() {
-
         var observable = new ContractNegotiationObservableImpl();
         observable.registerListener(listener);
 
@@ -403,12 +402,12 @@ class ConsumerContractNegotiationManagerImplTest {
                     new DispatchFailure(VERIFYING, VERIFYING, failedFuture(new EdcException("error")), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractAgreement(createContractAgreement())),
                     new DispatchFailure(TERMINATING, TERMINATING, failedFuture(new EdcException("error")), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).errorDetail("an error").contractOffer(contractOffer())),
                     // retries exhausted
-                    new DispatchFailure(REQUESTING, TERMINATING, failedFuture(new EdcException("error")), b -> b.stateCount(RETRIES_EXHAUSTED).contractOffer(contractOffer())),
+                    new DispatchFailure(REQUESTING, TERMINATED, failedFuture(new EdcException("error")), b -> b.stateCount(RETRIES_EXHAUSTED).contractOffer(contractOffer())),
                     new DispatchFailure(ACCEPTING, TERMINATING, failedFuture(new EdcException("error")), b -> b.stateCount(RETRIES_EXHAUSTED).contractOffer(contractOffer())),
                     new DispatchFailure(VERIFYING, TERMINATING, failedFuture(new EdcException("error")), b -> b.stateCount(RETRIES_EXHAUSTED).contractAgreement(createContractAgreement())),
                     new DispatchFailure(TERMINATING, TERMINATED, failedFuture(new EdcException("error")), b -> b.stateCount(RETRIES_EXHAUSTED).errorDetail("an error").contractOffer(contractOffer())),
                     // fatal error, in this case retry should never be done
-                    new DispatchFailure(REQUESTING, TERMINATING, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer())),
+                    new DispatchFailure(REQUESTING, TERMINATED, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer())),
                     new DispatchFailure(ACCEPTING, TERMINATING, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractOffer(contractOffer())),
                     new DispatchFailure(VERIFYING, TERMINATING, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).contractAgreement(createContractAgreement())),
                     new DispatchFailure(TERMINATING, TERMINATED, completedFuture(StatusResult.failure(FATAL_ERROR)), b -> b.stateCount(RETRIES_NOT_EXHAUSTED).errorDetail("an error").contractOffer(contractOffer()))

--- a/data-protocols/dsp/dsp-core/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImpl.java
+++ b/data-protocols/dsp/dsp-core/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImpl.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -148,13 +147,9 @@ public class DspHttpRemoteMessageDispatcherImpl implements DspHttpRemoteMessageD
 
                 return StatusResult.success(responseType.cast(responsePayload));
             } else {
-                var stringBody = Optional.ofNullable(responseBody)
-                        .map(this::asString)
-                        .orElse("Response body is null. Error code: " + response.code());
-
                 var status = response.code() >= 400 && response.code() < 500 ? FATAL_ERROR : ERROR_RETRY;
 
-                return StatusResult.failure(status, stringBody);
+                return StatusResult.failure(status, asString(responseBody));
             }
         }
     }


### PR DESCRIPTION
## What this PR changes/adds

transition consumer negotiation to `TERMINATED` if request fails. 

## Why it does that

No point in sending a termination message since the provider won't be aware of the negotiation.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5243 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
