### PR TITLE
feat: add dataplaneMetadata field to TransferRequest/Process

### DIFF
--- a/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
@@ -159,6 +159,7 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
                 .callbackAddresses(transferRequest.getCallbackAddresses())
                 .traceContext(telemetry.getCurrentTraceContext())
                 .participantContextId(participantContext.getParticipantContextId())
+                .dataplaneMetadata(transferRequest.getDataplaneMetadata())
                 .build();
 
         observable.invokeForEach(l -> l.preCreated(process));

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/from/JsonObjectFromAssetTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/from/JsonObjectFromAssetTransformer.java
@@ -63,7 +63,7 @@ public class JsonObjectFromAssetTransformer extends AbstractJsonLdTransformer<As
             builder.add(Asset.EDC_ASSET_DATA_ADDRESS, context.transform(asset.getDataAddress(), JsonObject.class));
         }
 
-        if (asset.getDataplaneMetadata() != null && !asset.getDataplaneMetadata().isEmpty()) {
+        if (asset.getDataplaneMetadata() != null) {
             builder.add(Asset.EDC_ASSET_DATAPLANE_METADATA, context.transform(asset.getDataplaneMetadata(), JsonObject.class));
         }
 

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/from/JsonObjectFromDataplaneMetadataTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/from/JsonObjectFromDataplaneMetadataTransformer.java
@@ -25,6 +25,9 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Supplier;
 
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata.EDC_DATAPLANE_METADATA_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+
 public class JsonObjectFromDataplaneMetadataTransformer extends AbstractJsonLdTransformer<DataplaneMetadata, JsonObject> {
 
     private final JsonBuilderFactory jsonFactory;
@@ -38,7 +41,8 @@ public class JsonObjectFromDataplaneMetadataTransformer extends AbstractJsonLdTr
 
     @Override
     public @Nullable JsonObject transform(@NotNull DataplaneMetadata dataplaneMetadata, @NotNull TransformerContext context) {
-        var builder = jsonFactory.createObjectBuilder();
+        var builder = jsonFactory.createObjectBuilder()
+                .add(TYPE, EDC_DATAPLANE_METADATA_TYPE);
 
         var labels = dataplaneMetadata.getLabels();
         if (!labels.isEmpty()) {

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/transferprocess/from/JsonObjectFromTransferProcessTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/transferprocess/from/JsonObjectFromTransferProcessTransformer.java
@@ -30,6 +30,7 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_CALLBACK_ADDRESSES;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_CONTRACT_ID;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_CORRELATION_ID;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_DATAPLANE_METADATA;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_DATA_DESTINATION;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_ERROR_DETAIL;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_STATE;
@@ -70,6 +71,8 @@ public class JsonObjectFromTransferProcessTransformer extends AbstractJsonLdTran
         addIfNotNull(input.getErrorDetail(), TRANSFER_PROCESS_ERROR_DETAIL, builder);
         Optional.ofNullable(input.getDataDestination()).map(it -> context.transform(it, JsonObject.class))
                 .ifPresent(it -> builder.add(TRANSFER_PROCESS_DATA_DESTINATION, it));
+        Optional.ofNullable(input.getDataplaneMetadata()).map(it -> context.transform(it, JsonObject.class))
+                .ifPresent(it -> builder.add(TRANSFER_PROCESS_DATAPLANE_METADATA, it));
 
         return builder.build();
     }

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/transferprocess/to/JsonObjectToTransferRequestTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/transferprocess/to/JsonObjectToTransferRequestTransformer.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.controlplane.transform.edc.transferprocess.to;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -35,6 +36,7 @@ import static jakarta.json.JsonValue.ValueType.OBJECT;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_CALLBACK_ADDRESSES;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_CONTRACT_ID;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_DATAPLANE_METADATA;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_DATA_DESTINATION;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_PRIVATE_PROPERTIES;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_PROTOCOL;
@@ -51,21 +53,24 @@ public class JsonObjectToTransferRequestTransformer extends AbstractJsonLdTransf
         var builder = TransferRequest.Builder.newInstance();
 
         builder.id(nodeId(input));
-        visitProperties(input, k -> switch (k) {
-            case TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS ->
-                    v -> builder.counterPartyAddress(transformString(v, context));
-            case TRANSFER_REQUEST_CONTRACT_ID -> (v) -> builder.contractId(transformString(v, context));
-            case TRANSFER_REQUEST_DATA_DESTINATION ->
-                    v -> builder.dataDestination(transformObject(v, DataAddress.class, context));
-            case TRANSFER_REQUEST_CALLBACK_ADDRESSES -> (v) -> {
+        visitProperties(input, key -> switch (key) {
+            case TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS -> value ->
+                    builder.counterPartyAddress(transformString(value, context));
+            case TRANSFER_REQUEST_CONTRACT_ID -> value -> builder.contractId(transformString(value, context));
+            case TRANSFER_REQUEST_DATA_DESTINATION -> value ->
+                    builder.dataDestination(transformObject(value, DataAddress.class, context));
+            case TRANSFER_REQUEST_CALLBACK_ADDRESSES -> value -> {
                 var addresses = new ArrayList<CallbackAddress>();
-                transformArrayOrObject(v, CallbackAddress.class, addresses::add, context);
+                transformArrayOrObject(value, CallbackAddress.class, addresses::add, context);
                 builder.callbackAddresses(addresses);
             };
-            case TRANSFER_REQUEST_PRIVATE_PROPERTIES ->
-                    (v) -> transformProperties(v, builder::privateProperties, context);
-            case TRANSFER_REQUEST_PROTOCOL -> (v) -> builder.protocol(transformString(v, context));
-            case TRANSFER_REQUEST_TRANSFER_TYPE -> (v) -> builder.transferType(transformString(v, context));
+            case TRANSFER_REQUEST_PRIVATE_PROPERTIES -> value ->
+                    transformProperties(value, builder::privateProperties, context);
+            case TRANSFER_REQUEST_PROTOCOL -> value -> builder.protocol(transformString(value, context));
+            case TRANSFER_REQUEST_TRANSFER_TYPE -> value ->
+                    builder.transferType(transformString(value, context));
+            case TRANSFER_REQUEST_DATAPLANE_METADATA -> value ->
+                    builder.dataplaneMetadata(transformObject(value, DataplaneMetadata.class, context));
             default -> doNothing();
         });
 
@@ -74,10 +79,10 @@ public class JsonObjectToTransferRequestTransformer extends AbstractJsonLdTransf
 
     private void transformProperties(JsonValue jsonValue, Consumer<Map<String, Object>> consumer, TransformerContext context) {
         JsonObject jsonObject;
-        if (jsonValue instanceof JsonArray) {
-            jsonObject = jsonValue.asJsonArray().getJsonObject(0);
-        } else if (jsonValue instanceof JsonObject) {
-            jsonObject = (JsonObject) jsonValue;
+        if (jsonValue instanceof JsonArray array) {
+            jsonObject = array.getJsonObject(0);
+        } else if (jsonValue instanceof JsonObject object) {
+            jsonObject = object;
         } else {
             context.problem()
                     .unexpectedType()
@@ -87,6 +92,7 @@ public class JsonObjectToTransferRequestTransformer extends AbstractJsonLdTransf
                     .report();
             return;
         }
+
         var properties = new HashMap<String, Object>();
         visitProperties(jsonObject, (k, v) -> properties.put(k, transformString(v, context)));
         consumer.accept(properties);

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/from/JsonObjectFromDataplaneMetadataTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/from/JsonObjectFromDataplaneMetadataTransformerTest.java
@@ -25,6 +25,8 @@ import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata.EDC_DATAPLANE_METADATA_LABELS;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata.EDC_DATAPLANE_METADATA_PROPERTIES;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata.EDC_DATAPLANE_METADATA_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.mockito.Mockito.mock;
 
 class JsonObjectFromDataplaneMetadataTransformerTest {
@@ -41,6 +43,8 @@ class JsonObjectFromDataplaneMetadataTransformerTest {
 
         var result = transformer.transform(dataplaneMetadata, context);
 
+        assertThat(result).isNotNull();
+        assertThat(result.getString(TYPE)).isEqualTo(EDC_DATAPLANE_METADATA_TYPE);
         assertThat(result.getJsonArray(EDC_DATAPLANE_METADATA_LABELS)).hasSize(1).first()
                 .extracting(JsonString.class::cast).extracting(JsonString::getString).isEqualTo("label");
         assertThat(result.getJsonObject(EDC_DATAPLANE_METADATA_PROPERTIES)).hasSize(1)

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/transferprocess/from/JsonObjectFromTransferProcessTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/transferprocess/from/JsonObjectFromTransferProcessTransformerTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.controlplane.transform.edc.transferprocess.fro
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
@@ -32,6 +33,7 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_CALLBACK_ADDRESSES;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_CONTRACT_ID;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_CORRELATION_ID;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_DATAPLANE_METADATA;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_DATA_DESTINATION;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_ERROR_DETAIL;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_STATE;
@@ -63,8 +65,10 @@ class JsonObjectFromTransferProcessTransformerTest {
     void transform() {
         var dataDestinationJson = Json.createObjectBuilder().build();
         var callbackAddressJson = Json.createObjectBuilder().build();
+        var dataplaneMetadataJson = Json.createObjectBuilder().build();
         when(context.transform(isA(DataAddress.class), any())).thenReturn(dataDestinationJson);
         when(context.transform(isA(CallbackAddress.class), any())).thenReturn(callbackAddressJson);
+        when(context.transform(isA(DataplaneMetadata.class), any())).thenReturn(dataplaneMetadataJson);
         var input = TransferProcess.Builder.newInstance()
                 .id("transferProcessId")
                 .state(STARTED.code())
@@ -78,6 +82,7 @@ class JsonObjectFromTransferProcessTransformerTest {
                 .dataDestination(DataAddress.Builder.newInstance().type("any").properties(Map.of("bar", "foo")).build())
                 .callbackAddresses(List.of(CallbackAddress.Builder.newInstance().uri("http://any").events(emptySet()).build()))
                 .errorDetail("an error")
+                .dataplaneMetadata(DataplaneMetadata.Builder.newInstance().label("label").build())
                 .build();
 
         var result = transformer.transform(input, context);
@@ -95,6 +100,7 @@ class JsonObjectFromTransferProcessTransformerTest {
         assertThat(result.getJsonObject(TRANSFER_PROCESS_DATA_DESTINATION)).isSameAs(dataDestinationJson);
         assertThat(result.getJsonArray(TRANSFER_PROCESS_CALLBACK_ADDRESSES).get(0)).isSameAs(callbackAddressJson);
         assertThat(result.getString(TRANSFER_PROCESS_ERROR_DETAIL)).isEqualTo("an error");
+        assertThat(result.getJsonObject(TRANSFER_PROCESS_DATAPLANE_METADATA)).isSameAs(dataplaneMetadataJson);
     }
 
     @Test

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/dataplane-metadata-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/dataplane-metadata-schema.json
@@ -25,10 +25,7 @@
         "properties": {
           "type": "object"
         }
-      },
-      "required": [
-        "@type"
-      ]
+      }
     }
   }
 }

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/transfer-process-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/transfer-process-schema.json
@@ -58,6 +58,9 @@
         },
         "dataDestination": {
           "$ref": "https://w3id.org/edc/connector/management/schema/v4/data-address-schema.json"
+        },
+        "dataplaneMetadata": {
+          "$ref": "https://w3id.org/edc/connector/management/schema/v4/dataplane-metadata-schema.json"
         }
       },
       "required": [

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/transfer-request-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/transfer-request-schema.json
@@ -45,6 +45,9 @@
           "items": {
             "$ref": "https://w3id.org/edc/connector/management/schema/v4/callback-address-schema.json"
           }
+        },
+        "dataplaneMetadata": {
+          "$ref": "https://w3id.org/edc/connector/management/schema/v4/dataplane-metadata-schema.json"
         }
       },
       "required": [

--- a/extensions/common/json-ld/src/main/resources/document/management-context-v2.jsonld
+++ b/extensions/common/json-ld/src/main/resources/document/management-context-v2.jsonld
@@ -24,11 +24,18 @@
           }
         },
         "dataplaneMetadata": {
-          "@id": "edc:dataplaneMetadata",
-          "@context": {
-            "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
-          }
+          "@id": "edc:dataplaneMetadata"
         }
+      }
+    },
+    "DataplaneMetadata": {
+      "@id": "edc:DataplaneMetadata",
+      "@context": {
+        "labels": {
+          "@id": "edc:labels",
+          "@container": "@set"
+        },
+        "properties": "edc:properties"
       }
     },
     "CatalogAsset": {
@@ -226,7 +233,10 @@
         "transferType": "edc:transferType",
         "dataDestination": "edc:dataDestination",
         "contractId": "edc:contractId",
-        "protocol": "edc:protocol"
+        "protocol": "edc:protocol",
+        "dataplaneMetadata": {
+          "@id": "edc:dataplaneMetadata"
+        }
       }
     },
     "TransferState": {
@@ -250,7 +260,10 @@
         "dataDestination": "edc:dataDestination",
         "correlationId": "edc:correlationId",
         "errorDetail": "edc:errorDetail",
-        "state": "edc:state"
+        "state": "edc:state",
+        "dataplaneMetadata": {
+          "@id": "edc:dataplaneMetadata"
+        }
       }
     },
     "TerminateTransfer": {

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/resources/asset-index-schema.sql
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/resources/asset-index-schema.sql
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS edc_asset
     private_properties      JSON    DEFAULT '{}',
     data_address            JSON    DEFAULT '{}',
     participant_context_id  VARCHAR NOT NULL,
-    dataplane_metadata      JSON    DEFAULT '{}'
+    dataplane_metadata      JSON
 );
 
 COMMENT ON COLUMN edc_asset.properties IS 'Asset properties serialized as JSON';

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.controlplane.store.sql.transferprocess.store;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata;
 import org.eclipse.edc.connector.controlplane.store.sql.transferprocess.store.schema.TransferProcessStoreStatements;
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.ProvisionedResourceSet;
@@ -144,7 +145,8 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
                         entity.getAssetId(),
                         entity.getContractId(),
                         toJson(entity.getDataDestination()),
-                        entity.getParticipantContextId());
+                        entity.getParticipantContextId(),
+                        toJson(entity.getDataplaneMetadata()));
 
                 return leaseContext.withConnection(conn).breakLease(entity.getId());
             } catch (SQLException e) {
@@ -262,6 +264,7 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
                 .protocolMessages(fromJson(resultSet.getString(statements.getProtocolMessagesColumn()), ProtocolMessages.class))
                 .dataPlaneId(resultSet.getString(statements.getDataPlaneIdColumn()))
                 .participantContextId(resultSet.getString(statements.getParticipantContextIdColumn()))
+                .dataplaneMetadata(fromJson(resultSet.getString(statements.getDataplaneMetadata()), DataplaneMetadata.class))
                 .build();
     }
 

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/store/schema/BaseSqlDialectStatements.java
@@ -69,6 +69,7 @@ public class BaseSqlDialectStatements implements TransferProcessStoreStatements 
                 .column(getContractIdColumn())
                 .jsonColumn(getDataDestinationColumn())
                 .column(getParticipantContextIdColumn())
+                .jsonColumn(getDataplaneMetadata())
                 .upsertInto(getTransferProcessTableName(), getIdColumn());
     }
 

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/store/schema/TransferProcessStoreStatements.java
@@ -113,8 +113,11 @@ public interface TransferProcessStoreStatements extends StatefulEntityStatements
         return "participant_context_id";
     }
 
+    default String getDataplaneMetadata() {
+        return "dataplane_metadata";
+    }
+
     SqlQueryStatement createQuery(QuerySpec querySpec);
 
     SqlQueryStatement createNextNotLeaseQuery(QuerySpec querySpec);
-
 }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/resources/transfer-process-schema.sql
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/resources/transfer-process-schema.sql
@@ -16,9 +16,7 @@ COMMENT ON COLUMN edc_lease.lease_duration IS 'duration of lease in milliseconds
 
 CREATE TABLE IF NOT EXISTS edc_transfer_process
 (
-    transferprocess_id       VARCHAR           NOT NULL
-        CONSTRAINT transfer_process_pk
-            PRIMARY KEY,
+    transferprocess_id         VARCHAR           PRIMARY KEY,
     type                       VARCHAR           NOT NULL,
     state                      INTEGER           NOT NULL,
     state_count                INTEGER DEFAULT 0 NOT NULL,
@@ -43,23 +41,16 @@ CREATE TABLE IF NOT EXISTS edc_transfer_process
     asset_id                   VARCHAR,
     contract_id                VARCHAR,
     data_destination           JSON,
-    participant_context_id VARCHAR NOT NULL
+    participant_context_id     VARCHAR NOT NULL,
+    dataplane_metadata         JSON
 );
 
 COMMENT ON COLUMN edc_transfer_process.trace_context IS 'Java Map serialized as JSON';
-
 COMMENT ON COLUMN edc_transfer_process.resource_manifest IS 'java ResourceManifest serialized as JSON';
-
 COMMENT ON COLUMN edc_transfer_process.provisioned_resource_set IS 'ProvisionedResourceSet serialized as JSON';
-
 COMMENT ON COLUMN edc_transfer_process.content_data_address IS 'DataAddress serialized as JSON';
-
 COMMENT ON COLUMN edc_transfer_process.deprovisioned_resources IS 'List of deprovisioned resources, serialized as JSON';
-
-
-CREATE UNIQUE INDEX IF NOT EXISTS transfer_process_id_uindex
-    ON edc_transfer_process (transferprocess_id);
-
+COMMENT ON COLUMN edc_transfer_process.dataplane_metadata IS 'Dataplane Metadata serialized as JSON';
 
 -- This will help to identify states that need to be transitioned without a table scan when the entries grow
 CREATE INDEX IF NOT EXISTS transfer_process_state ON edc_transfer_process (state,state_time_stamp);

--- a/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/Asset.java
+++ b/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/Asset.java
@@ -55,7 +55,7 @@ public class Asset extends AbstractParticipantResource {
     public static final String EDC_ASSET_DATAPLANE_METADATA = EDC_NAMESPACE + "dataplaneMetadata";
     private final Map<String, Object> properties = new HashMap<>();
     private final Map<String, Object> privateProperties = new HashMap<>();
-    private DataplaneMetadata dataplaneMetadata = DataplaneMetadata.Builder.newInstance().build();
+    private DataplaneMetadata dataplaneMetadata;
     private DataAddress dataAddress;
 
     private Asset() {

--- a/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/DataplaneMetadata.java
+++ b/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/DataplaneMetadata.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.controlplane.asset.spi.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -29,6 +28,7 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 @JsonDeserialize(builder = DataplaneMetadata.Builder.class)
 public class DataplaneMetadata {
 
+    public static final String EDC_DATAPLANE_METADATA_TYPE = EDC_NAMESPACE + "DataplaneMetadata";
     public static final String EDC_DATAPLANE_METADATA_LABELS = EDC_NAMESPACE + "labels";
     public static final String EDC_DATAPLANE_METADATA_PROPERTIES = EDC_NAMESPACE + "properties";
 
@@ -45,11 +45,6 @@ public class DataplaneMetadata {
 
     public Map<String, Object> getProperties() {
         return properties;
-    }
-
-    @JsonIgnore
-    public boolean isEmpty() {
-        return labels.isEmpty() && properties.isEmpty();
     }
 
     @JsonPOJOBuilder(withPrefix = "")

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantResource;
 import org.eclipse.edc.spi.entity.ProtocolMessages;
 import org.eclipse.edc.spi.entity.StatefulEntity;
@@ -128,6 +129,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> implements 
     public static final String TRANSFER_PROCESS_ERROR_DETAIL = EDC_NAMESPACE + "errorDetail";
     public static final String TRANSFER_PROCESS_DATA_DESTINATION = EDC_NAMESPACE + "dataDestination";
     public static final String TRANSFER_PROCESS_CALLBACK_ADDRESSES = EDC_NAMESPACE + "callbackAddresses";
+    public static final String TRANSFER_PROCESS_DATAPLANE_METADATA = EDC_NAMESPACE + "dataplaneMetadata";
 
     private Type type = CONSUMER;
     private String protocol;
@@ -146,6 +148,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> implements 
     private String transferType;
     private String dataPlaneId;
     private String participantContextId;
+    private DataplaneMetadata dataplaneMetadata;
 
 
     private TransferProcess() {
@@ -403,6 +406,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> implements 
         transition(SUSPENDING_REQUESTED, state -> canBeSuspended());
     }
 
+    @Deprecated(since = "0.15.0")
     public void transitionSuspended(String reason) {
         this.errorDetail = reason;
         transitionSuspended();
@@ -488,6 +492,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> implements 
     }
 
     @JsonIgnore
+    @Deprecated(since = "0.15.0")
     public String getDestinationType() {
         return dataDestination.getType();
     }
@@ -498,6 +503,10 @@ public class TransferProcess extends StatefulEntity<TransferProcess> implements 
 
     public void setDataPlaneId(String dataPlaneId) {
         this.dataPlaneId = dataPlaneId;
+    }
+
+    public DataplaneMetadata getDataplaneMetadata() {
+        return dataplaneMetadata;
     }
 
     @Override
@@ -519,7 +528,8 @@ public class TransferProcess extends StatefulEntity<TransferProcess> implements 
                 .type(type)
                 .protocolMessages(protocolMessages)
                 .dataPlaneId(dataPlaneId)
-                .participantContextId(participantContextId);
+                .participantContextId(participantContextId)
+                .dataplaneMetadata(dataplaneMetadata);
         return copy(builder);
     }
 
@@ -692,6 +702,11 @@ public class TransferProcess extends StatefulEntity<TransferProcess> implements 
 
         public Builder participantContextId(String participantContextId) {
             entity.participantContextId = participantContextId;
+            return this;
+        }
+
+        public Builder dataplaneMetadata(DataplaneMetadata dataplaneMetadata) {
+            entity.dataplaneMetadata = dataplaneMetadata;
             return this;
         }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferRequest.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferRequest.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.edc.connector.controlplane.transfer.spi.types;
 
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 
@@ -38,6 +39,7 @@ public class TransferRequest {
     @Deprecated(since = "management-api:v3")
     public static final String TRANSFER_REQUEST_ASSET_ID = EDC_NAMESPACE + "assetId";
     public static final String TRANSFER_REQUEST_CALLBACK_ADDRESSES = EDC_NAMESPACE + "callbackAddresses";
+    public static final String TRANSFER_REQUEST_DATAPLANE_METADATA = EDC_NAMESPACE + "dataplaneMetadata";
 
     private String id;
     private String protocol;
@@ -47,6 +49,7 @@ public class TransferRequest {
     private DataAddress dataDestination;
     private Map<String, Object> privateProperties = new HashMap<>();
     private List<CallbackAddress> callbackAddresses = new ArrayList<>();
+    private DataplaneMetadata dataplaneMetadata;
 
     public String getCounterPartyAddress() {
         return counterPartyAddress;
@@ -78,6 +81,10 @@ public class TransferRequest {
 
     public String getTransferType() {
         return transferType;
+    }
+
+    public DataplaneMetadata getDataplaneMetadata() {
+        return dataplaneMetadata;
     }
 
     public static final class Builder {
@@ -128,6 +135,11 @@ public class TransferRequest {
 
         public Builder callbackAddresses(List<CallbackAddress> callbackAddresses) {
             request.callbackAddresses = callbackAddresses;
+            return this;
+        }
+
+        public Builder dataplaneMetadata(DataplaneMetadata dataplaneMetadata) {
+            request.dataplaneMetadata = dataplaneMetadata;
             return this;
         }
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
@@ -93,8 +93,8 @@ public class AssetApiV4EndToEndTest {
             assertThat(body.getMap("'dataAddress'.'complex'.'nested'"))
                     .containsEntry("innerValue", "value");
             assertThat(body.getMap("'dataplaneMetadata'"))
-                    .containsEntry("labels", "label")
-                    .containsEntry("properties", Map.of("property", "value"));
+                    .containsEntry("labels", List.of("label"))
+                    .containsEntry("properties", Map.of("edc:property", "value"));
         }
 
         @Test


### PR DESCRIPTION
## What this PR changes/adds

Adds `dataplaneMetadata` to `TransferRequest` and `TransferProcess`

## Why it does that

support upcoming dataplane signaling api

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #5323 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
