### PR TITLE
refactor: deprecate monitor-jdk-logger

### DIFF
--- a/extensions/common/monitor/monitor-jdk-logger/README.md
+++ b/extensions/common/monitor/monitor-jdk-logger/README.md
@@ -1,5 +1,7 @@
 # JDK Logger Monitor
 
+> This extension has been deprecated and it could be removed after 0.17.0 release
+
 This extension provides a `Logger` which is an implementation of edc `Monitor` interface. It is based on `java.util.logging` package so it doesn't introduce any additional dependencies. As this extension is based on `MonitorExtension` which means this logger extension will load during the runtime initialization and all monitor logs (including edc core framework) will be forwarded to this logger.
 
 ## Usages

--- a/extensions/common/monitor/monitor-jdk-logger/src/main/java/org/eclipse/edc/monitor/logger/LoggerMonitor.java
+++ b/extensions/common/monitor/monitor-jdk-logger/src/main/java/org/eclipse/edc/monitor/logger/LoggerMonitor.java
@@ -24,7 +24,10 @@ import java.util.logging.Logger;
 
 /**
  * Logging monitor using java.util.logging.
+ *
+ * @deprecated will be removed soon.
  */
+@Deprecated(since = "0.15.0")
 public class LoggerMonitor implements Monitor {
 
     /**

--- a/extensions/common/monitor/monitor-jdk-logger/src/main/java/org/eclipse/edc/monitor/logger/LoggerMonitorExtension.java
+++ b/extensions/common/monitor/monitor-jdk-logger/src/main/java/org/eclipse/edc/monitor/logger/LoggerMonitorExtension.java
@@ -20,9 +20,17 @@ import org.eclipse.edc.spi.system.MonitorExtension;
 
 /**
  * Extension adding logging monitor.
+ *
+ * @deprecated will be removed soon.
  */
 @Extension("Logger monitor")
+@Deprecated(since = "0.15.0")
 public class LoggerMonitorExtension implements MonitorExtension {
+
+    @Override
+    public String name() {
+        return "DEPRECATED: Logger Monitor";
+    }
 
     @Override
     public Monitor getMonitor() {


### PR DESCRIPTION
## What this PR changes/adds

Deprecates `monitor-jdk-logger`

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5312 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
