### PR TITLE
feat: add missing fields on events

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/asset/AssetEventListener.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/asset/AssetEventListener.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.controlplane.services.asset;
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
 import org.eclipse.edc.connector.controlplane.asset.spi.event.AssetCreated;
 import org.eclipse.edc.connector.controlplane.asset.spi.event.AssetDeleted;
+import org.eclipse.edc.connector.controlplane.asset.spi.event.AssetEvent;
 import org.eclipse.edc.connector.controlplane.asset.spi.event.AssetUpdated;
 import org.eclipse.edc.connector.controlplane.asset.spi.observe.AssetListener;
 import org.eclipse.edc.spi.event.EventRouter;
@@ -33,29 +34,30 @@ public class AssetEventListener implements AssetListener {
 
     @Override
     public void created(Asset asset) {
-        var event = AssetCreated.Builder.newInstance()
-                .assetId(asset.getId())
-                .build();
+        var builder = AssetCreated.Builder.newInstance();
 
-        eventRouter.publish(event);
+        eventRouter.publish(withBaseProperties(builder, asset));
     }
 
     @Override
     public void deleted(Asset asset) {
-        var event = AssetDeleted.Builder.newInstance()
-                .assetId(asset.getId())
-                .build();
+        var builder = AssetDeleted.Builder.newInstance();
 
-        eventRouter.publish(event);
+        eventRouter.publish(withBaseProperties(builder, asset));
     }
 
     @Override
     public void updated(Asset asset) {
-        var event = AssetUpdated.Builder.newInstance()
-                .assetId(asset.getId())
-                .build();
+        var builder = AssetUpdated.Builder.newInstance();
 
-        eventRouter.publish(event);
+        eventRouter.publish(withBaseProperties(builder, asset));
+    }
+
+    private <E extends AssetEvent> E withBaseProperties(AssetEvent.Builder<E, ?> builder, Asset asset) {
+        return builder
+                .assetId(asset.getId())
+                .participantContextId(asset.getParticipantContextId())
+                .build();
     }
 
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractdefinition/ContractDefinitionEventListener.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractdefinition/ContractDefinitionEventListener.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.controlplane.services.contractdefinition;
 import org.eclipse.edc.connector.controlplane.contract.spi.definition.observe.ContractDefinitionListener;
 import org.eclipse.edc.connector.controlplane.contract.spi.event.contractdefinition.ContractDefinitionCreated;
 import org.eclipse.edc.connector.controlplane.contract.spi.event.contractdefinition.ContractDefinitionDeleted;
+import org.eclipse.edc.connector.controlplane.contract.spi.event.contractdefinition.ContractDefinitionEvent;
 import org.eclipse.edc.connector.controlplane.contract.spi.event.contractdefinition.ContractDefinitionUpdated;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.spi.event.EventRouter;
@@ -33,29 +34,30 @@ public class ContractDefinitionEventListener implements ContractDefinitionListen
 
     @Override
     public void created(ContractDefinition contractDefinition) {
-        var event = ContractDefinitionCreated.Builder.newInstance()
-                .contractDefinitionId(contractDefinition.getId())
-                .build();
+        var builder = ContractDefinitionCreated.Builder.newInstance();
 
-        eventRouter.publish(event);
+        eventRouter.publish(withBaseProperties(builder, contractDefinition));
     }
 
     @Override
     public void deleted(ContractDefinition contractDefinition) {
-        var event = ContractDefinitionDeleted.Builder.newInstance()
-                .contractDefinitionId(contractDefinition.getId())
-                .build();
+        var builder = ContractDefinitionDeleted.Builder.newInstance();
 
-        eventRouter.publish(event);
+        eventRouter.publish(withBaseProperties(builder, contractDefinition));
     }
 
     @Override
     public void updated(ContractDefinition contractDefinition) {
-        var event = ContractDefinitionUpdated.Builder.newInstance()
-                .contractDefinitionId(contractDefinition.getId())
-                .build();
+        var builder = ContractDefinitionUpdated.Builder.newInstance();
 
-        eventRouter.publish(event);
+        eventRouter.publish(withBaseProperties(builder, contractDefinition));
+    }
+
+    private <E extends ContractDefinitionEvent> E withBaseProperties(ContractDefinitionEvent.Builder<E, ?> builder, ContractDefinition contractDefinition) {
+        return builder
+                .contractDefinitionId(contractDefinition.getId())
+                .participantContextId(contractDefinition.getParticipantContextId())
+                .build();
     }
 
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionEventListener.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/policydefinition/PolicyDefinitionEventListener.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.controlplane.services.policydefinition;
 import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.controlplane.policy.spi.event.PolicyDefinitionCreated;
 import org.eclipse.edc.connector.controlplane.policy.spi.event.PolicyDefinitionDeleted;
+import org.eclipse.edc.connector.controlplane.policy.spi.event.PolicyDefinitionEvent;
 import org.eclipse.edc.connector.controlplane.policy.spi.event.PolicyDefinitionUpdated;
 import org.eclipse.edc.connector.controlplane.policy.spi.observe.PolicyDefinitionListener;
 import org.eclipse.edc.spi.event.EventRouter;
@@ -33,29 +34,30 @@ public class PolicyDefinitionEventListener implements PolicyDefinitionListener {
 
     @Override
     public void created(PolicyDefinition policyDefinition) {
-        var event = PolicyDefinitionCreated.Builder.newInstance()
-                .policyDefinitionId(policyDefinition.getId())
-                .build();
+        var builder = PolicyDefinitionCreated.Builder.newInstance();
 
-        eventRouter.publish(event);
+        eventRouter.publish(withBaseProperties(builder, policyDefinition));
     }
 
     @Override
     public void deleted(PolicyDefinition policyDefinition) {
-        var event = PolicyDefinitionDeleted.Builder.newInstance()
-                .policyDefinitionId(policyDefinition.getId())
-                .build();
+        var builder = PolicyDefinitionDeleted.Builder.newInstance();
 
-        eventRouter.publish(event);
+        eventRouter.publish(withBaseProperties(builder, policyDefinition));
     }
 
     @Override
     public void updated(PolicyDefinition policyDefinition) {
-        var event = PolicyDefinitionUpdated.Builder.newInstance()
-                .policyDefinitionId(policyDefinition.getId())
-                .build();
+        var builder = PolicyDefinitionUpdated.Builder.newInstance();
 
-        eventRouter.publish(event);
+        eventRouter.publish(withBaseProperties(builder, policyDefinition));
+    }
+
+    private <E extends PolicyDefinitionEvent> E withBaseProperties(PolicyDefinitionEvent.Builder<E, ?> builder, PolicyDefinition policyDefinition) {
+        return builder
+                .policyDefinitionId(policyDefinition.getId())
+                .participantContextId(policyDefinition.getParticipantContextId())
+                .build();
     }
 
 }

--- a/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/listener/ContractNegotiationEventListener.java
+++ b/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/listener/ContractNegotiationEventListener.java
@@ -90,6 +90,7 @@ public class ContractNegotiationEventListener implements ContractNegotiationList
                 .callbackAddresses(negotiation.getCallbackAddresses())
                 .contractOffers(negotiation.getContractOffers())
                 .counterPartyId(negotiation.getCounterPartyId())
+                .participantContextId(negotiation.getParticipantContextId())
                 .protocol(negotiation.getProtocol());
     }
 

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/listener/TransferProcessEventListener.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/listener/TransferProcessEventListener.java
@@ -129,7 +129,8 @@ public class TransferProcessEventListener implements TransferProcessListener {
                 .assetId(process.getAssetId())
                 .type(process.getType().name())
                 .participantContextId(process.getParticipantContextId())
-                .callbackAddresses(process.getCallbackAddresses());
+                .callbackAddresses(process.getCallbackAddresses())
+                .protocol(process.getProtocol());
     }
 
 }

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/provision/ProvisionerManagerImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/provision/ProvisionerManagerImpl.java
@@ -56,14 +56,14 @@ public class ProvisionerManagerImpl implements ProvisionerManager {
     @Override
     public CompletableFuture<List<StatusResult<ProvisionedResource>>> provision(List<ProvisionResource> definitions) {
         return definitions.stream()
-                .map(definition -> provision(definition).whenComplete(logOnError(definition)))
+                .map(definition -> provision(definition).whenComplete(logOnError(definition, "provisioning")))
                 .collect(asyncAllOf());
     }
 
     @Override
     public CompletableFuture<List<StatusResult<DeprovisionedResource>>> deprovision(List<ProvisionResource> definitions) {
         return definitions.stream()
-                .map(definition -> deprovision(definition).whenComplete(logOnError(definition)))
+                .map(definition -> deprovision(definition).whenComplete(logOnError(definition, "deprovisioning")))
                 .collect(asyncAllOf());
     }
 
@@ -94,10 +94,10 @@ public class ProvisionerManagerImpl implements ProvisionerManager {
     }
 
     @NotNull
-    private BiConsumer<StatusResult<?>, Throwable> logOnError(ProvisionResource definition) {
+    private BiConsumer<StatusResult<?>, Throwable> logOnError(ProvisionResource definition, String type) {
         return (result, throwable) -> {
             if (throwable != null) {
-                monitor.severe("Error provisioning definition %s for flow %s: %s".formatted(definition.getId(), definition.getFlowId(), throwable.getMessage()));
+                monitor.severe("Error %s definition %s for flow %s: %s".formatted(type, definition.getId(), definition.getFlowId(), throwable.getMessage()));
             }
         };
     }

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/provision/ProvisionerManagerImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/provision/ProvisionerManagerImplTest.java
@@ -120,7 +120,7 @@ class ProvisionerManagerImplTest {
             var result = provisionerManager.deprovision(List.of(definition));
 
             assertThat(result).failsWithin(1, SECONDS);
-            verify(monitor).severe(contains("Error provisioning"));
+            verify(monitor).severe(contains("Error deprovisioning"));
         }
 
         @Test

--- a/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/event/AssetEvent.java
+++ b/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/event/AssetEvent.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.controlplane.asset.spi.event;
 
 import org.eclipse.edc.spi.event.Event;
-import org.eclipse.edc.spi.event.EventPayload;
 
 import java.util.Objects;
 
@@ -26,18 +25,14 @@ import java.util.Objects;
 public abstract class AssetEvent extends Event {
 
     protected String assetId;
+    protected String participantContextId;
 
     public String getAssetId() {
         return assetId;
     }
 
-
-    public abstract static class Payload extends EventPayload {
-        protected String assetId;
-
-        public String getAssetId() {
-            return assetId;
-        }
+    public String getParticipantContextId() {
+        return participantContextId;
     }
 
     public abstract static class Builder<T extends AssetEvent, B extends AssetEvent.Builder<T, B>> {
@@ -52,6 +47,11 @@ public abstract class AssetEvent extends Event {
 
         public B assetId(String assetId) {
             event.assetId = assetId;
+            return self();
+        }
+
+        public B participantContextId(String participantContextId) {
+            event.participantContextId = participantContextId;
             return self();
         }
 

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/event/contractdefinition/ContractDefinitionEvent.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/event/contractdefinition/ContractDefinitionEvent.java
@@ -26,9 +26,14 @@ import java.util.Objects;
 public abstract class ContractDefinitionEvent extends Event {
 
     protected String contractDefinitionId;
+    protected String participantContextId;
 
     public String getContractDefinitionId() {
         return contractDefinitionId;
+    }
+
+    public String getParticipantContextId() {
+        return participantContextId;
     }
 
     public abstract static class Builder<T extends ContractDefinitionEvent, B extends Builder<T, B>> {
@@ -39,14 +44,17 @@ public abstract class ContractDefinitionEvent extends Event {
             this.event = event;
         }
 
-
         public B contractDefinitionId(String contractDefinitionId) {
             event.contractDefinitionId = contractDefinitionId;
             return self();
         }
 
-        public abstract B self();
+        public B participantContextId(String participantContextId) {
+            event.participantContextId = participantContextId;
+            return self();
+        }
 
+        public abstract B self();
 
         public T build() {
             Objects.requireNonNull(event.contractDefinitionId);

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/event/contractnegotiation/ContractNegotiationEvent.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/event/contractnegotiation/ContractNegotiationEvent.java
@@ -30,18 +30,16 @@ import java.util.Objects;
 public abstract class ContractNegotiationEvent extends Event implements CallbackAddresses {
 
     protected String contractNegotiationId;
-
     protected String counterPartyAddress;
     protected String counterPartyId;
-
     protected List<CallbackAddress> callbackAddresses = new ArrayList<>();
     protected List<ContractOffer> contractOffers = new ArrayList<>();
+    protected String participantContextId;
     protected String protocol;
 
     public String getContractNegotiationId() {
         return contractNegotiationId;
     }
-
 
     public String getCounterPartyAddress() {
         return counterPartyAddress;
@@ -53,6 +51,10 @@ public abstract class ContractNegotiationEvent extends Event implements Callback
 
     public List<ContractOffer> getContractOffers() {
         return contractOffers;
+    }
+
+    public String getParticipantContextId() {
+        return participantContextId;
     }
 
     public String getProtocol() {
@@ -107,6 +109,11 @@ public abstract class ContractNegotiationEvent extends Event implements Callback
 
         public B callbackAddresses(List<CallbackAddress> callbackAddresses) {
             event.callbackAddresses = callbackAddresses;
+            return self();
+        }
+
+        public B participantContextId(String participantContextId) {
+            event.participantContextId = participantContextId;
             return self();
         }
 

--- a/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/controlplane/policy/spi/event/PolicyDefinitionEvent.java
+++ b/spi/control-plane/policy-spi/src/main/java/org/eclipse/edc/connector/controlplane/policy/spi/event/PolicyDefinitionEvent.java
@@ -25,11 +25,15 @@ import java.util.Objects;
 public abstract class PolicyDefinitionEvent extends Event {
 
     protected String policyDefinitionId;
+    protected String participantContextId;
 
     public String getPolicyDefinitionId() {
         return policyDefinitionId;
     }
 
+    public String getParticipantContextId() {
+        return participantContextId;
+    }
 
     public abstract static class Builder<T extends PolicyDefinitionEvent, B extends PolicyDefinitionEvent.Builder<T, B>> {
 
@@ -43,6 +47,11 @@ public abstract class PolicyDefinitionEvent extends Event {
 
         public B policyDefinitionId(String policyDefinitionId) {
             event.policyDefinitionId = policyDefinitionId;
+            return self();
+        }
+
+        public B participantContextId(String participantContextId) {
+            event.participantContextId = participantContextId;
             return self();
         }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/event/TransferProcessEvent.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/event/TransferProcessEvent.java
@@ -34,6 +34,7 @@ public abstract class TransferProcessEvent extends Event implements CallbackAddr
     protected String type;
     protected String contractId;
     protected String participantContextId;
+    protected String protocol;
 
     public String getTransferProcessId() {
         return transferProcessId;
@@ -53,6 +54,10 @@ public abstract class TransferProcessEvent extends Event implements CallbackAddr
 
     public String getParticipantContextId() {
         return participantContextId;
+    }
+
+    public String getProtocol() {
+        return protocol;
     }
 
     @Override
@@ -95,6 +100,11 @@ public abstract class TransferProcessEvent extends Event implements CallbackAddr
 
         public B participantContextId(String participantContextId) {
             event.participantContextId = participantContextId;
+            return self();
+        }
+
+        public B protocol(String protocol) {
+            event.protocol = protocol;
             return self();
         }
 


### PR DESCRIPTION
## What this PR changes/adds

Add missing `protocol` on `TransferProcessEvent`.
Add also `participantContextId` where missing (asset, contract negotiation, contract definition, policy definition)

## Why it does that

_Briefly state why the change was necessary._

## Further notes

- fixed also a logging nit in `ProvisionerManagerImpl.java`


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5283

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
