### PR TITLE
refactor: change provision semantics to prepare for dataplane signaling protocol

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImpl.java
@@ -27,10 +27,10 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.AddProvisionedResourceCommand;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.CompleteProvisionCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.CompleteTransferCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.DeprovisionCompleteCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.DeprovisionRequest;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.NotifyPreparedCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.ResumeTransferCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.SuspendTransferCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.TerminateTransferCommand;
@@ -158,7 +158,7 @@ public class TransferProcessServiceImpl implements TransferProcessService {
     }
 
     @Override
-    public ServiceResult<Void> completeProvision(CompleteProvisionCommand command) {
+    public ServiceResult<Void> notifyPrepared(NotifyPreparedCommand command) {
         return execute(command);
     }
 

--- a/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
@@ -212,7 +212,7 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
             var manifest = manifestResult.getContent();
 
             if (manifest.empty()) {
-                var provisioning = dataFlowManager.provision(process, policy);
+                var provisioning = dataFlowManager.prepare(process, policy);
                 if (provisioning.succeeded()) {
                     var response = provisioning.getContent();
                     if (response.isProvisioning()) {

--- a/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplIntegrationTest.java
+++ b/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplIntegrationTest.java
@@ -138,7 +138,7 @@ class TransferProcessManagerImplIntegrationTest {
     @DisplayName("Verify that no process 'starves' during two consecutive runs, when the batch size > number of processes")
     void verifyProvision_shouldNotStarve() {
         var numProcesses = TRANSFER_MANAGER_BATCH_SIZE * 2;
-        when(dataFlowManager.provision(any(), any())).thenReturn(StatusResult.failure(FATAL_ERROR));
+        when(dataFlowManager.prepare(any(), any())).thenReturn(StatusResult.failure(FATAL_ERROR));
         when(provisionManager.provision(any(), any(Policy.class))).thenAnswer(i -> completedFuture(List.of(
                 ProvisionResponse.Builder.newInstance()
                         .resource(new TestProvisionedDataDestinationResource("any", "1"))

--- a/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
+++ b/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
@@ -747,7 +747,7 @@ class TransferProcessManagerImplTest {
         @Test
         void shouldTransitionToTerminated_whenNoPolicyFound() {
             var transferProcess = createTransferProcess(INITIAL);
-            when(dataFlowManager.provision(any(), any())).thenReturn(StatusResult.failure(FATAL_ERROR));
+            when(dataFlowManager.prepare(any(), any())).thenReturn(StatusResult.failure(FATAL_ERROR));
             when(transferProcessStore.nextNotLeased(anyInt(), stateIs(INITIAL.code())))
                     .thenReturn(List.of(transferProcess))
                     .thenReturn(emptyList());
@@ -765,7 +765,7 @@ class TransferProcessManagerImplTest {
         @Test
         void shouldTransitionToProvisioning_whenLegacyControlPaneProvisioning() {
             var transferProcess = createTransferProcess(INITIAL);
-            when(dataFlowManager.provision(any(), any())).thenReturn(StatusResult.failure(FATAL_ERROR));
+            when(dataFlowManager.prepare(any(), any())).thenReturn(StatusResult.failure(FATAL_ERROR));
             when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
             when(transferProcessStore.nextNotLeased(anyInt(), stateIs(INITIAL.code())))
                     .thenReturn(List.of(transferProcess))
@@ -780,14 +780,14 @@ class TransferProcessManagerImplTest {
                 verify(policyArchive, atLeastOnce()).findPolicyForContract(anyString());
                 verifyNoInteractions(provisionManager);
                 verify(transferProcessStore).save(argThat(p -> p.getState() == PROVISIONING.code()));
-                verify(dataFlowManager, never()).provision(any(), any());
+                verify(dataFlowManager, never()).prepare(any(), any());
             });
         }
 
         @Test
         void shouldTransitionToTerminated_whenLegacyManifestEvaluationFailed() {
             var transferProcess = createTransferProcess(INITIAL);
-            when(dataFlowManager.provision(any(), any())).thenReturn(StatusResult.failure(FATAL_ERROR));
+            when(dataFlowManager.prepare(any(), any())).thenReturn(StatusResult.failure(FATAL_ERROR));
             when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
             when(transferProcessStore.nextNotLeased(anyInt(), stateIs(INITIAL.code())))
                     .thenReturn(List.of(transferProcess))
@@ -817,7 +817,7 @@ class TransferProcessManagerImplTest {
                     .thenReturn(emptyList());
             when(manifestGenerator.generateConsumerResourceManifest(any(TransferProcess.class), any(Policy.class)))
                     .thenReturn(Result.success(ResourceManifest.Builder.newInstance().build()));
-            when(dataFlowManager.provision(any(), any())).thenReturn(StatusResult.success(dataFlowResponse));
+            when(dataFlowManager.prepare(any(), any())).thenReturn(StatusResult.success(dataFlowResponse));
 
             manager.start();
 
@@ -845,7 +845,7 @@ class TransferProcessManagerImplTest {
                     .thenReturn(emptyList());
             when(manifestGenerator.generateConsumerResourceManifest(any(TransferProcess.class), any(Policy.class)))
                     .thenReturn(Result.success(ResourceManifest.Builder.newInstance().build()));
-            when(dataFlowManager.provision(any(), any())).thenReturn(StatusResult.success(dataFlowResponse));
+            when(dataFlowManager.prepare(any(), any())).thenReturn(StatusResult.success(dataFlowResponse));
 
             manager.start();
 

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferProcessCommandExtension.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferProcessCommandExtension.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.edc.connector.controlplane.transfer;
 
-import org.eclipse.edc.connector.controlplane.transfer.command.handlers.CompleteProvisionCommandHandler;
 import org.eclipse.edc.connector.controlplane.transfer.command.handlers.CompleteTransferCommandHandler;
 import org.eclipse.edc.connector.controlplane.transfer.command.handlers.DeprovisionRequestCommandHandler;
+import org.eclipse.edc.connector.controlplane.transfer.command.handlers.NotifyPreparedCommandHandler;
 import org.eclipse.edc.connector.controlplane.transfer.command.handlers.ResumeTransferCommandHandler;
 import org.eclipse.edc.connector.controlplane.transfer.command.handlers.SuspendTransferCommandHandler;
 import org.eclipse.edc.connector.controlplane.transfer.command.handlers.TerminateTransferCommandHandler;
@@ -47,7 +47,7 @@ public class TransferProcessCommandExtension implements ServiceExtension {
         registry.register(new ResumeTransferCommandHandler(store));
         registry.register(new DeprovisionRequestCommandHandler(store));
         registry.register(new CompleteTransferCommandHandler(store));
-        registry.register(new CompleteProvisionCommandHandler(store, observable));
+        registry.register(new NotifyPreparedCommandHandler(store, observable));
     }
 
 }

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/AddProvisionedResourceCommandHandler.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/AddProvisionedResourceCommandHandler.java
@@ -25,7 +25,10 @@ import java.util.List;
 
 /**
  * Processes a {@link AddProvisionedResourceCommand}
+ *
+ * @deprecated provisioning will be fully managed by the data-plane
  */
+@Deprecated(since = "0.14.1")
 public class AddProvisionedResourceCommandHandler extends EntityCommandHandler<AddProvisionedResourceCommand, TransferProcess> {
 
     private final ProvisionResponsesHandler provisionResponsesHandler;

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/DeprovisionCompleteCommandHandler.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/DeprovisionCompleteCommandHandler.java
@@ -25,7 +25,10 @@ import java.util.List;
 
 /**
  * Handles a {@link DeprovisionCompleteCommand}.
+ *
+ * @deprecated provisioning will be fully managed by the data-plane
  */
+@Deprecated(since = "0.14.1")
 public class DeprovisionCompleteCommandHandler extends EntityCommandHandler<DeprovisionCompleteCommand, TransferProcess> {
 
     private final DeprovisionResponsesHandler deprovisionResponsesHandler;

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/DeprovisionRequestCommandHandler.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/DeprovisionRequestCommandHandler.java
@@ -23,7 +23,10 @@ import org.eclipse.edc.spi.command.EntityCommandHandler;
 
 /**
  * Transitions a transfer process to the {@link TransferProcessStates#DEPROVISIONING DEPROVISIONING} state.
+ *
+ * @deprecated provisioning will be fully managed by the data-plane
  */
+@Deprecated(since = "0.14.1")
 public class DeprovisionRequestCommandHandler extends EntityCommandHandler<DeprovisionRequest, TransferProcess> {
 
     public DeprovisionRequestCommandHandler(TransferProcessStore store) {

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/NotifyPreparedCommandHandler.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/NotifyPreparedCommandHandler.java
@@ -17,30 +17,30 @@ package org.eclipse.edc.connector.controlplane.transfer.command.handlers;
 import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.CompleteProvisionCommand;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.NotifyPreparedCommand;
 import org.eclipse.edc.spi.command.EntityCommandHandler;
 
 /**
- * Handles a {@link CompleteProvisionCommand}.
+ * Handles a {@link NotifyPreparedCommand}.
  */
-public class CompleteProvisionCommandHandler extends EntityCommandHandler<CompleteProvisionCommand, TransferProcess> {
+public class NotifyPreparedCommandHandler extends EntityCommandHandler<NotifyPreparedCommand, TransferProcess> {
 
     private final TransferProcessObservable observable;
 
-    public CompleteProvisionCommandHandler(TransferProcessStore store, TransferProcessObservable observable) {
+    public NotifyPreparedCommandHandler(TransferProcessStore store, TransferProcessObservable observable) {
         super(store);
         this.observable = observable;
     }
 
     @Override
-    public Class<CompleteProvisionCommand> getType() {
-        return CompleteProvisionCommand.class;
+    public Class<NotifyPreparedCommand> getType() {
+        return NotifyPreparedCommand.class;
     }
 
     @Override
-    protected boolean modify(TransferProcess entity, CompleteProvisionCommand command) {
-        if (command.getNewAddress() != null) {
-            entity.updateDestination(command.getNewAddress());
+    protected boolean modify(TransferProcess entity, NotifyPreparedCommand command) {
+        if (command.getDataAddress() != null) {
+            entity.updateDestination(command.getDataAddress());
         }
 
         if (entity.getType() == TransferProcess.Type.CONSUMER) {
@@ -52,7 +52,7 @@ public class CompleteProvisionCommandHandler extends EntityCommandHandler<Comple
     }
 
     @Override
-    public void postActions(TransferProcess entity, CompleteProvisionCommand command) {
+    public void postActions(TransferProcess entity, NotifyPreparedCommand command) {
         observable.invokeForEach(l -> l.provisioned(entity));
     }
 }

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/flow/DataFlowManagerImpl.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/flow/DataFlowManagerImpl.java
@@ -59,9 +59,9 @@ public class DataFlowManagerImpl implements DataFlowManager {
     }
 
     @Override
-    public @NotNull StatusResult<DataFlowResponse> provision(TransferProcess transferProcess, Policy policy) {
+    public @NotNull StatusResult<DataFlowResponse> prepare(TransferProcess transferProcess, Policy policy) {
         try {
-            return chooseControllerAndApply(transferProcess, controller -> controller.provision(transferProcess, policy));
+            return chooseControllerAndApply(transferProcess, controller -> controller.prepare(transferProcess, policy));
         } catch (Exception e) {
             var message = runtimeException(transferProcess.getId(), e.getMessage());
             monitor.severe(message, e);

--- a/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/NotifyPreparedCommandHandlerTest.java
+++ b/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/NotifyPreparedCommandHandlerTest.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProce
 import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.CompleteProvisionCommand;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.NotifyPreparedCommand;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.junit.jupiter.api.Test;
 
@@ -33,21 +33,21 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-class CompleteProvisionCommandHandlerTest {
+class NotifyPreparedCommandHandlerTest {
 
     private final TransferProcessObservable observable = new TransferProcessObservableImpl();
-    private final CompleteProvisionCommandHandler handler = new CompleteProvisionCommandHandler(mock(TransferProcessStore.class), observable);
+    private final NotifyPreparedCommandHandler handler = new NotifyPreparedCommandHandler(mock(TransferProcessStore.class), observable);
 
     @Test
     void verifyCorrectType() {
-        assertThat(handler.getType()).isEqualTo(CompleteProvisionCommand.class);
+        assertThat(handler.getType()).isEqualTo(NotifyPreparedCommand.class);
     }
 
     @Test
     void shouldTransitionProvisioned_whenConsumer() {
         var newDestination = DataAddress.Builder.newInstance().type("new").build();
         var originalDestination = DataAddress.Builder.newInstance().type("original").build();
-        var command = new CompleteProvisionCommand("test-id", newDestination);
+        var command = new NotifyPreparedCommand("test-id", newDestination);
         var entity = TransferProcess.Builder.newInstance().state(PROVISIONING_REQUESTED.code()).type(CONSUMER).dataDestination(originalDestination).build();
 
         var result = handler.modify(entity, command);
@@ -59,7 +59,7 @@ class CompleteProvisionCommandHandlerTest {
 
     @Test
     void shouldNotUpdateDestination_whenItIsMissing() {
-        var command = new CompleteProvisionCommand("test-id", null);
+        var command = new NotifyPreparedCommand("test-id", null);
         var originalDestination = DataAddress.Builder.newInstance().type("original").build();
         var entity = TransferProcess.Builder.newInstance().state(PROVISIONING_REQUESTED.code()).dataDestination(originalDestination).build();
 
@@ -74,7 +74,7 @@ class CompleteProvisionCommandHandlerTest {
     void shouldTransitionToStarting_whenProvider() {
         var newDestination = DataAddress.Builder.newInstance().type("new").build();
         var originalDestination = DataAddress.Builder.newInstance().type("original").build();
-        var command = new CompleteProvisionCommand("test-id", newDestination);
+        var command = new NotifyPreparedCommand("test-id", newDestination);
         var entity = TransferProcess.Builder.newInstance().state(STARTUP_REQUESTED.code()).type(PROVIDER).dataDestination(originalDestination).build();
 
         var result = handler.modify(entity, command);
@@ -86,7 +86,7 @@ class CompleteProvisionCommandHandlerTest {
 
     @Test
     void postAction_shouldCallProvisioned() {
-        var command = new CompleteProvisionCommand("test-id", null);
+        var command = new NotifyPreparedCommand("test-id", null);
         var entity = TransferProcess.Builder.newInstance().state(PROVISIONING_REQUESTED.code()).build();
         var listener = mock(TransferProcessListener.class);
         observable.registerListener(listener);

--- a/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/flow/DataFlowManagerImplTest.java
+++ b/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/flow/DataFlowManagerImplTest.java
@@ -129,13 +129,13 @@ class DataFlowManagerImplTest {
             var policy = Policy.Builder.newInstance().build();
 
             when(controller.canHandle(any())).thenReturn(true);
-            when(controller.provision(any(), any())).thenReturn(StatusResult.success(DataFlowResponse.Builder.newInstance().build()));
+            when(controller.prepare(any(), any())).thenReturn(StatusResult.success(DataFlowResponse.Builder.newInstance().build()));
             manager.register(controller);
 
-            var result = manager.provision(transferProcess, policy);
+            var result = manager.prepare(transferProcess, policy);
 
             assertThat(result).isSucceeded();
-            verify(controller).provision(transferProcess, policy);
+            verify(controller).prepare(transferProcess, policy);
         }
     }
 

--- a/extensions/control-plane/api/control-plane-api-client/src/main/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/EmbeddedTransferProcessHttpClient.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/main/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/EmbeddedTransferProcessHttpClient.java
@@ -15,7 +15,7 @@
 package org.eclipse.edc.connector.controlplane.api.client.transferprocess;
 
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.CompleteProvisionCommand;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.NotifyPreparedCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.TerminateTransferCommand;
 import org.eclipse.edc.connector.dataplane.spi.DataFlow;
 import org.eclipse.edc.connector.dataplane.spi.port.TransferProcessApiClient;
@@ -49,7 +49,7 @@ public class EmbeddedTransferProcessHttpClient implements TransferProcessApiClie
 
     @Override
     public StatusResult<Void> provisioned(DataFlow dataFlow) {
-        return transferProcessService.completeProvision(new CompleteProvisionCommand(dataFlow.getId(), dataFlow.provisionedDataAddress()))
+        return transferProcessService.notifyPrepared(new NotifyPreparedCommand(dataFlow.getId(), dataFlow.provisionedDataAddress()))
                 .flatMap(toStatusResult());
     }
 

--- a/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/EmbeddedTransferProcessHttpClientTest.java
+++ b/extensions/control-plane/api/control-plane-api-client/src/test/java/org/eclipse/edc/connector/controlplane/api/client/transferprocess/EmbeddedTransferProcessHttpClientTest.java
@@ -69,12 +69,12 @@ class EmbeddedTransferProcessHttpClientTest {
         @Test
         void shouldCallService() {
             var serviceResult = ServiceResult.<Void>success();
-            when(service.completeProvision(any())).thenReturn(serviceResult);
+            when(service.notifyPrepared(any())).thenReturn(serviceResult);
 
             var result = client.provisioned(DataFlow.Builder.newInstance().id("anyId").build());
 
             assertThat(result).isSucceeded();
-            verify(service).completeProvision(any());
+            verify(service).notifyPrepared(any());
         }
     }
 

--- a/extensions/control-plane/api/control-plane-api/src/main/java/org/eclipse/edc/connector/controlplane/api/transferprocess/TransferProcessControlApiController.java
+++ b/extensions/control-plane/api/control-plane-api/src/main/java/org/eclipse/edc/connector/controlplane/api/transferprocess/TransferProcessControlApiController.java
@@ -23,7 +23,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.eclipse.edc.connector.controlplane.api.transferprocess.model.TransferProcessFailStateDto;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.CompleteProvisionCommand;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.NotifyPreparedCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.TerminateTransferCommand;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.validator.spi.ValidationResult;
@@ -68,10 +68,10 @@ public class TransferProcessControlApiController implements TransferProcessContr
     @POST
     @Path("/{processId}/provisioned")
     @Override
-    public void provisioned(@PathParam("processId") String processId, DataAddress newDataAddress) {
-        var command = new CompleteProvisionCommand(processId, newDataAddress);
+    public void provisioned(@PathParam("processId") String processId, DataAddress dataAddress) {
+        var command = new NotifyPreparedCommand(processId, dataAddress);
 
-        transferProcessService.completeProvision(command)
+        transferProcessService.notifyPrepared(command)
                 .orElseThrow(exceptionMapper(TransferProcess.class, processId));
     }
 

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowController.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowController.java
@@ -78,7 +78,7 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
     }
 
     @Override
-    public StatusResult<DataFlowResponse> provision(TransferProcess transferProcess, Policy policy) {
+    public StatusResult<DataFlowResponse> prepare(TransferProcess transferProcess, Policy policy) {
         var selection = selectorClient.select(selectionStrategy, dataPlane ->
                 dataPlane.canProvisionDestination(transferProcess.getDataDestination()));
         if (selection.failed()) {
@@ -108,7 +108,7 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
 
         var dataPlaneInstance = selection.getContent();
         return clientFactory.createClient(dataPlaneInstance)
-                .provision(dataFlowRequest)
+                .prepare(dataFlowRequest)
                 .map(it -> toResponse(it, dataPlaneInstance));
     }
 

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowControllerTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/DataPlaneSignalingFlowControllerTest.java
@@ -113,16 +113,16 @@ public class DataPlaneSignalingFlowControllerTest {
                     .dataAddress(newDestinationAddress)
                     .provisioning(true)
                     .build();
-            when(dataPlaneClient.provision(any())).thenReturn(StatusResult.success(flowResponseMessage));
+            when(dataPlaneClient.prepare(any())).thenReturn(StatusResult.success(flowResponseMessage));
 
-            var result = flowController.provision(transferProcess, policyBuilder().build());
+            var result = flowController.prepare(transferProcess, policyBuilder().build());
 
             assertThat(result).isSucceeded().satisfies(dataFlowResponse -> {
                 assertThat(dataFlowResponse.getDataPlaneId()).isEqualTo(dataPlaneInstance.getId());
                 assertThat(dataFlowResponse.getDataAddress()).isSameAs(newDestinationAddress);
                 assertThat(dataFlowResponse.isProvisioning()).isTrue();
             });
-            verify(dataPlaneClient).provision(isA(DataFlowProvisionMessage.class));
+            verify(dataPlaneClient).prepare(isA(DataFlowProvisionMessage.class));
         }
 
         @Test
@@ -130,7 +130,7 @@ public class DataPlaneSignalingFlowControllerTest {
             var transferProcess = transferProcessBuilder().build();
             when(selectorService.select(any(), any())).thenReturn(ServiceResult.notFound("no data plane can provision this"));
 
-            var result = flowController.provision(transferProcess, policyBuilder().build());
+            var result = flowController.prepare(transferProcess, policyBuilder().build());
 
             assertThat(result).isFailed();
             verifyNoInteractions(dataPlaneClientFactory);
@@ -141,7 +141,7 @@ public class DataPlaneSignalingFlowControllerTest {
             var transferProcess = transferProcessBuilder().build();
             when(selectorService.select(any(), any())).thenReturn(ServiceResult.unexpected("unexpected error"));
 
-            var result = flowController.provision(transferProcess, policyBuilder().build());
+            var result = flowController.prepare(transferProcess, policyBuilder().build());
 
             assertThat(result).isFailed();
         }
@@ -152,7 +152,7 @@ public class DataPlaneSignalingFlowControllerTest {
             when(selectorService.select(any(), any())).thenReturn(ServiceResult.success(createDataPlaneInstance()));
             when(transferTypeParser.parse(any())).thenReturn(Result.failure("transferType error"));
 
-            var result = flowController.provision(transferProcess, policyBuilder().build());
+            var result = flowController.prepare(transferProcess, policyBuilder().build());
 
             assertThat(result).isFailed().detail().isEqualTo("transferType error");
         }
@@ -164,7 +164,7 @@ public class DataPlaneSignalingFlowControllerTest {
             when(transferTypeParser.parse(any())).thenReturn(Result.success(new TransferType("any", FlowType.PUSH)));
             when(propertiesProvider.propertiesFor(any(), any())).thenReturn(StatusResult.failure(ResponseStatus.FATAL_ERROR, "propertiesProvider error"));
 
-            var result = flowController.provision(transferProcess, policyBuilder().build());
+            var result = flowController.prepare(transferProcess, policyBuilder().build());
 
             assertThat(result).isFailed().detail().isEqualTo("propertiesProvider error");
         }

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClient.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClient.java
@@ -70,7 +70,7 @@ public class DataPlaneSignalingClient implements DataPlaneClient {
     }
 
     @Override
-    public StatusResult<DataFlowResponseMessage> provision(DataFlowProvisionMessage message) {
+    public StatusResult<DataFlowResponseMessage> prepare(DataFlowProvisionMessage message) {
         var url = "%s/prepare".formatted(dataPlane.getUrl());
         return createRequestBuilder(message, url)
                 .compose(builder -> httpClient.request(builder)

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClient.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClient.java
@@ -38,7 +38,7 @@ public class EmbeddedDataPlaneClient implements DataPlaneClient {
     }
 
     @Override
-    public StatusResult<DataFlowResponseMessage> provision(DataFlowProvisionMessage request) {
+    public StatusResult<DataFlowResponseMessage> prepare(DataFlowProvisionMessage request) {
         var provisioning = dataPlaneManager.provision(request);
         if (provisioning.failed()) {
             return StatusResult.failure(ResponseStatus.FATAL_ERROR, provisioning.getFailureDetail());

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientTest.java
@@ -296,7 +296,7 @@ class DataPlaneSignalingClientTest {
                     .willReturn(badRequest()));
 
 
-            var result = dataPlaneClient.provision(request);
+            var result = dataPlaneClient.prepare(request);
 
             dataPlane.verify(postRequestedFor(urlEqualTo(DATA_PLANE_PATH + "/prepare")).withRequestBody(equalTo(body)));
 
@@ -319,7 +319,7 @@ class DataPlaneSignalingClientTest {
             dataPlane.stubFor(post(DATA_PLANE_PATH + "/prepare").withRequestBody(equalTo(body))
                     .willReturn(aResponse().withStatus(400).withBody(errorMsg)));
 
-            var result = dataPlaneClient.provision(request);
+            var result = dataPlaneClient.prepare(request);
 
             dataPlane.verify(postRequestedFor(urlEqualTo(DATA_PLANE_PATH + "/prepare")).withRequestBody(equalTo(body)));
 
@@ -335,7 +335,7 @@ class DataPlaneSignalingClientTest {
 
             when(registry.transform(any(), any())).thenReturn(Result.failure("Transform Failure"));
 
-            var result = dataPlaneClient.provision(request);
+            var result = dataPlaneClient.prepare(request);
 
             assertThat(result).isFailed().extracting(ResponseFailure::status).isEqualTo(FATAL_ERROR);
             assertThat(result.getFailureMessages())
@@ -356,7 +356,7 @@ class DataPlaneSignalingClientTest {
             dataPlane.stubFor(post(DATA_PLANE_PATH + "/prepare").withRequestBody(equalTo(body))
                     .willReturn(okJson("{}")));
 
-            var result = dataPlaneClient.provision(request);
+            var result = dataPlaneClient.prepare(request);
 
             dataPlane.verify(postRequestedFor(urlEqualTo(DATA_PLANE_PATH + "/prepare")).withRequestBody(equalTo(body)));
 
@@ -383,7 +383,7 @@ class DataPlaneSignalingClientTest {
             dataPlane.stubFor(post(DATA_PLANE_PATH + "/prepare").withRequestBody(equalTo(body))
                     .willReturn(okJson(MAPPER.writeValueAsString(response))));
 
-            var result = dataPlaneClient.provision(request);
+            var result = dataPlaneClient.prepare(request);
 
             dataPlane.verify(postRequestedFor(urlEqualTo(DATA_PLANE_PATH + "/prepare")).withRequestBody(equalTo(body)));
 
@@ -406,7 +406,7 @@ class DataPlaneSignalingClientTest {
             dataPlane.stubFor(post(DATA_PLANE_PATH + "/prepare").withRequestBody(equalTo(body))
                     .willReturn(okJson(MAPPER.writeValueAsString(response))));
 
-            var result = dataPlaneClient.provision(request);
+            var result = dataPlaneClient.prepare(request);
 
             dataPlane.verify(postRequestedFor(urlEqualTo(DATA_PLANE_PATH + "/prepare")).withRequestBody(equalTo(body)));
 

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClientTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/EmbeddedDataPlaneClientTest.java
@@ -51,7 +51,7 @@ class EmbeddedDataPlaneClientTest {
                     .build();
             when(dataPlaneManager.provision(any())).thenReturn(StatusResult.success(response));
 
-            var result = client.provision(request);
+            var result = client.prepare(request);
 
             assertThat(result).isSucceeded().isEqualTo(response);
         }
@@ -64,7 +64,7 @@ class EmbeddedDataPlaneClientTest {
                     .build();
             when(dataPlaneManager.provision(any())).thenReturn(StatusResult.failure(ResponseStatus.FATAL_ERROR, "error"));
 
-            var result = client.provision(request);
+            var result = client.prepare(request);
 
             assertThat(result).isFailed();
         }

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/transferprocess/TransferProcessService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/transferprocess/TransferProcessService.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.DeprovisionedRe
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionResponse;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.CompleteProvisionCommand;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.NotifyPreparedCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.ResumeTransferCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.SuspendTransferCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.TerminateTransferCommand;
@@ -121,12 +121,12 @@ public interface TransferProcessService {
     ServiceResult<TransferProcess> initiateTransfer(ParticipantContext participantContext, TransferRequest request);
 
     /**
-     * Asynchronously notifies the system that the provisioning phase has been completed.
+     * Asynchronously notifies the system that the preparation phase has been completed by the data-plane.
      *
      * @param command the command.
      * @return the result.
      */
-    ServiceResult<Void> completeProvision(CompleteProvisionCommand command);
+    ServiceResult<Void> notifyPrepared(NotifyPreparedCommand command);
 
     /**
      * Asynchronously informs the system that the {@link DeprovisionedResource} has been provisioned
@@ -134,7 +134,9 @@ public interface TransferProcessService {
      * @param transferProcessId The transfer process id
      * @param resource          The {@link DeprovisionedResource} to deprovision
      * @return a result that is successful if the transfer process was found
+     * @deprecated provisioning will be fully managed by the data-plane
      */
+    @Deprecated(since = "0.14.1")
     ServiceResult<Void> completeDeprovision(String transferProcessId, DeprovisionedResource resource);
 
     /**
@@ -143,7 +145,9 @@ public interface TransferProcessService {
      * @param transferProcessId The transfer process id
      * @param response          The {@link ProvisionResponse} to handle
      * @return a result that is successful if the transfer process was found
+     * @deprecated provisioning will be fully managed by the data-plane
      */
+    @Deprecated(since = "0.14.1")
     ServiceResult<Void> addProvisionedResource(String transferProcessId, ProvisionResponse response);
 
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowController.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowController.java
@@ -37,7 +37,14 @@ public interface DataFlowController {
      */
     boolean canHandle(TransferProcess transferProcess);
 
-    StatusResult<DataFlowResponse> provision(TransferProcess transferProcess, Policy policy);
+    /**
+     * Prepare a DataFlow
+     *
+     * @param transferProcess the transfer process.
+     * @param policy the contract agreement policy.
+     * @return success if the preparation initialize/completes correctly, failure otherwise.
+     */
+    StatusResult<DataFlowResponse> prepare(TransferProcess transferProcess, Policy policy);
 
     /**
      * Initiate a data flow.

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowManager.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowManager.java
@@ -50,10 +50,10 @@ public interface DataFlowManager {
      *
      * @param transferProcess the transfer process
      * @param policy          the contract agreement usage policy for the asset being transferred
-     * @return succeeded StatusResult if flow has been initiated correctly, failed one otherwise.
+     * @return succeeded StatusResult if preparation has been initiated/completed correctly, failed one otherwise.
      */
     @NotNull
-    StatusResult<DataFlowResponse> provision(TransferProcess transferProcess, Policy policy);
+    StatusResult<DataFlowResponse> prepare(TransferProcess transferProcess, Policy policy);
 
     /**
      * Starts a provider data flow.

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/DataFlowResponse.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/DataFlowResponse.java
@@ -18,7 +18,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 
 /**
- * A Response for {@link DataFlowManager#start} and {@link DataFlowManager#provision} operation
+ * A Response for {@link DataFlowManager#start} and {@link DataFlowManager#prepare} operation
  */
 public class DataFlowResponse {
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/DeprovisionedResource.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/DeprovisionedResource.java
@@ -25,7 +25,10 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A response for a deprovision operation.
+ *
+ * @deprecated provisioning will be fully managed by the data-plane
  */
+@Deprecated(since = "0.14.1")
 @JsonTypeName("dataspaceconnector:deprovisionedresource")
 @JsonDeserialize(builder = DeprovisionedResource.Builder.class)
 public class DeprovisionedResource {

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/ProvisionResponse.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/ProvisionResponse.java
@@ -21,7 +21,10 @@ import java.util.Objects;
 
 /**
  * An asynchronous response to a provision request.
+ *
+ * @deprecated provisioning will be fully managed by the data-plane
  */
+@Deprecated(since = "0.14.1")
 public class ProvisionResponse {
     private final ProvisionedResource resource;
     private final SecretToken secretToken;

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/ProvisionedContentResource.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/ProvisionedContentResource.java
@@ -20,7 +20,10 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
  * A provisioned resource that is asset content.
  *
  * This resource type is created when a provider's backend system provisions data as part of a data transfer.
+ *
+ * @deprecated provisioning will be fully managed by the data-plane
  */
+@Deprecated(since = "0.14.1")
 public abstract class ProvisionedContentResource extends ProvisionedDataAddressResource {
 
     protected ProvisionedContentResource() {

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/ProvisionedDataAddressResource.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/ProvisionedDataAddressResource.java
@@ -21,7 +21,10 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A provisioned resource that is referenced using a {@link DataAddress}.
+ *
+ * @deprecated provisioning will be fully managed by the data-plane
  */
+@Deprecated(since = "0.14.1")
 public abstract class ProvisionedDataAddressResource extends ProvisionedResource {
     protected String resourceName;
     protected DataAddress dataAddress;

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/ProvisionedDataDestinationResource.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/ProvisionedDataDestinationResource.java
@@ -20,7 +20,10 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 /**
  * A provisioned resource that serves as a data destination.
+ *
+ * @deprecated provisioning will be fully managed by the data-plane
  */
+@Deprecated(since = "0.14.1")
 @JsonTypeName("dataspaceconnector:provisioneddatadestinationresource")
 @JsonDeserialize(builder = ProvisionedDataDestinationResource.Builder.class)
 public abstract class ProvisionedDataDestinationResource extends ProvisionedDataAddressResource {

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/ProvisionedResource.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/ProvisionedResource.java
@@ -24,7 +24,10 @@ import java.util.Objects;
 
 /**
  * A provisioned resource that supports a data transfer request.
+ *
+ * @deprecated provisioning will be fully managed by the data-plane
  */
+@Deprecated(since = "0.14.1")
 @JsonTypeName("dataspaceconnector:provisionedresource")
 @JsonDeserialize(builder = ProvisionedResource.Builder.class)
 public abstract class ProvisionedResource implements Polymorphic {

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/ProvisionedResourceSet.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/ProvisionedResourceSet.java
@@ -23,7 +23,10 @@ import java.util.List;
 
 /**
  * A collection of provisioned resources that support a data transfer.
+ *
+ * @deprecated provisioning will be fully managed by the data-plane
  */
+@Deprecated(since = "0.14.1")
 @JsonTypeName("dataspaceconnector:provisionedresourceset")
 @JsonDeserialize(builder = ProvisionedResourceSet.Builder.class)
 public class ProvisionedResourceSet {

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/ResourceDefinition.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/ResourceDefinition.java
@@ -24,7 +24,10 @@ import java.util.Objects;
 
 /**
  * A resource to be provisioned to support a data transfer.
+ *
+ * @deprecated provisioning will be fully managed by the data-plane
  */
+@Deprecated(since = "0.14.1")
 @JsonTypeName("dataspaceconnector:resourcedefinition")
 @JsonDeserialize(builder = ResourceDefinition.Builder.class)
 public abstract class ResourceDefinition implements Polymorphic {

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/ResourceManifest.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/ResourceManifest.java
@@ -25,7 +25,10 @@ import java.util.Objects;
 
 /**
  * A collection of resources to be provisioned to support a data transfer, e.g. a data destination such as an object storage container.
+ *
+ * @deprecated provisioning will be fully managed by the data-plane
  */
+@Deprecated(since = "0.14.1")
 @JsonTypeName("dataspaceconnector:resourcemanifest")
 @JsonDeserialize(builder = ResourceManifest.Builder.class)
 public class ResourceManifest {

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/SecretToken.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/SecretToken.java
@@ -19,7 +19,10 @@ import org.eclipse.edc.spi.types.domain.Polymorphic;
 
 /**
  * A temporary token with write privileges to the data destination.
+ *
+ * @deprecated provisioning will be fully managed by the data-plane
  */
+@Deprecated(since = "0.14.1")
 @JsonTypeName("dataspaceconnector:secrettoken")
 public interface SecretToken extends Polymorphic {
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/command/AddProvisionedResourceCommand.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/command/AddProvisionedResourceCommand.java
@@ -24,7 +24,10 @@ import org.eclipse.edc.spi.command.EntityCommand;
  * a provisioner that delegates to an external system may receive a response on an asynchronous callback channel. The response therefore cannot be returned using the
  * provisioner's future as there is no guarantee the response from the external system will be routed to the originating EDC runtime.
  * <p>
+ *
+ * @deprecated provisioning will be fully managed by the data-plane
  */
+@Deprecated(since = "0.14.1")
 public class AddProvisionedResourceCommand extends EntityCommand {
     private final ProvisionResponse provisionResponse;
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/command/DeprovisionCompleteCommand.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/command/DeprovisionCompleteCommand.java
@@ -19,7 +19,10 @@ import org.eclipse.edc.spi.command.EntityCommand;
 
 /**
  * Informs the system that deprovisioning a resource has indeed completed.
+ *
+ * @deprecated provisioning will be fully managed by the data-plane
  */
+@Deprecated(since = "0.14.1")
 public class DeprovisionCompleteCommand extends EntityCommand {
     private final DeprovisionedResource resource;
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/command/DeprovisionRequest.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/command/DeprovisionRequest.java
@@ -21,7 +21,10 @@ import org.eclipse.edc.spi.command.EntityCommand;
 /**
  * Issues a request to start deprovisioning a transfer process by setting its state to
  * {@link TransferProcessStates#DEPROVISIONING DEPROVISIONING}.
+ *
+ * @deprecated provisioning will be fully managed by the data-plane
  */
+@Deprecated(since = "0.14.1")
 public class DeprovisionRequest extends EntityCommand {
 
     public DeprovisionRequest(String transferProcessId) {

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/command/NotifyPreparedCommand.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/command/NotifyPreparedCommand.java
@@ -20,16 +20,16 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 /**
  * Informs the transfer process that the provision phase has been completed
  */
-public class CompleteProvisionCommand extends EntityCommand {
+public class NotifyPreparedCommand extends EntityCommand {
 
-    private final DataAddress newAddress;
+    private final DataAddress dataAddress;
 
-    public CompleteProvisionCommand(String transferProcessId, DataAddress newAddress) {
+    public NotifyPreparedCommand(String transferProcessId, DataAddress dataAddress) {
         super(transferProcessId);
-        this.newAddress = newAddress;
+        this.dataAddress = dataAddress;
     }
 
-    public DataAddress getNewAddress() {
-        return newAddress;
+    public DataAddress getDataAddress() {
+        return dataAddress;
     }
 }

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/client/DataPlaneClient.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/client/DataPlaneClient.java
@@ -32,7 +32,7 @@ public interface DataPlaneClient {
      * @param request the request.
      * @return success if the data flow preparation has been triggered/executed, failure otherwise
      */
-    StatusResult<DataFlowResponseMessage> provision(DataFlowProvisionMessage request);
+    StatusResult<DataFlowResponseMessage> prepare(DataFlowProvisionMessage request);
 
     /**
      * Delegates data transfer to the Data Plane.


### PR DESCRIPTION
## What this PR changes/adds

Adapts "prepare" semantics to the Dataplane Signaling Protocol at the TransferProcess service layer

## Why it does that

prepare to DSP

## Further notes
- deprecated some control-plane provision stuff


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

part of #5323 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
