### PR TITLE
refactor: fixup 0.13.0 deprecations

### DIFF
--- a/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-http-api-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/NegotiationApiPaths.java
+++ b/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-http-api-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/NegotiationApiPaths.java
@@ -25,7 +25,7 @@ public interface NegotiationApiPaths {
     String INITIAL_CONTRACT_OFFER = "offer";
     String INITIAL_CONTRACT_OFFERS = "offers";
     String CONTRACT_REQUEST = "/" + INITIAL_CONTRACT_REQUEST;
-    @Deprecated(since = "0.13.0")
+    @Deprecated(since = "0.14.0")
     String CONTRACT_OFFER = "/" + INITIAL_CONTRACT_OFFER;
     String CONTRACT_OFFERS = "/" + INITIAL_CONTRACT_OFFERS;
     String EVENT = "/events";

--- a/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-http-api-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiControllerTestBase.java
+++ b/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-http-api-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiControllerTestBase.java
@@ -49,10 +49,10 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.AGREEMENT;
-import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.CONTRACT_OFFER;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.CONTRACT_OFFERS;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.CONTRACT_REQUEST;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.EVENT;
-import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.INITIAL_CONTRACT_OFFER;
+import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.INITIAL_CONTRACT_OFFERS;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.INITIAL_CONTRACT_REQUEST;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.TERMINATION;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.VERIFICATION;
@@ -202,11 +202,11 @@ public abstract class DspNegotiationApiControllerTestBase extends RestController
 
 
     protected String offersPath() {
-        return CONTRACT_OFFER;
+        return CONTRACT_OFFERS;
     }
 
     protected String initialOffersPath() {
-        return INITIAL_CONTRACT_OFFER;
+        return INITIAL_CONTRACT_OFFERS;
     }
 
     private RequestSpecification baseRequest() {


### PR DESCRIPTION
## What this PR changes/adds

Provide endpoints with the correct path and deprecate the old ones.
Moved deprecations to 0.14.0 so the wrong endpoints will be removed since the next version

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
