### PR TITLE
feat: e2e components for simpler and dynamic test setup

### DIFF
--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/annotations/Runtime.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/annotations/Runtime.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.junit.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to be used to inject named parameters into test methods.
+ */
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Runtime {
+    String value();
+}

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/ComponentRuntimeContext.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/ComponentRuntimeContext.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.junit.extensions;
+
+import org.eclipse.edc.junit.utils.Endpoints;
+import org.eclipse.edc.junit.utils.LazySupplier;
+import org.eclipse.edc.spi.system.configuration.Config;
+
+import java.net.URI;
+
+/**
+ * Provides access to runtime services and endpoints for a component under test.
+ */
+public class ComponentRuntimeContext {
+
+    private final EmbeddedRuntime runtime;
+    private final Endpoints endpoints;
+
+    protected ComponentRuntimeContext(EmbeddedRuntime runtime, Endpoints endpoints) {
+        this.runtime = runtime;
+        this.endpoints = endpoints;
+    }
+
+    /**
+     * Retrieves the endpoint URI supplier for the specified endpoint name.
+     *
+     * @param name the name of the endpoint
+     * @return a lazy supplier of the endpoint URI
+     */
+    public LazySupplier<URI> getEndpoint(String name) {
+        return endpoints.getEndpoint(name);
+    }
+
+    /**
+     * Retrieves a service instance of the specified class from the runtime.
+     *
+     * @param klass the class of the service to retrieve
+     * @param <T>   the type of the service
+     * @return an instance of the requested service
+     */
+    public <T> T getService(Class<T> klass) {
+        return runtime.getService(klass);
+    }
+
+    /**
+     * Retrieves the configuration of the runtime.
+     *
+     * @return the runtime configuration
+     */
+    public Config getConfig() {
+        return runtime.getContext().getConfig();
+    }
+
+}

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/ComponentRuntimeExtension.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/extensions/ComponentRuntimeExtension.java
@@ -1,0 +1,170 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.junit.extensions;
+
+import org.eclipse.edc.junit.annotations.Runtime;
+import org.eclipse.edc.junit.utils.Endpoints;
+import org.eclipse.edc.junit.utils.LazySupplier;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.eclipse.edc.util.io.Ports.getFreePort;
+
+/**
+ * Base class for all component extensions. It requires a {@link RuntimePerClassExtension} which means
+ * it the runtime will be created once per test class. It takes in input the modules and additional configurations that are required
+ * for the runtime to be created. Implementors should provide the default configuration for the runtime.
+ * It also supports injecting services mocks tagged with {@link Runtime} in case there are multiple
+ * extensions of the same type.
+ */
+public class ComponentRuntimeExtension extends RuntimePerClassExtension {
+
+    private final ComponentRuntimeContext context;
+    protected String name;
+    protected Endpoints endpoints = Endpoints.Builder.newInstance().build();
+    protected Map<Class<?>, LazySupplier<?>> paramProviders = new HashMap<>();
+
+    private ComponentRuntimeExtension(EmbeddedRuntime runtime, ComponentRuntimeContext context) {
+        super(runtime);
+        this.context = context;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    protected Config defaultConfig() {
+        var cfg = new HashMap<String, String>();
+        endpoints.getEndpoints().forEach((key, endpoint) -> {
+            if (key.equals("default")) {
+                cfg.put("web.http.port", String.valueOf(endpoint.get().getPort()));
+                cfg.put("web.http.path", endpoint.get().getPath());
+            } else {
+                cfg.put("web.http." + key + ".port", String.valueOf(endpoint.get().getPort()));
+                cfg.put("web.http." + key + ".path", endpoint.get().getPath());
+            }
+        });
+        // if the default endpoint is not set, set a random port and /api path
+        if (!cfg.containsKey("web.http.port")) {
+            cfg.put("web.http.port", String.valueOf(getFreePort()));
+            cfg.put("web.http.path", "/api");
+        }
+        return ConfigFactory.fromMap(cfg);
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        if (parameterContext.getParameter().getType().equals(ComponentRuntimeContext.class)) {
+            return matchName(parameterContext);
+        }
+        if (paramProviders.containsKey(parameterContext.getParameter().getType())) {
+            return matchName(parameterContext);
+        }
+        return super.supportsParameter(parameterContext, extensionContext) && matchName(parameterContext);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        if (parameterContext.getParameter().getType().equals(ComponentRuntimeContext.class)) {
+            return context;
+        }
+        if (paramProviders.containsKey(parameterContext.getParameter().getType())) {
+            return paramProviders.get(parameterContext.getParameter().getType()).get();
+        }
+        return super.resolveParameter(parameterContext, extensionContext);
+    }
+
+    protected boolean matchName(ParameterContext parameterContext) {
+        return parameterContext.findAnnotation(Runtime.class)
+                .map(Runtime::value)
+                .map(name -> name.equals(getName()))
+                .orElse(true);
+    }
+
+    public static class Builder {
+
+        protected final List<Supplier<Config>> configurationProviders = new ArrayList<>();
+        protected final Map<Class<?>, Function<ComponentRuntimeContext, ?>> paramProviders = new HashMap<>();
+        protected String name;
+        protected List<String> modules = new ArrayList<>();
+        protected Endpoints endpoints = Endpoints.Builder.newInstance().build();
+
+
+        protected Builder() {
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder endpoints(Endpoints endpoints) {
+            this.endpoints = endpoints;
+            return this;
+        }
+
+        public Builder modules(String... modules) {
+            this.modules.addAll(Arrays.stream(modules).toList());
+            return this;
+        }
+
+        public Builder configurationProvider(Supplier<Config> configurationProvider) {
+            this.configurationProviders.add(configurationProvider);
+            return this;
+        }
+
+        public <T> Builder paramProvider(Class<T> klass, Function<ComponentRuntimeContext, T> paramProvider) {
+            this.paramProviders.put(klass, paramProvider);
+            return this;
+        }
+
+        public ComponentRuntimeExtension build() {
+            Objects.requireNonNull(name, "name");
+
+            var runtime = new EmbeddedRuntime(name, modules.toArray(new String[0]));
+            var context = new ComponentRuntimeContext(runtime, endpoints);
+            var extension = new ComponentRuntimeExtension(runtime, context);
+
+            extension.name = name;
+            extension.runtime.configurationProvider(extension::defaultConfig);
+            extension.endpoints = endpoints;
+
+            extension.paramProviders = paramProviders.entrySet()
+                    .stream().map(entry -> Map.entry(entry.getKey(), new LazySupplier<>(() -> entry.getValue().apply(context))))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            configurationProviders.forEach(extension.runtime::configurationProvider);
+
+            return extension;
+        }
+
+    }
+}

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/utils/Endpoints.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/utils/Endpoints.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.junit.utils;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Holds a set of named endpoints. To configure the default endpoint (web.http.{port,path}), use the `default`
+ * string as the name.
+ *
+ */
+public class Endpoints {
+
+    private final Map<String, LazySupplier<URI>> endpoints;
+
+
+    private Endpoints(Map<String, LazySupplier<URI>> endpoints) {
+        this.endpoints = endpoints;
+    }
+
+    /**
+     * Returns the endpoint supplier for the given name.
+     *
+     * @param name the name of the endpoint
+     * @return the endpoint supplier, or null if not found
+     */
+    @Nullable
+    public LazySupplier<URI> getEndpoint(String name) {
+        return endpoints.get(name);
+    }
+
+    /**
+     * Returns all the endpoints.
+     *
+     * @return a map of endpoint names to their suppliers
+     */
+    public Map<String, LazySupplier<URI>> getEndpoints() {
+        return endpoints;
+    }
+
+    public static class Builder {
+        private final Map<String, Supplier<URI>> endpoints = new HashMap<>();
+
+
+        private Builder() {
+
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder endpoint(String name, Supplier<URI> urlSupplier) {
+            endpoints.put(name, urlSupplier);
+            return this;
+        }
+
+        public Endpoints build() {
+            var endpoints = this.endpoints.entrySet().stream()
+                    .map(entry -> Map.entry(entry.getKey(), new LazySupplier<>(entry.getValue())))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            return new Endpoints(endpoints);
+        }
+    }
+}

--- a/core/common/junit/src/main/java/org/eclipse/edc/junit/utils/LazySupplier.java
+++ b/core/common/junit/src/main/java/org/eclipse/edc/junit/utils/LazySupplier.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.connector.controlplane.test.system.utils;
+package org.eclipse.edc.junit.utils;
 
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/v4alpha/ContractAgreementApiV4AlphaController.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/v4alpha/ContractAgreementApiV4AlphaController.java
@@ -27,8 +27,10 @@ import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.Con
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.spi.validation.SchemaType;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 
 @Consumes(APPLICATION_JSON)
 @Produces(APPLICATION_JSON)
@@ -41,7 +43,7 @@ public class ContractAgreementApiV4AlphaController extends BaseContractAgreement
     @POST
     @Path("/request")
     @Override
-    public JsonArray queryAgreementsV4Alpha(JsonObject querySpecJson) {
+    public JsonArray queryAgreementsV4Alpha(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson) {
         return queryAgreements(querySpecJson);
     }
 

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/CounterParty.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/CounterParty.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.test.system.utils;
+
+/**
+ * Represents a counter-party in a system test.
+ *
+ * @param participantId the participant identifier
+ * @param protocolUrl   the protocol URL of the counter-party
+ */
+public record CounterParty(String participantId, String protocolUrl) {
+}

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/ManagementApiClientV4.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/ManagementApiClientV4.java
@@ -1,0 +1,497 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.test.system.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.specification.RequestSpecification;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
+import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.junit.utils.LazySupplier;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.query.Criterion;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createObjectBuilder;
+import static jakarta.json.stream.JsonCollectors.toJsonArray;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZED;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
+/**
+ * Testing Client for the Management API v4.
+ */
+public class ManagementApiClientV4 {
+
+    protected String participantId;
+    protected LazySupplier<URI> controlPlaneManagement;
+    protected LazySupplier<URI> controlPlaneProtocol;
+    protected String protocolVersionPath = "/2025-1";
+    protected UnaryOperator<RequestSpecification> enrichManagementRequest = r -> r;
+    protected ObjectMapper objectMapper;
+    protected Duration timeout = Duration.ofSeconds(30);
+    protected String protocol = "dataspace-protocol-http:2025-1";
+
+    protected ManagementApiClientV4() {
+        super();
+    }
+
+
+    public Duration getTimeout() {
+        return timeout;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        setProtocol(protocol, "");
+    }
+
+    public void setProtocol(String protocol, String path) {
+        this.protocol = protocol;
+        this.protocolVersionPath = path;
+    }
+
+    public String getProtocolVersionPath() {
+        return protocolVersionPath;
+    }
+
+    public String getParticipantId() {
+        return participantId;
+    }
+
+    /**
+     * Get the protocol URL of the participant which is the protocol base path + protocol version path (empty by default).
+     *
+     * @return protocol URL
+     */
+    public String getProtocolUrl() {
+        return controlPlaneProtocol.get() + protocolVersionPath;
+    }
+
+    /**
+     * Create a new {@link org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset}.
+     *
+     * @param assetId               asset id
+     * @param properties            asset properties
+     * @param dataAddressProperties data address properties
+     * @return id of the created asset.
+     */
+    public String createAsset(String assetId, Map<String, Object> properties, Map<String, Object> dataAddressProperties) {
+        var requestBody = createObjectBuilder()
+                .add(CONTEXT, jsonLdContext())
+                .add(ID, assetId)
+                .add(TYPE, "Asset")
+                .add("properties", createObjectBuilder(properties))
+                .add("dataAddress", createObjectBuilder(dataAddressProperties))
+                .build();
+
+        return baseManagementRequest()
+                .contentType(JSON)
+                .body(requestBody)
+                .when()
+                .post("/v4alpha/assets")
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().jsonPath().getString(ID);
+    }
+
+    /**
+     * Create a new {@link PolicyDefinition}.
+     *
+     * @param policy Json-LD representation of the policy
+     * @return id of the created policy.
+     */
+    public String createPolicyDefinition(JsonObject policy) {
+        var requestBody = createObjectBuilder()
+                .add(CONTEXT, jsonLdContext())
+                .add(TYPE, "PolicyDefinition")
+                .add("policy", policy)
+                .build();
+
+        return baseManagementRequest()
+                .contentType(JSON)
+                .body(requestBody)
+                .when()
+                .post("/v4alpha/policydefinitions")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().jsonPath().getString(ID);
+    }
+
+    /**
+     * Create a new {@link ContractDefinition}.
+     *
+     * @param assetId          asset id
+     * @param definitionId     contract definition id
+     * @param accessPolicyId   access policy id
+     * @param contractPolicyId contract policy id
+     * @return id of the created contract definition.
+     */
+    public String createContractDefinition(String assetId, String definitionId, String accessPolicyId, String contractPolicyId) {
+        var requestBody = createObjectBuilder()
+                .add(CONTEXT, jsonLdContext())
+                .add(ID, definitionId)
+                .add(TYPE, "ContractDefinition")
+                .add("accessPolicyId", accessPolicyId)
+                .add("contractPolicyId", contractPolicyId)
+                .add("assetsSelector", Json.createArrayBuilder()
+                        .add(createObjectBuilder()
+                                .add(TYPE, "Criterion")
+                                .add("operandLeft", EDC_NAMESPACE + "id")
+                                .add("operator", "=")
+                                .add("operandRight", assetId)
+                                .build())
+                        .build())
+                .build();
+
+        return baseManagementRequest()
+                .contentType(JSON)
+                .body(requestBody)
+                .when()
+                .post("/v4alpha/contractdefinitions")
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getString(ID);
+    }
+
+    /**
+     * Get first {@link Dataset} from provider matching the given asset id.
+     *
+     * @param provider data provider
+     * @param assetId  asset id
+     * @return dataset.
+     */
+    public JsonObject getDatasetForAsset(CounterParty provider, String assetId) {
+        var requestBody = createObjectBuilder()
+                .add(CONTEXT, jsonLdContext())
+                .add(TYPE, "DatasetRequest")
+                .add(ID, assetId)
+                .add("counterPartyId", provider.participantId())
+                .add("counterPartyAddress", provider.protocolUrl())
+                .add("protocol", protocol)
+                .build();
+
+        var response = baseManagementRequest()
+                .contentType(JSON)
+                .body(requestBody)
+                .when()
+                .post("/v4alpha/catalog/dataset/request")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .log().ifValidationFails()
+                .extract();
+
+        try {
+            var responseBody = response.body().asString();
+            return objectMapper.readValue(responseBody, JsonObject.class);
+        } catch (JsonProcessingException e) {
+            throw new EdcException("Cannot deserialize dataset", e);
+        }
+    }
+
+    /**
+     * Initiate negotiation with a provider for an asset.
+     * - Fetches the dataset for the ID
+     * - Extracts the first policy
+     * - Starts the contract negotiation
+     *
+     * @param provider data provider
+     * @param assetId  asset id
+     * @return id of the contract negotiation.
+     */
+    public String initContractNegotiation(CounterParty provider, String assetId) {
+        return initContractNegotiation(provider, getOfferForAsset(provider, assetId));
+    }
+
+    /**
+     * Initiate negotiation with a provider given an input policy.
+     *
+     * @param provider data provider
+     * @param policy   policy
+     * @return id of the contract negotiation.
+     */
+    public String initContractNegotiation(CounterParty provider, JsonObject policy) {
+        var requestBody = createObjectBuilder()
+                .add(CONTEXT, jsonLdContext())
+                .add(TYPE, "ContractRequest")
+                .add("counterPartyAddress", provider.protocolUrl())
+                .add("protocol", protocol)
+                .add("policy", policy)
+                .build();
+
+        return baseManagementRequest()
+                .contentType(JSON)
+                .body(requestBody)
+                .when()
+                .post("/v3/contractnegotiations")
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .extract().body().jsonPath().getString(ID);
+    }
+
+
+    /**
+     * Get current state of a contract negotiation.
+     *
+     * @param id contract negotiation id
+     * @return state of a contract negotiation.
+     */
+    public String getContractNegotiationState(String id) {
+        return getContractNegotiationField(id, "state");
+    }
+
+    public RequestSpecification baseManagementRequest() {
+        var request = given().baseUri(controlPlaneManagement.get().toString());
+        return enrichManagementRequest.apply(request);
+    }
+
+    protected String getContractNegotiationField(String negotiationId, String fieldName) {
+        return baseManagementRequest()
+                .contentType(JSON)
+                .when()
+                .get("/v4alpha/contractnegotiations/{id}", negotiationId)
+                .then()
+                .statusCode(200)
+                .extract().body().jsonPath()
+                .getString(fieldName);
+    }
+
+    private JsonObject getOfferForAsset(CounterParty provider, String assetId) {
+        var dataset = getDatasetForAsset(provider, assetId);
+        var policy = dataset.getJsonArray("hasPolicy").get(0).asJsonObject();
+        return createObjectBuilder(policy)
+                .add("assigner", provider.participantId())
+                .add("target", dataset.get(ID))
+                .build();
+    }
+
+    /**
+     * Initiate negotiation with a provider.
+     *
+     * @param provider data provider
+     * @param assetId  asset id
+     * @return id of the contract agreement.
+     */
+    public String negotiateContract(CounterParty provider, String assetId) {
+
+        var negotiationId = initContractNegotiation(provider, assetId);
+
+        await().atMost(timeout).untilAsserted(() -> {
+            var state = getContractNegotiationState(negotiationId);
+            assertThat(state).isEqualTo(FINALIZED.name());
+        });
+
+        return getContractAgreementId(negotiationId);
+    }
+
+    /**
+     * Initiate negotiation with a provider.
+     *
+     * @param provider data provider
+     * @param policy   policy
+     * @return id of the contract agreement.
+     */
+    public String negotiateContract(CounterParty provider, JsonObject policy) {
+
+        var negotiationId = initContractNegotiation(provider, policy);
+
+        await().atMost(timeout).untilAsserted(() -> {
+            var state = getContractNegotiationState(negotiationId);
+            assertThat(state).isEqualTo(FINALIZED.name());
+        });
+
+        return getContractAgreementId(negotiationId);
+    }
+
+    private String getContractAgreementId(String negotiationId) {
+        var contractAgreementIdAtomic = new AtomicReference<String>();
+
+        await().atMost(timeout).untilAsserted(() -> {
+            var agreementId = getContractNegotiationField(negotiationId, "contractAgreementId");
+            assertThat(agreementId).isNotNull().isInstanceOf(String.class);
+
+            contractAgreementIdAtomic.set(agreementId);
+        });
+
+        var contractAgreementId = contractAgreementIdAtomic.get();
+        assertThat(participantId).isNotEmpty();
+        return contractAgreementId;
+    }
+
+    public JsonObject getContractAgreement(String contractAgreementId) {
+        var response = baseManagementRequest()
+                .contentType(JSON)
+                .when()
+                .get("/v4alpha/contractagreements/{id}", contractAgreementId)
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .log().ifValidationFails()
+                .extract();
+
+        try {
+            var responseBody = response.body().asString();
+            return objectMapper.readValue(responseBody, JsonObject.class);
+        } catch (JsonProcessingException e) {
+            throw new EdcException("Cannot deserialize dataset", e);
+        }
+    }
+
+    public JsonArray queryContractAgreements(Criterion... criteria) {
+        return queryContractAgreements(toQueryObject(criteria));
+    }
+
+    public JsonArray queryContractAgreements(JsonObject querySpec) {
+        var response = baseManagementRequest()
+                .contentType(JSON)
+                .body(querySpec)
+                .when()
+                .post("/v4alpha/contractagreements/request")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .log().ifValidationFails()
+                .extract();
+
+        try {
+            var responseBody = response.body().asString();
+            return objectMapper.readValue(responseBody, JsonArray.class);
+        } catch (JsonProcessingException e) {
+            throw new EdcException("Cannot deserialize dataset", e);
+        }
+    }
+
+    public CounterParty asCounterParty() {
+        return new CounterParty(participantId, getProtocolUrl());
+    }
+
+    private JsonObject toQueryObject(Criterion... criteria) {
+        var criteriaJson = Arrays.stream(criteria)
+                .map(it -> {
+                            JsonValue operandRight;
+                            if (it.getOperandRight() instanceof Collection<?> collection) {
+                                operandRight = Json.createArrayBuilder(collection).build();
+                            } else {
+                                operandRight = Json.createValue(it.getOperandRight().toString());
+                            }
+                            return createObjectBuilder()
+                                    .add(TYPE, "Criterion")
+                                    .add("operandLeft", it.getOperandLeft().toString())
+                                    .add("operator", it.getOperator())
+                                    .add("operandRight", operandRight)
+                                    .build();
+                        }
+                ).collect(toJsonArray());
+
+        return createObjectBuilder()
+                .add(CONTEXT, jsonLdContext())
+                .add(TYPE, "QuerySpec")
+                .add("filterExpression", criteriaJson)
+                .build();
+    }
+
+    private JsonArray jsonLdContext() {
+        return Json.createArrayBuilder()
+                .add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2)
+                .build();
+    }
+
+    public static class Builder {
+        protected final ManagementApiClientV4 participant;
+
+        protected Builder(ManagementApiClientV4 participant) {
+            this.participant = participant;
+        }
+
+        public static Builder newInstance() {
+            return new Builder(new ManagementApiClientV4());
+        }
+
+        public Builder participantId(String id) {
+            participant.participantId = id;
+            return this;
+        }
+
+        public Builder protocol(String protocol) {
+            participant.protocol = protocol;
+            return this;
+        }
+
+        public Builder timeout(Duration timeout) {
+            participant.timeout = timeout;
+            return this;
+        }
+
+        public Builder objectMapper(ObjectMapper objectMapper) {
+            participant.objectMapper = objectMapper;
+            return this;
+        }
+
+        public Builder controlPlaneManagement(LazySupplier<URI> controlPlaneManagement) {
+            participant.controlPlaneManagement = controlPlaneManagement;
+            return this;
+        }
+
+        public Builder controlPlaneProtocol(LazySupplier<URI> controlPlaneProtocol) {
+            participant.controlPlaneProtocol = controlPlaneProtocol;
+            return this;
+        }
+
+        public ManagementApiClientV4 build() {
+            Objects.requireNonNull(participant.participantId, "participantId");
+            Objects.requireNonNull(participant.controlPlaneManagement, "controlPlaneManagement");
+            Objects.requireNonNull(participant.controlPlaneProtocol, "controlPlaneProtocol");
+
+            if (participant.objectMapper == null) {
+                participant.objectMapper = JacksonJsonLd.createObjectMapper();
+            }
+
+            return participant;
+        }
+
+    }
+
+
+}

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess
 import org.eclipse.edc.jsonld.TitaniumJsonLd;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.junit.utils.LazySupplier;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.ConsoleMonitor;
 

--- a/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DummyControlPlane.java
+++ b/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DummyControlPlane.java
@@ -15,7 +15,7 @@
 package org.eclipse.edc.test.e2e;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import org.eclipse.edc.connector.controlplane.test.system.utils.LazySupplier;
+import org.eclipse.edc.junit.utils.LazySupplier;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.util.io.Ports;

--- a/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/participant/DataPlaneParticipant.java
+++ b/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/participant/DataPlaneParticipant.java
@@ -16,8 +16,8 @@ package org.eclipse.edc.test.e2e.participant;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.restassured.specification.RequestSpecification;
-import org.eclipse.edc.connector.controlplane.test.system.utils.LazySupplier;
 import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
+import org.eclipse.edc.junit.utils.LazySupplier;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.jetbrains.annotations.NotNull;

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
@@ -16,8 +16,8 @@ package org.eclipse.edc.test.e2e;
 
 import io.restassured.common.mapper.TypeRef;
 import org.assertj.core.api.ThrowingConsumer;
-import org.eclipse.edc.connector.controlplane.test.system.utils.LazySupplier;
 import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
+import org.eclipse.edc.junit.utils.LazySupplier;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.spi.types.domain.DataAddress;

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/negotiation/ContractNegotiationEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/negotiation/ContractNegotiationEndToEndTest.java
@@ -1,0 +1,167 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.negotiation;
+
+import org.eclipse.edc.connector.controlplane.test.system.utils.ManagementApiClientV4;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.junit.annotations.Runtime;
+import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.noConstraintPolicy;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+
+
+@SuppressWarnings("JUnitMalformedDeclaration")
+class ContractNegotiationEndToEndTest {
+
+
+    abstract static class Tests {
+
+        public static final String CONSUMER_ID = "urn:connector:consumer";
+        public static final String PROVIDER_ID = "urn:connector:provider";
+        public static final String CONSUMER_NAME = "consumer";
+        public static final String PROVIDER_NAME = "provider";
+        protected static String noConstraintPolicyId;
+
+        @BeforeAll
+        static void createNoConstraintPolicy(@Runtime(PROVIDER_NAME) ManagementApiClientV4 provider) {
+            noConstraintPolicyId = provider.createPolicyDefinition(noConstraintPolicy());
+        }
+
+        private static @NotNull Map<String, Object> httpSourceDataAddress() {
+            return new HashMap<>(Map.of(
+                    "name", "transfer-test",
+                    "baseUrl", "http://any/source",
+                    "type", "HttpData"
+            ));
+        }
+
+        protected void createResourcesOnProvider(ManagementApiClientV4 provider, String assetId, Map<String, Object> dataAddressProperties) {
+            provider.createAsset(assetId, Map.of("description", "description"), dataAddressProperties);
+            provider.createContractDefinition(assetId, UUID.randomUUID().toString(), noConstraintPolicyId, noConstraintPolicyId);
+        }
+
+        @Test
+        void contractNegotiation(@Runtime(PROVIDER_NAME) ManagementApiClientV4 provider, @Runtime(CONSUMER_NAME) ManagementApiClientV4 consumer) {
+            var assetId = UUID.randomUUID().toString();
+            createResourcesOnProvider(provider, assetId, httpSourceDataAddress());
+
+            var agreementId = consumer.negotiateContract(provider.asCounterParty(), assetId);
+
+            var consumerAgreement = consumer.getContractAgreement(agreementId);
+
+            var filter = criterion("agreementId", "=", consumerAgreement.getString("agreementId"));
+            var providerAgreement = provider.queryContractAgreements(filter);
+
+            assertThat(providerAgreement).hasSize(1).first().satisfies(jsonValue -> {
+                var providerAgr = jsonValue.asJsonObject();
+
+                assertThat(providerAgr.getString("consumerId")).isEqualTo(consumerAgreement.getString("consumerId"));
+                assertThat(providerAgr.getString("providerId")).isEqualTo(consumerAgreement.getString("providerId"));
+                assertThat(providerAgr.getString("assetId")).isEqualTo(consumerAgreement.getString("assetId"));
+                assertThat(providerAgr.getJsonNumber("contractSignDate")).isEqualTo(consumerAgreement.getJsonNumber("contractSignDate"));
+                assertThat(providerAgr.getJsonObject("policy"))
+                        .usingRecursiveComparison().ignoringFields("@id")
+                        .isEqualTo(consumerAgreement.getJsonObject("policy"));
+
+
+            });
+
+            assertThat(consumerAgreement).isNotNull();
+
+        }
+
+    }
+
+    @Nested
+    @EndToEndTest
+    class InMemory extends Tests {
+
+        @RegisterExtension
+        static final RuntimeExtension CONSUMER_RUNTIME = ComponentRuntimeExtension.Builder.newInstance()
+                .name(CONSUMER_NAME)
+                .modules(Runtimes.ControlPlane.MODULES)
+                .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
+                .configurationProvider(() -> Runtimes.ControlPlane.config(CONSUMER_ID))
+                .paramProvider(ManagementApiClientV4.class, Runtimes.ControlPlane::getApiClient)
+                .build();
+
+        @RegisterExtension
+        static final RuntimeExtension PROVIDER_RUNTIME = ComponentRuntimeExtension.Builder.newInstance()
+                .name(PROVIDER_NAME)
+                .modules(Runtimes.ControlPlane.MODULES)
+                .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
+                .configurationProvider(() -> Runtimes.ControlPlane.config(PROVIDER_ID))
+                .paramProvider(ManagementApiClientV4.class, Runtimes.ControlPlane::getApiClient)
+                .build();
+
+
+    }
+
+    @Nested
+    @PostgresqlIntegrationTest
+    class Postgres extends Tests {
+
+        @Order(0)
+        @RegisterExtension
+        static final PostgresqlEndToEndExtension POSTGRESQL_EXTENSION = new PostgresqlEndToEndExtension();
+
+        @Order(1)
+        @RegisterExtension
+        static final BeforeAllCallback CREATE_DATABASES = context -> {
+            POSTGRESQL_EXTENSION.createDatabase(CONSUMER_NAME);
+            POSTGRESQL_EXTENSION.createDatabase(PROVIDER_NAME);
+        };
+
+        @RegisterExtension
+        static final RuntimeExtension CONSUMER_RUNTIME = ComponentRuntimeExtension.Builder.newInstance()
+                .name(CONSUMER_NAME)
+                .modules(Runtimes.ControlPlane.MODULES)
+                .modules(Runtimes.ControlPlane.SQL_MODULES)
+                .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
+                .configurationProvider(() -> Runtimes.ControlPlane.config(CONSUMER_ID))
+                .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(CONSUMER_NAME))
+                .paramProvider(ManagementApiClientV4.class, Runtimes.ControlPlane::getApiClient)
+                .build();
+
+        @RegisterExtension
+        static final RuntimeExtension PROVIDER_RUNTIME = ComponentRuntimeExtension.Builder.newInstance()
+                .name(PROVIDER_NAME)
+                .modules(Runtimes.ControlPlane.MODULES)
+                .modules(Runtimes.ControlPlane.SQL_MODULES)
+                .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
+                .configurationProvider(() -> Runtimes.ControlPlane.config(PROVIDER_ID))
+                .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(PROVIDER_NAME))
+                .paramProvider(ManagementApiClientV4.class, Runtimes.ControlPlane::getApiClient)
+                .build();
+
+    }
+
+}

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/negotiation/Runtimes.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/negotiation/Runtimes.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.negotiation;
+
+import org.eclipse.edc.connector.controlplane.test.system.utils.ManagementApiClientV4;
+import org.eclipse.edc.junit.extensions.ComponentRuntimeContext;
+import org.eclipse.edc.junit.utils.Endpoints;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+
+import java.net.URI;
+import java.util.Map;
+
+import static org.eclipse.edc.util.io.Ports.getFreePort;
+
+public interface Runtimes {
+
+
+    interface ControlPlane {
+        String[] MODULES = new String[]{
+                ":system-tests:e2e-transfer-test:control-plane",
+                ":extensions:data-plane:data-plane-signaling:data-plane-signaling-client"
+        };
+
+        String[] SQL_MODULES = new String[]{
+                ":dist:bom:controlplane-feature-sql-bom",
+        };
+
+        Endpoints.Builder ENDPOINTS = Endpoints.Builder.newInstance()
+                .endpoint("management", () -> URI.create("http://localhost:" + getFreePort() + "/management"))
+                .endpoint("control", () -> URI.create("http://localhost:" + getFreePort() + "/control"))
+                .endpoint("protocol", () -> URI.create("http://localhost:" + getFreePort() + "/protocol"));
+
+
+        static Config config(String participantId) {
+            return ConfigFactory.fromMap(Map.of("edc.participant.id", participantId));
+        }
+
+        static ManagementApiClientV4 getApiClient(ComponentRuntimeContext context) {
+            var participantId = context.getConfig().getString("edc.participant.id");
+            return ManagementApiClientV4.Builder.newInstance().participantId(participantId)
+                    .controlPlaneManagement(context.getEndpoint("management"))
+                    .controlPlaneProtocol(context.getEndpoint("protocol"))
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Implements DR #5287.

Implements a simple `ContractNegotiationEndToEndTest` to showcase the new components for testing and introduces

a `ManagementApiClientV4` as an utility for using management api v4.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

The `LazySupplier` has been moved the `junit` modules


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5286 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
