### PR TITLE
feat: participant identity resolution

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/BootServicesExtension.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/BootServicesExtension.java
@@ -36,10 +36,7 @@ import java.time.Clock;
 public class BootServicesExtension implements ServiceExtension {
 
     public static final String NAME = "Boot Services";
-
-    @Setting(description = "Configures the participant id this runtime is operating on behalf of")
-    public static final String PARTICIPANT_ID = "edc.participant.id";
-
+    
     @Setting(description = "Configures the runtime id. This should be fully or partly randomized, and need not be stable across restarts. It is recommended to leave this value blank.", defaultValue = "<random UUID>")
     public static final String RUNTIME_ID = "edc.runtime.id";
 

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContext.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContext.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.edc.boot.system;
 
-import org.eclipse.edc.boot.BootServicesExtension;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -39,7 +38,6 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
     private final Map<Class<?>, Object> services = new HashMap<>();
     private final Config config;
     private boolean isReadOnly = false;
-    private String participantId;
     private String runtimeId;
     private String componentId;
 
@@ -57,11 +55,6 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
     @Override
     public void freeze() {
         isReadOnly = true;
-    }
-
-    @Override
-    public String getParticipantId() {
-        return participantId;
     }
 
     @Override
@@ -109,11 +102,6 @@ public class DefaultServiceExtensionContext implements ServiceExtensionContext {
 
     @Override
     public void initialize() {
-        participantId = getSetting(BootServicesExtension.PARTICIPANT_ID, ANONYMOUS_PARTICIPANT);
-        if (ANONYMOUS_PARTICIPANT.equals(participantId)) {
-            getMonitor().warning("The runtime is configured as an anonymous participant. DO NOT DO THIS IN PRODUCTION.");
-        }
-
         runtimeId = getSetting(RUNTIME_ID, null);
         if (runtimeId != null) {
             getMonitor().warning("A configuration value for '%s' was found. Explicitly configuring this is not supported anymore and may get removed in the future. A random value will be assigned.".formatted(RUNTIME_ID));

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContextTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/DefaultServiceExtensionContextTest.java
@@ -31,13 +31,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.boot.BootServicesExtension.COMPONENT_ID;
 import static org.eclipse.edc.boot.BootServicesExtension.RUNTIME_ID;
-import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class DefaultServiceExtensionContextTest {
@@ -92,7 +87,6 @@ class DefaultServiceExtensionContextTest {
             var runtimeId = context.getRuntimeId();
             assertThat(UUID.fromString(runtimeId)).isNotNull();
 
-            verify(monitor, times(1)).warning(and(isA(String.class), argThat(message -> !message.contains(RUNTIME_ID))));
         }
 
         @Test
@@ -116,7 +110,6 @@ class DefaultServiceExtensionContextTest {
             var componentId = context.getComponentId();
             assertThat(UUID.fromString(componentId)).isNotNull();
 
-            verify(monitor).warning(and(isA(String.class), argThat(message -> !message.contains(COMPONENT_ID))));
         }
 
 
@@ -141,7 +134,6 @@ class DefaultServiceExtensionContextTest {
 
             assertThat(runtimeId).isEqualTo("runtime-id");
             assertThat(componentId).isEqualTo("component-id");
-            verify(monitor).warning(and(isA(String.class), argThat(message -> !message.contains(RUNTIME_ID))));
         }
     }
 

--- a/core/common/participant-context-single-core/src/main/java/org/eclipse/edc/participantcontext/single/SingleParticipantContextDefaultServicesExtension.java
+++ b/core/common/participant-context-single-core/src/main/java/org/eclipse/edc/participantcontext/single/SingleParticipantContextDefaultServicesExtension.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.participantcontext.single;
 import org.eclipse.edc.participantcontext.single.config.store.SingleParticipantContextConfigStore;
 import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.participantcontext.spi.config.store.ParticipantContextConfigStore;
+import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -61,6 +62,12 @@ public class SingleParticipantContextDefaultServicesExtension implements Service
     public ParticipantContextConfigStore participantContextConfigStore(ServiceExtensionContext context) {
         var contextId = participantContextId != null ? participantContextId : participantId;
         return new SingleParticipantContextConfigStore(contextId, context.getConfig());
+    }
+
+    // by default, resolve to the configured participant id for every protocol
+    @Provider(isDefault = true)
+    public ParticipantIdentityResolver participantIdentityResolver() {
+        return (context, protocol) -> participantId;
     }
 
     @Override

--- a/core/control-plane/control-plane-aggregate-services/build.gradle.kts
+++ b/core/control-plane/control-plane-aggregate-services/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 
     testImplementation(project(":core:common:runtime-core"))
     testImplementation(project(":core:common:connector-core"))
+    testImplementation(project(":core:common:participant-context-single-core"))
     testImplementation(project(":core:control-plane:control-plane-catalog"))
     testImplementation(project(":core:control-plane:control-plane-contract"))
     testImplementation(project(":core:control-plane:control-plane-core"))

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -68,6 +68,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcess
 import org.eclipse.edc.connector.secret.spi.observe.SecretObservableImpl;
 import org.eclipse.edc.connector.spi.service.SecretService;
 import org.eclipse.edc.participant.spi.ParticipantAgentService;
+import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
 import org.eclipse.edc.policy.context.request.spi.RequestCatalogPolicyContext;
 import org.eclipse.edc.policy.context.request.spi.RequestContractNegotiationPolicyContext;
 import org.eclipse.edc.policy.context.request.spi.RequestTransferProcessPolicyContext;
@@ -185,6 +186,9 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Inject
     private TransferTypeParser transferTypeParser;
 
+    @Inject
+    private ParticipantIdentityResolver identityResolver;
+
     @Override
     public String name() {
         return NAME;
@@ -220,7 +224,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public CatalogProtocolService catalogProtocolService() {
         return new CatalogProtocolServiceImpl(datasetResolver, dataServiceRegistry,
-                protocolTokenValidator(), dataspaceProfileContextRegistry, transactionContext);
+                protocolTokenValidator(), identityResolver, transactionContext);
     }
 
     @Provider

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogProtocolServiceImpl.java
@@ -24,9 +24,9 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequestMessage;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DatasetResolver;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogProtocolService;
 import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolTokenValidator;
+import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.context.request.spi.RequestCatalogPolicyContext;
-import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transaction.spi.TransactionContext;
@@ -38,7 +38,7 @@ public class CatalogProtocolServiceImpl implements CatalogProtocolService {
 
     private final DatasetResolver datasetResolver;
     private final DataServiceRegistry dataServiceRegistry;
-    private final DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
+    private final ParticipantIdentityResolver identityResolver;
     private final TransactionContext transactionContext;
 
     private final ProtocolTokenValidator protocolTokenValidator;
@@ -46,12 +46,12 @@ public class CatalogProtocolServiceImpl implements CatalogProtocolService {
     public CatalogProtocolServiceImpl(DatasetResolver datasetResolver,
                                       DataServiceRegistry dataServiceRegistry,
                                       ProtocolTokenValidator protocolTokenValidator,
-                                      DataspaceProfileContextRegistry dataspaceProfileContextRegistry,
+                                      ParticipantIdentityResolver identityResolver,
                                       TransactionContext transactionContext) {
         this.datasetResolver = datasetResolver;
         this.dataServiceRegistry = dataServiceRegistry;
         this.protocolTokenValidator = protocolTokenValidator;
-        this.dataspaceProfileContextRegistry = dataspaceProfileContextRegistry;
+        this.identityResolver = identityResolver;
         this.transactionContext = transactionContext;
     }
 
@@ -67,8 +67,7 @@ public class CatalogProtocolServiceImpl implements CatalogProtocolService {
                         return Catalog.Builder.newInstance()
                                 .dataServices(dataServices)
                                 .datasets(datasets.toList())
-                                // TODO it should be dynamic based on the participant context
-                                .participantId(dataspaceProfileContextRegistry.getParticipantId(message.getProtocol()))
+                                .participantId(identityResolver.getParticipantId(participantContext.getParticipantContextId(), message.getProtocol()))
                                 .build();
                     }
                 })

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogProtocolServiceImplTest.java
@@ -23,9 +23,9 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.DatasetResolver;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
 import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolTokenValidator;
 import org.eclipse.edc.participant.spi.ParticipantAgent;
+import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceFailure;
@@ -56,12 +56,12 @@ class CatalogProtocolServiceImplTest {
     private final DatasetResolver datasetResolver = mock();
     private final DataServiceRegistry dataServiceRegistry = mock();
     private final ProtocolTokenValidator protocolTokenValidator = mock();
-    private final DataspaceProfileContextRegistry dataspaceProfileContextRegistry = mock();
+    private final ParticipantIdentityResolver identityResolver = mock();
     private final TransactionContext transactionContext = spy(new NoopTransactionContext());
     private final ParticipantContext participantContext = new ParticipantContext("participantContextId");
 
     private final CatalogProtocolServiceImpl service = new CatalogProtocolServiceImpl(datasetResolver,
-            dataServiceRegistry, protocolTokenValidator, dataspaceProfileContextRegistry, transactionContext);
+            dataServiceRegistry, protocolTokenValidator, identityResolver, transactionContext);
 
     private ParticipantAgent createParticipantAgent() {
         return new ParticipantAgent(emptyMap(), emptyMap());
@@ -95,7 +95,7 @@ class CatalogProtocolServiceImplTest {
             when(protocolTokenValidator.verify(eq(participantContext), eq(tokenRepresentation), any(), eq(message))).thenReturn(ServiceResult.success(participantAgent));
             when(dataServiceRegistry.getDataServices(any())).thenReturn(List.of(dataService));
             when(datasetResolver.query(eq(participantContext), any(), any(), any())).thenReturn(Stream.of(createDataset()));
-            when(dataspaceProfileContextRegistry.getParticipantId(any())).thenReturn(participantId);
+            when(identityResolver.getParticipantId(any(), any())).thenReturn(participantId);
 
             var result = service.getCatalog(participantContext, message, tokenRepresentation);
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -34,6 +34,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceS
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
+import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
@@ -78,6 +79,7 @@ class ContractNegotiationEventDispatchTest {
     private final ClaimToken token = ClaimToken.Builder.newInstance().claim("client_id", CONSUMER).build();
     private final TokenRepresentation tokenRepresentation = TokenRepresentation.Builder.newInstance().token(UUID.randomUUID().toString()).build();
     protected DataspaceProfileContextRegistry dataspaceProfileContextRegistry = mock();
+    protected ParticipantIdentityResolver identityResolver = mock();
 
     @BeforeEach
     void setUp(RuntimeExtension extension) {
@@ -107,7 +109,7 @@ class ContractNegotiationEventDispatchTest {
         dispatcherRegistry.register("test", succeedingDispatcher());
 
         when(identityService.verifyJwtToken(any(), eq(tokenRepresentation), isA(VerificationContext.class))).thenReturn(Result.success(token));
-        when(dataspaceProfileContextRegistry.getParticipantId(any())).thenReturn("provider");
+        when(identityResolver.getParticipantId(any(), any())).thenReturn("provider");
 
         eventRouter.register(ContractNegotiationEvent.class, eventSubscriber);
         var policy = Policy.Builder.newInstance().build();

--- a/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/ContractManagerExtension.java
+++ b/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/ContractManagerExtension.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ProviderC
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.observe.ContractNegotiationObservable;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.policy.engine.spi.RuleBindingRegistry;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
@@ -115,6 +116,9 @@ public class ContractManagerExtension implements ServiceExtension {
     @Inject
     private ExecutorInstrumentation executorInstrumentation;
 
+    @Inject
+    private ParticipantIdentityResolver identityResolver;
+
     @Override
     public String name() {
         return NAME;
@@ -169,6 +173,7 @@ public class ContractManagerExtension implements ServiceExtension {
                 .batchSize(consumerStateMachineConfiguration.batchSize())
                 .entityRetryProcessConfiguration(consumerStateMachineConfiguration.entityRetryProcessConfiguration())
                 .dataspaceProfileContextRegistry(dataspaceProfileContextRegistry)
+                .identityResolver(identityResolver)
                 .pendingGuard(pendingGuard)
                 .build();
 
@@ -185,6 +190,7 @@ public class ContractManagerExtension implements ServiceExtension {
                 .batchSize(providerStateMachineConfiguration.batchSize())
                 .entityRetryProcessConfiguration(providerStateMachineConfiguration.entityRetryProcessConfiguration())
                 .dataspaceProfileContextRegistry(dataspaceProfileContextRegistry)
+                .identityResolver(identityResolver)
                 .pendingGuard(pendingGuard)
                 .build();
 

--- a/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/AbstractContractNegotiationManager.java
+++ b/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/AbstractContractNegotiationManager.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Con
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationTerminationMessage;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.protocol.ContractNegotiationAck;
 import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.query.Criterion;
@@ -48,6 +49,7 @@ public abstract class AbstractContractNegotiationManager extends AbstractStateEn
     protected ContractNegotiationObservable observable;
     protected PolicyDefinitionStore policyStore;
     protected DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
+    protected ParticipantIdentityResolver identityResolver;
     protected ContractNegotiationPendingGuard pendingGuard = it -> false;
 
     abstract ContractNegotiation.Type type();
@@ -226,7 +228,7 @@ public abstract class AbstractContractNegotiationManager extends AbstractStateEn
             Objects.requireNonNull(manager.dataspaceProfileContextRegistry, "dataspaceProfileContextRegistry");
             Objects.requireNonNull(manager.dispatcherRegistry, "dispatcherRegistry");
             Objects.requireNonNull(manager.observable, "observable");
-
+            Objects.requireNonNull(manager.identityResolver, "identityResolver");
             Objects.requireNonNull(manager.policyStore, "policyStore");
             return manager;
         }
@@ -248,6 +250,11 @@ public abstract class AbstractContractNegotiationManager extends AbstractStateEn
 
         public Builder<T> dataspaceProfileContextRegistry(DataspaceProfileContextRegistry dataspaceProfileContextRegistry) {
             manager.dataspaceProfileContextRegistry = dataspaceProfileContextRegistry;
+            return this;
+        }
+
+        public Builder<T> identityResolver(ParticipantIdentityResolver identityResolver) {
+            manager.identityResolver = identityResolver;
             return this;
         }
 

--- a/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -135,15 +135,16 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
                 .orElseGet(() -> {
                     var lastOffer = negotiation.getLastContractOffer();
                     var protocol = negotiation.getProtocol();
+                    var providerId = identityResolver.getParticipantId(negotiation.getParticipantContextId(), protocol);
 
                     var contractPolicy = lastOffer.getPolicy().toBuilder().type(PolicyType.CONTRACT)
                             .assignee(negotiation.getCounterPartyId())
-                            .assigner(dataspaceProfileContextRegistry.getParticipantId(protocol))
+                            .assigner(providerId)
                             .build();
 
                     return ContractAgreement.Builder.newInstance()
                             .contractSigningDate(clock.instant().getEpochSecond())
-                            .providerId(dataspaceProfileContextRegistry.getParticipantId(protocol))
+                            .providerId(providerId)
                             .consumerId(negotiation.getCounterPartyId())
                             .policy(contractPolicy)
                             .assetId(lastOffer.getAssetId())

--- a/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -29,6 +29,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Con
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.protocol.ContractNegotiationAck;
 import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
@@ -95,6 +96,7 @@ class ConsumerContractNegotiationManagerImplTest {
     private final PolicyDefinitionStore policyStore = mock();
     private final ContractNegotiationListener listener = mock();
     private final DataspaceProfileContextRegistry dataspaceProfileContextRegistry = mock();
+    private final ParticipantIdentityResolver identityResolver = mock();
     private final String protocolWebhookUrl = "http://protocol.webhook/url";
     private final ContractNegotiationPendingGuard pendingGuard = mock();
     private ConsumerContractNegotiationManagerImpl manager;
@@ -112,6 +114,7 @@ class ConsumerContractNegotiationManagerImplTest {
                 .policyStore(policyStore)
                 .entityRetryProcessConfiguration(new EntityRetryProcessConfiguration(RETRY_LIMIT, () -> new ExponentialWaitStrategy(0L)))
                 .dataspaceProfileContextRegistry(dataspaceProfileContextRegistry)
+                .identityResolver(identityResolver)
                 .pendingGuard(pendingGuard)
                 .build();
     }

--- a/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -41,6 +41,7 @@ import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.C
 import org.eclipse.edc.connector.controlplane.services.spi.protocol.ProtocolTokenValidator;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.participant.spi.ParticipantAgent;
+import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Action;
 import org.eclipse.edc.policy.model.Duty;
@@ -123,6 +124,7 @@ class ContractNegotiationIntegrationTest {
     private final ProtocolTokenValidator protocolTokenValidator = mock();
     private final ProtocolWebhook protocolWebhook = () -> "http://dummy";
     private final DataspaceProfileContextRegistry dataspaceProfileContextRegistry = mock();
+    private final ParticipantIdentityResolver identityResolver = mock();
     private final AtomicReference<String> providerNegotiationId = new AtomicReference<>(null);
     private final NoopTransactionContext transactionContext = new NoopTransactionContext();
     private final ParticipantContext participantContext = new ParticipantContext("participantContextId");
@@ -155,6 +157,7 @@ class ContractNegotiationIntegrationTest {
                 .store(providerStore)
                 .policyStore(mock())
                 .dataspaceProfileContextRegistry(dataspaceProfileContextRegistry)
+                .identityResolver(identityResolver)
                 .build();
 
         consumerManager = ConsumerContractNegotiationManagerImpl.Builder.newInstance()
@@ -164,6 +167,7 @@ class ContractNegotiationIntegrationTest {
                 .store(consumerStore)
                 .policyStore(mock())
                 .dataspaceProfileContextRegistry(dataspaceProfileContextRegistry)
+                .identityResolver(identityResolver)
                 .build();
 
         when(protocolTokenValidator.verify(eq(participantContext), eq(tokenRepresentation), any(), any(), any())).thenReturn(ServiceResult.success(participantAgent));
@@ -194,7 +198,7 @@ class ContractNegotiationIntegrationTest {
         when(validationService.validateConfirmed(eq(participantAgent), any(ContractAgreement.class), any(ContractOffer.class))).thenReturn(Result.success());
         when(validationService.validateRequest(eq(participantAgent), any(ContractNegotiation.class))).thenReturn(Result.success());
 
-        when(dataspaceProfileContextRegistry.getParticipantId(any())).thenReturn(PROVIDER_ID);
+        when(identityResolver.getParticipantId(any(), any())).thenReturn(PROVIDER_ID);
 
         // Start provider and consumer negotiation managers
         providerManager.start();
@@ -283,7 +287,7 @@ class ContractNegotiationIntegrationTest {
         when(validationService.validateInitialOffer(participantAgent, validatableOffer)).thenReturn(Result.success(new ValidatedConsumerOffer(CONSUMER_ID, offer)));
         when(validationService.validateConfirmed(eq(participantAgent), any(ContractAgreement.class), any(ContractOffer.class))).thenReturn(Result.failure("error"));
 
-        when(dataspaceProfileContextRegistry.getParticipantId(any())).thenReturn(PROVIDER_ID);
+        when(identityResolver.getParticipantId(any(), any())).thenReturn(PROVIDER_ID);
 
         // Start provider and consumer negotiation managers
         providerManager.start();

--- a/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -31,6 +31,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractO
 import org.eclipse.edc.connector.controlplane.contract.spi.types.protocol.ContractNegotiationAck;
 import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.policy.model.PolicyType;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
@@ -100,6 +101,7 @@ class ProviderContractNegotiationManagerImplTest {
     private final ContractNegotiationListener listener = mock();
     private final ContractNegotiationPendingGuard pendingGuard = mock();
     private final DataspaceProfileContextRegistry dataspaceProfileContextRegistry = mock();
+    private final ParticipantIdentityResolver identityResolver = mock();
     private ProviderContractNegotiationManagerImpl manager;
 
     @BeforeEach
@@ -115,6 +117,7 @@ class ProviderContractNegotiationManagerImplTest {
                 .entityRetryProcessConfiguration(new EntityRetryProcessConfiguration(RETRY_LIMIT, () -> new ExponentialWaitStrategy(0L)))
                 .pendingGuard(pendingGuard)
                 .dataspaceProfileContextRegistry(dataspaceProfileContextRegistry)
+                .identityResolver(identityResolver)
                 .build();
     }
 
@@ -219,7 +222,7 @@ class ProviderContractNegotiationManagerImplTest {
         when(store.findById(negotiation.getId())).thenReturn(negotiation);
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).id("policyId").build());
         when(dataspaceProfileContextRegistry.getWebhook(negotiation.getProtocol())).thenReturn(() -> "http://callback.address");
-        when(dataspaceProfileContextRegistry.getParticipantId(negotiation.getProtocol())).thenReturn(PROVIDER_ID);
+        when(identityResolver.getParticipantId(negotiation.getParticipantContextId(), negotiation.getProtocol())).thenReturn(PROVIDER_ID);
 
         manager.start();
 
@@ -296,7 +299,7 @@ class ProviderContractNegotiationManagerImplTest {
         when(dispatcherRegistry.dispatch(any(), any(), any())).thenReturn(result);
         when(store.findById(negotiation.getId())).thenReturn(negotiation);
         when(dataspaceProfileContextRegistry.getWebhook(negotiation.getProtocol())).thenReturn(() -> "http://callback.address");
-        when(dataspaceProfileContextRegistry.getParticipantId(negotiation.getProtocol())).thenReturn(PROVIDER_ID);
+        when(identityResolver.getParticipantId(negotiation.getParticipantContextId(), negotiation.getProtocol())).thenReturn(PROVIDER_ID);
 
         manager.start();
 

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/profile/DataspaceProfileContextRegistryImpl.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/profile/DataspaceProfileContextRegistryImpl.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.controlplane.profile;
 
+
 import org.eclipse.edc.protocol.spi.DataspaceProfileContext;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.protocol.spi.ParticipantIdExtractionFunction;
@@ -58,17 +59,7 @@ public class DataspaceProfileContextRegistryImpl implements DataspaceProfileCont
         return profiles().stream().filter(it -> it.name().equals(protocol))
                 .map(DataspaceProfileContext::protocolVersion).findAny().orElse(null);
     }
-    
-    @Override
-    public @Nullable String getParticipantId(String protocol) {
-        return profiles().stream()
-                .filter(it -> it.name().equals(protocol))
-                .map(DataspaceProfileContext::participantId)
-                .findAny()
-                .orElse(null);
-    }
-    
-    
+
     @Override
     public @Nullable ParticipantIdExtractionFunction getIdExtractionFunction(String protocol) {
         return profiles().stream()
@@ -77,7 +68,7 @@ public class DataspaceProfileContextRegistryImpl implements DataspaceProfileCont
                 .findAny()
                 .orElse(null);
     }
-    
+
     private List<DataspaceProfileContext> profiles() {
         return standardProfiles.isEmpty() ? defaultProfiles : standardProfiles;
     }

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/controlplane/profile/DataspaceProfileContextRegistryImplTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/controlplane/profile/DataspaceProfileContextRegistryImplTest.java
@@ -33,7 +33,7 @@ class DataspaceProfileContextRegistryImplTest {
         @Test
         void shouldReturnVersions_whenContextsRegisteredDefault() {
             var version = new ProtocolVersion("version name", "/path", "binding");
-            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url", "participantId", ct -> "id"));
+            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url", ct -> "id"));
 
             var result = registry.getProtocolVersions().protocolVersions();
 
@@ -44,8 +44,8 @@ class DataspaceProfileContextRegistryImplTest {
         void shouldIgnoreDefaultContexts_whenStandardAreRegistered() {
             var defaultVersion = new ProtocolVersion("default", "/path", "binding");
             var standardVersion = new ProtocolVersion("default", "/path", "binding");
-            registry.registerDefault(new DataspaceProfileContext("default", defaultVersion, () -> "url", "participantId", ct -> "id"));
-            registry.register(new DataspaceProfileContext("standard", standardVersion, () -> "url", "participantId", ct -> "id"));
+            registry.registerDefault(new DataspaceProfileContext("default", defaultVersion, () -> "url", ct -> "id"));
+            registry.register(new DataspaceProfileContext("standard", standardVersion, () -> "url", ct -> "id"));
 
             var result = registry.getProtocolVersions().protocolVersions();
 
@@ -66,7 +66,7 @@ class DataspaceProfileContextRegistryImplTest {
         @Test
         void shouldReturnWebhookForName() {
             var version = new ProtocolVersion("version name", "/path", "binding");
-            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url", "participantId", ct -> "id"));
+            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url", ct -> "id"));
 
             var result = registry.getWebhook("profile");
 
@@ -87,7 +87,7 @@ class DataspaceProfileContextRegistryImplTest {
         @Test
         void shouldReturnVersionForName() {
             var version = new ProtocolVersion("version name", "/path", "binding");
-            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url", "participantId", ct -> "id"));
+            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url", ct -> "id"));
 
             var result = registry.getProtocolVersion("profile");
 
@@ -96,44 +96,24 @@ class DataspaceProfileContextRegistryImplTest {
     }
 
     @Nested
-    class GetParticipantId {
-        @Test
-        void shouldReturnNull_whenNoParticipantIdFound() {
-            var result = registry.getParticipantId("unexistent");
-
-            assertThat(result).isNull();
-        }
-
-        @Test
-        void shouldReturnParticipantIdForName() {
-            var version = new ProtocolVersion("version name", "/path", "binding");
-            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url", "participantId", ct -> "id"));
-            
-            var result = registry.getParticipantId("profile");
-
-            assertThat(result).isEqualTo("participantId");
-        }
-    }
-    
-    @Nested
     class GetIdExtractionFunction {
         @Test
         void shouldReturnNull_whenNoIdExtractionFunctionFound() {
             var result = registry.getIdExtractionFunction("unexistent");
-            
+
             assertThat(result).isNull();
         }
-        
+
         @Test
         void shouldReturnIdExtractionFunctionForName() {
             var claimToken = ClaimToken.Builder.newInstance().build();
             var participantId = "participantId";
             var version = new ProtocolVersion("version name", "/path", "binding");
-            
-            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url", participantId, ct -> participantId));
-            
+
+            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url", ct -> participantId));
+
             var result = registry.getIdExtractionFunction("profile");
-            
+
             assertThat(result).isNotNull();
             assertThat(result.apply(claimToken)).isEqualTo(participantId);
         }

--- a/data-protocols/dsp/dsp-08/dsp-http-api-configuration-08/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiConfigurationV08Extension.java
+++ b/data-protocols/dsp/dsp-08/dsp-http-api-configuration-08/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiConfigurationV08Extension.java
@@ -88,7 +88,7 @@ public class DspApiConfigurationV08Extension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        dataspaceProfileContextRegistry.registerDefault(new DataspaceProfileContext(DATASPACE_PROTOCOL_HTTP, V_08, () -> dspWebhookAddress.get(), context.getParticipantId(), participantIdExtractionFunction));
+        dataspaceProfileContextRegistry.registerDefault(new DataspaceProfileContext(DATASPACE_PROTOCOL_HTTP, V_08, () -> dspWebhookAddress.get(), participantIdExtractionFunction));
 
         // registers ns for DSP scope
         registerNamespaces();

--- a/data-protocols/dsp/dsp-2024/dsp-http-api-configuration-2024/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiConfigurationV2024Extension.java
+++ b/data-protocols/dsp/dsp-2024/dsp-http-api-configuration-2024/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiConfigurationV2024Extension.java
@@ -98,7 +98,7 @@ public class DspApiConfigurationV2024Extension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         var v2024Path = dspWebhookAddress.get() + (wellKnownPathEnabled ? "" : V_2024_1_PATH);
 
-        dataspaceProfileContextRegistry.registerDefault(new DataspaceProfileContext(DATASPACE_PROTOCOL_HTTP_V_2024_1, V_2024_1, () -> v2024Path, context.getParticipantId(), participantIdExtractionFunction));
+        dataspaceProfileContextRegistry.registerDefault(new DataspaceProfileContext(DATASPACE_PROTOCOL_HTTP_V_2024_1, V_2024_1, () -> v2024Path, participantIdExtractionFunction));
 
         // registers ns for DSP scope
         registerNamespaces();

--- a/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/v2025/DspApiConfigurationV2025Extension.java
+++ b/data-protocols/dsp/dsp-2025/dsp-http-api-configuration-2025/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/v2025/DspApiConfigurationV2025Extension.java
@@ -86,7 +86,7 @@ public class DspApiConfigurationV2025Extension implements ServiceExtension {
         registerNamespaces();
         registerTransformers();
 
-        dataspaceProfileContextRegistry.registerDefault(new DataspaceProfileContext(DATASPACE_PROTOCOL_HTTP_V_2025_1, V_2025_1, () -> dspWebhookAddress.get() + V_2025_1_PATH, context.getParticipantId(), participantIdExtractionFunction));
+        dataspaceProfileContextRegistry.registerDefault(new DataspaceProfileContext(DATASPACE_PROTOCOL_HTTP_V_2025_1, V_2025_1, () -> dspWebhookAddress.get() + V_2025_1_PATH, participantIdExtractionFunction));
     }
 
     private void registerNamespaces() {

--- a/extensions/common/iam/iam-mock/src/main/java/org/eclipse/edc/iam/mock/IamMockExtension.java
+++ b/extensions/common/iam/iam-mock/src/main/java/org/eclipse/edc/iam/mock/IamMockExtension.java
@@ -28,6 +28,8 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 
+import static org.eclipse.edc.spi.system.ServiceExtensionContext.ANONYMOUS_PARTICIPANT;
+
 /**
  * An IAM provider mock used for testing.
  */
@@ -36,12 +38,12 @@ import org.eclipse.edc.spi.types.TypeManager;
 public class IamMockExtension implements ServiceExtension {
 
     public static final String NAME = "Mock IAM";
-    
+
     public static final String DEFAULT_IDENTITY_CLAIM_KEY = "client_id";
-    
+    @Setting(description = "Configures the participant id this runtime is operating on behalf of", key = "edc.participant.id", defaultValue = ANONYMOUS_PARTICIPANT)
+    public String participantId;
     @Setting(key = "edc.agent.identity.key", description = "The name of the claim key used to determine the participant identity", defaultValue = DEFAULT_IDENTITY_CLAIM_KEY)
     private String agentIdentityKey;
-
     @Inject
     private TypeManager typeManager;
 
@@ -54,10 +56,9 @@ public class IamMockExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         var region = context.getSetting("edc.mock.region", "eu");
         var faultyClientId = context.getSetting("edc.mock.faulty_client_id", "faultyClientId");
-        var participantId = context.getParticipantId();
         context.registerService(IdentityService.class, new MockIdentityService(typeManager, region, participantId, faultyClientId));
     }
-    
+
     @Provider(isDefault = true)
     public DefaultParticipantIdExtractionFunction defaultParticipantIdExtractionFunction() {
         return new MockParticipantIdExtractionFunction(agentIdentityKey);

--- a/extensions/control-plane/provision/provision-http/build.gradle.kts
+++ b/extensions/control-plane/provision/provision-http/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     testImplementation(project(":core:common:connector-core"))
     testImplementation(project(":core:common:runtime-core"))
     testImplementation(project(":core:control-plane:control-plane-core"))
+    testImplementation(project(":core:common:participant-context-single-core"))
     testImplementation(project(":core:common:junit"))
     testImplementation(project(":core:data-plane-selector:data-plane-selector-core"))
     testImplementation(project(":extensions:common:api:api-core"))

--- a/extensions/data-plane/data-plane-iam/src/main/java/org/eclipse/edc/connector/dataplane/iam/DataPlaneIamExtension.java
+++ b/extensions/data-plane/data-plane-iam/src/main/java/org/eclipse/edc/connector/dataplane/iam/DataPlaneIamExtension.java
@@ -23,15 +23,21 @@ import org.eclipse.edc.connector.dataplane.spi.iam.PublicEndpointGeneratorServic
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 
 import java.time.Clock;
 
+import static org.eclipse.edc.spi.system.ServiceExtensionContext.ANONYMOUS_PARTICIPANT;
+
 @Extension(value = DataPlaneIamExtension.NAME)
 public class DataPlaneIamExtension implements ServiceExtension {
 
     public static final String NAME = "Data Plane IAM";
+
+    @Setting(description = "Configures the participant id this runtime is operating on behalf of", key = "edc.participant.id", defaultValue = ANONYMOUS_PARTICIPANT)
+    public String participantId;
 
     @Inject
     private Clock clock;
@@ -65,7 +71,7 @@ public class DataPlaneIamExtension implements ServiceExtension {
 
     private DataPlaneAuthorizationServiceImpl getDataPlaneAuthorizationService(ServiceExtensionContext context) {
         if (dataPlaneAuthorizationService == null) {
-            dataPlaneAuthorizationService = new DataPlaneAuthorizationServiceImpl(accessTokenService, endpointGenerator, accessControlService, context.getParticipantId(), clock);
+            dataPlaneAuthorizationService = new DataPlaneAuthorizationServiceImpl(accessTokenService, endpointGenerator, accessControlService, participantId, clock);
         }
         return dataPlaneAuthorizationService;
     }

--- a/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/system/ServiceExtensionContext.java
+++ b/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/system/ServiceExtensionContext.java
@@ -33,13 +33,6 @@ public interface ServiceExtensionContext extends SettingResolver {
     }
 
     /**
-     * Returns the id of the participant this runtime operates on behalf of. If not configured {@link #ANONYMOUS_PARTICIPANT} is used.
-     *
-     * @return the participant id.
-     */
-    String getParticipantId();
-
-    /**
      * Return the id of the runtime. A runtime is a physical process. If {@code edc.runtime.id} is not configured, a random UUID is used.
      * <br/><em>It is recommended to leave this configuration blank..</em>
      *

--- a/spi/common/connector-participant-context-spi/src/main/java/org/eclipse/edc/participantcontext/spi/identity/ParticipantIdentityResolver.java
+++ b/spi/common/connector-participant-context-spi/src/main/java/org/eclipse/edc/participantcontext/spi/identity/ParticipantIdentityResolver.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.participantcontext.spi.identity;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Resolver for participant identities associated with participant context IDs and protocols.
+ */
+public interface ParticipantIdentityResolver {
+
+    @Nullable
+    String getParticipantId(String participantContextId, String protocol);
+}

--- a/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/DataspaceProfileContext.java
+++ b/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/DataspaceProfileContext.java
@@ -17,10 +17,11 @@ package org.eclipse.edc.protocol.spi;
 /**
  * Represent a Dataspace Profile Context
  *
- * @param name the name.
+ * @param name            the name.
  * @param protocolVersion the protocol version associated.
- * @param webhook the protocol endpoint url.
+ * @param webhook         the protocol endpoint url.
  */
-public record DataspaceProfileContext(String name, ProtocolVersion protocolVersion, ProtocolWebhook webhook, String participantId, ParticipantIdExtractionFunction idExtractionFunction) {
+public record DataspaceProfileContext(String name, ProtocolVersion protocolVersion, ProtocolWebhook webhook,
+                                      ParticipantIdExtractionFunction idExtractionFunction) {
 
 }

--- a/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/DataspaceProfileContextRegistry.java
+++ b/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/DataspaceProfileContextRegistry.java
@@ -68,15 +68,6 @@ public interface DataspaceProfileContextRegistry {
     ProtocolVersion getProtocolVersion(String protocol);
     
     /**
-     * Get the participant id for a given protocol.
-     *
-     * @param protocol the protocol name
-     * @return the participant id, or null if no participant id is registered for the protocol
-     */
-    @Nullable
-    String getParticipantId(String protocol);
-    
-    /**
      * Get the function for participant id extraction for a given protocol.
      *
      * @param protocol The protocol name

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
@@ -32,7 +32,6 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.io.File.separator;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.boot.BootServicesExtension.PARTICIPANT_ID;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 
 public class TransferEndToEndParticipant extends Participant {
@@ -48,7 +47,7 @@ public class TransferEndToEndParticipant extends Participant {
     public Config controlPlaneConfig() {
         var settings = new HashMap<String, String>() {
             {
-                put(PARTICIPANT_ID, id);
+                put("edc.participant.id", id);
                 put("web.http.port", String.valueOf(getFreePort()));
                 put("web.http.path", "/api");
                 put("web.http.protocol.port", String.valueOf(controlPlaneProtocol.get().getPort()));

--- a/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspVersionApiEndToEndTest.java
+++ b/system-tests/protocol-test/src/test/java/org/eclipse/edc/test/e2e/protocol/DspVersionApiEndToEndTest.java
@@ -49,7 +49,7 @@ class DspVersionApiEndToEndTest {
     @Test
     void shouldReturnValidJson() {
         runtime.getService(DataspaceProfileContextRegistry.class)
-                .register(new DataspaceProfileContext("profile", new ProtocolVersion("1.0", "/v1/path", "HTTPS"), () -> "url", "participantId", ct -> "id"));
+                .register(new DataspaceProfileContext("profile", new ProtocolVersion("1.0", "/v1/path", "HTTPS"), () -> "url", ct -> "id"));
 
         var response = given()
                 .port(PROTOCOL_PORT)
@@ -88,8 +88,8 @@ class DspVersionApiEndToEndTest {
                 .contentType(ContentType.JSON)
                 .body("'@context'", nullValue())
                 .extract().body().as(JsonObject.class);
-        
-        
+
+
         assertThat(response.getJsonArray(DSPACE_PROPERTY_PROTOCOL_VERSIONS))
                 .hasSize(1)
                 .extracting(JsonValue::asJsonObject)


### PR DESCRIPTION
## What this PR changes/adds

participant identity resolution: implements DR #5305 

## Why it does that

_Briefly state why the change was necessary._

## Further notes

Breaking change:

If custom profiles in the `DataspaceProfileContextRegistry` were use to configure a participantId for a specific protocol/profile, the new approach is to implementa a custom `ParticipantIdentityResolver` which resolves the `participantId`
based on `participantContextId` and `protocol`. 
The `participantContextId`  can be ignored in a single participant context scenario.


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5250 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
