### PR TITLE
refactor: extract presentation request service

### DIFF
--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/build.gradle.kts
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(project(":extensions:common:iam:decentralized-claims:decentralized-claims-service"))
     implementation(project(":extensions:common:iam:decentralized-claims:decentralized-claims-transform"))
     implementation(project(":extensions:common:iam:decentralized-claims:decentralized-claims-sts:decentralized-claims-sts-remote-client"))
+    implementation(project(":extensions:common:iam:decentralized-claims:lib:decentralized-claims-lib"))
     implementation(project(":extensions:common:iam:verifiable-credentials"))
     implementation(libs.nimbus.jwt)
 

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpPresentationRequestExtension.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpPresentationRequestExtension.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.decentralizedclaims.core;
+
+import jakarta.json.Json;
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.iam.decentralizedclaims.core.defaults.DefaultCredentialServiceClient;
+import org.eclipse.edc.iam.decentralizedclaims.lib.DefaultPresentationRequestService;
+import org.eclipse.edc.iam.decentralizedclaims.service.DidCredentialServiceUrlResolver;
+import org.eclipse.edc.iam.decentralizedclaims.spi.CredentialServiceClient;
+import org.eclipse.edc.iam.decentralizedclaims.spi.PresentationRequestService;
+import org.eclipse.edc.iam.decentralizedclaims.spi.SecureTokenService;
+import org.eclipse.edc.iam.decentralizedclaims.transform.to.JsonObjectToPresentationResponseMessageTransformer;
+import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+
+import java.util.Map;
+
+import static org.eclipse.edc.iam.decentralizedclaims.spi.DcpConstants.DCP_CONTEXT_URL;
+import static org.eclipse.edc.iam.decentralizedclaims.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_0_8;
+import static org.eclipse.edc.iam.decentralizedclaims.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+import static org.eclipse.edc.iam.decentralizedclaims.spi.DcpConstants.DSPACE_DCP_V_1_0_CONTEXT;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+/**
+ * Provides services required to make DCP presentation requests.
+ */
+@Extension("DCP Presentation Request Extension")
+public class DcpPresentationRequestExtension implements ServiceExtension {
+
+    public static final String DCP_CLIENT_CONTEXT = "dcp-client";
+
+    @Setting(description = "If set enable the dcp v0.8 namespace will be used", key = "edc.dcp.v08.forced", required = false, defaultValue = "false")
+    private boolean enableDcpV08;
+
+    @Inject
+    private SecureTokenService secureTokenService;
+    @Inject
+    private DidResolverRegistry didResolverRegistry;
+    @Inject
+    private TypeTransformerRegistry typeTransformerRegistry;
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private EdcHttpClient httpClient;
+    @Inject
+    private JsonLd jsonLd;
+
+    @Provider(isDefault = true)
+    public PresentationRequestService presentationRequestService(ServiceExtensionContext context) {
+        var credentialServiceUrlResolver = new DidCredentialServiceUrlResolver(didResolverRegistry);
+        return new DefaultPresentationRequestService(secureTokenService, credentialServiceUrlResolver, credentialServiceClient(context));
+    }
+
+    @Provider
+    public CredentialServiceClient credentialServiceClient(ServiceExtensionContext context) {
+        var clientTypeTransformerRegistry = typeTransformerRegistry.forContext(DCP_CLIENT_CONTEXT);
+        clientTypeTransformerRegistry.register(new JsonObjectToPresentationResponseMessageTransformer(typeManager, JSON_LD, dcpNamespace()));
+
+        return new DefaultCredentialServiceClient(httpClient, Json.createBuilderFactory(Map.of()),
+                typeManager, JSON_LD, clientTypeTransformerRegistry, jsonLd, context.getMonitor(), dcpContext(), !enableDcpV08);
+    }
+
+    private JsonLdNamespace dcpNamespace() {
+        return enableDcpV08 ? DSPACE_DCP_NAMESPACE_V_0_8 : DSPACE_DCP_NAMESPACE_V_1_0;
+    }
+
+    private String dcpContext() {
+        return enableDcpV08 ? DCP_CONTEXT_URL : DSPACE_DCP_V_1_0_CONTEXT;
+    }
+}

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -9,6 +9,7 @@
 #
 #  Contributors:
 #       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+#       Cofinity-X - extract presentation request service
 #
 #
 
@@ -16,3 +17,4 @@ org.eclipse.edc.iam.decentralizedclaims.core.DcpDefaultServicesExtension
 org.eclipse.edc.iam.decentralizedclaims.core.DcpScopeExtractorExtension
 org.eclipse.edc.iam.decentralizedclaims.core.DcpCoreExtension
 org.eclipse.edc.iam.decentralizedclaims.core.DcpTransformExtension
+org.eclipse.edc.iam.decentralizedclaims.core.DcpPresentationRequestExtension

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpCoreExtensionTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpCoreExtensionTest.java
@@ -45,7 +45,6 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.eclipse.edc.iam.decentralizedclaims.core.DcpCoreExtension.DCP_CLIENT_CONTEXT;
 import static org.eclipse.edc.iam.decentralizedclaims.core.DcpCoreExtension.DCP_SELF_ISSUED_TOKEN_CONTEXT;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -76,7 +75,6 @@ class DcpCoreExtensionTest {
 
         ));
         when(context.getConfig()).thenReturn(config);
-        when(transformerRegistry.forContext(DCP_CLIENT_CONTEXT)).thenReturn(transformerRegistry);
     }
 
     @Test

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpPresentationRequestExtensionTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpPresentationRequestExtensionTest.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.decentralizedclaims.core;
+
+import org.eclipse.edc.boot.system.injection.ObjectFactory;
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.iam.decentralizedclaims.core.defaults.DefaultCredentialServiceClient;
+import org.eclipse.edc.iam.decentralizedclaims.lib.DefaultPresentationRequestService;
+import org.eclipse.edc.iam.decentralizedclaims.spi.SecureTokenService;
+import org.eclipse.edc.iam.decentralizedclaims.transform.to.JsonObjectToPresentationResponseMessageTransformer;
+import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.iam.decentralizedclaims.core.DcpPresentationRequestExtension.DCP_CLIENT_CONTEXT;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class DcpPresentationRequestExtensionTest {
+
+    private static final String DCP_08_PROPERTY  = "edc.dcp.v08.forced";
+
+    private final TypeTransformerRegistry transformerRegistry = mock();
+
+    @BeforeEach
+    void setUp(ServiceExtensionContext context) {
+        context.registerService(SecureTokenService.class, mock());
+        context.registerService(DidResolverRegistry.class, mock());
+        context.registerService(TypeTransformerRegistry.class, transformerRegistry);
+        context.registerService(TypeManager.class, mock());
+        context.registerService(EdcHttpClient.class, mock());
+        context.registerService(JsonLd.class, mock());
+
+        var config = ConfigFactory.fromMap(Map.of(
+                DCP_08_PROPERTY, "false"
+
+        ));
+        when(context.getConfig()).thenReturn(config);
+        when(transformerRegistry.forContext(DCP_CLIENT_CONTEXT)).thenReturn(transformerRegistry);
+    }
+
+    @Test
+    void verifyPresentationRequestService(ServiceExtensionContext context, ObjectFactory objectFactory) {
+        var service = objectFactory.constructInstance(DcpPresentationRequestExtension.class).presentationRequestService(context);
+        assertThat(service).isNotNull().isInstanceOf(DefaultPresentationRequestService.class);
+    }
+
+    @Test
+    void verifyCredentialServiceClient(ServiceExtensionContext context, ObjectFactory objectFactory) {
+        var service = objectFactory.constructInstance(DcpPresentationRequestExtension.class).credentialServiceClient(context);
+
+        assertThat(service).isNotNull().isInstanceOf(DefaultCredentialServiceClient.class);
+        verify(transformerRegistry, times(1)).forContext(DCP_CLIENT_CONTEXT);
+        verify(transformerRegistry, times(1)).register(isA(JsonObjectToPresentationResponseMessageTransformer.class));
+    }
+}

--- a/extensions/common/iam/decentralized-claims/lib/decentralized-claims-lib/build.gradle.kts
+++ b/extensions/common/iam/decentralized-claims/lib/decentralized-claims-lib/build.gradle.kts
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+dependencies {
+    api(project(":spi:common:decentralized-claims-spi"))
+    api(project(":spi:common:jwt-spi"))
+
+    testImplementation(project(":core:common:junit"))
+    testImplementation(testFixtures(project(":spi:common:verifiable-credentials-spi")))
+}

--- a/extensions/common/iam/decentralized-claims/lib/decentralized-claims-lib/src/main/java/org/eclipse/edc/iam/decentralizedclaims/lib/DefaultPresentationRequestService.java
+++ b/extensions/common/iam/decentralized-claims/lib/decentralized-claims-lib/src/main/java/org/eclipse/edc/iam/decentralizedclaims/lib/DefaultPresentationRequestService.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.decentralizedclaims.lib;
+
+import org.eclipse.edc.iam.decentralizedclaims.spi.CredentialServiceClient;
+import org.eclipse.edc.iam.decentralizedclaims.spi.CredentialServiceUrlResolver;
+import org.eclipse.edc.iam.decentralizedclaims.spi.PresentationRequestService;
+import org.eclipse.edc.iam.decentralizedclaims.spi.SecureTokenService;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiablePresentationContainer;
+import org.eclipse.edc.spi.result.Result;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+
+import static org.eclipse.edc.iam.decentralizedclaims.spi.SelfIssuedTokenConstants.PRESENTATION_TOKEN_CLAIM;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.EXPIRATION_TIME;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUED_AT;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUER;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SUBJECT;
+
+/**
+ * Default implementation of the {@link PresentationRequestService}. When receiving the
+ * counter-party's SI token, generates the own SI token and requests the Verifiable Presentation
+ * using this token.
+ */
+public class DefaultPresentationRequestService implements PresentationRequestService {
+
+    private final SecureTokenService secureTokenService;
+    private final CredentialServiceClient credentialServiceClient;
+    private final CredentialServiceUrlResolver credentialServiceUrlResolver;
+
+    public DefaultPresentationRequestService(SecureTokenService secureTokenService,
+                                             CredentialServiceUrlResolver credentialServiceUrlResolver,
+                                             CredentialServiceClient credentialServiceClient) {
+        this.secureTokenService = secureTokenService;
+        this.credentialServiceUrlResolver = credentialServiceUrlResolver;
+        this.credentialServiceClient = credentialServiceClient;
+    }
+
+    @Override
+    public Result<List<VerifiablePresentationContainer>> requestPresentation(String participantContextId, String ownDid,
+                                                                             String counterPartyDid, String counterPartyToken,
+                                                                             List<String> scopes) {
+        Map<String, Object> siTokenClaims = Map.of(PRESENTATION_TOKEN_CLAIM, counterPartyToken,
+                ISSUED_AT, Instant.now().getEpochSecond(),
+                AUDIENCE, counterPartyDid,
+                ISSUER, ownDid,
+                SUBJECT, ownDid,
+                EXPIRATION_TIME, Instant.now().plus(5, ChronoUnit.MINUTES).getEpochSecond());
+        var siToken = secureTokenService.createToken(participantContextId, siTokenClaims, null);
+        if (siToken.failed()) {
+            return siToken.mapFailure();
+        }
+        var siTokenString = siToken.getContent().getToken();
+
+        return credentialServiceUrlResolver.resolve(counterPartyDid)
+                .compose(url -> credentialServiceClient.requestPresentation(url, siTokenString, scopes));
+    }
+}

--- a/extensions/common/iam/decentralized-claims/lib/decentralized-claims-lib/src/test/java/org/eclipse/edc/iam/decentralizedclaims/lib/DefaultPresentationRequestServiceTest.java
+++ b/extensions/common/iam/decentralized-claims/lib/decentralized-claims-lib/src/test/java/org/eclipse/edc/iam/decentralizedclaims/lib/DefaultPresentationRequestServiceTest.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.decentralizedclaims.lib;
+
+import org.eclipse.edc.iam.decentralizedclaims.spi.CredentialServiceClient;
+import org.eclipse.edc.iam.decentralizedclaims.spi.CredentialServiceUrlResolver;
+import org.eclipse.edc.iam.decentralizedclaims.spi.SecureTokenService;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.result.Result;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.TestFunctions.createPresentationContainer;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUER;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SUBJECT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class DefaultPresentationRequestServiceTest {
+
+    private String participantContextId = "pcId";
+    private String did = "did:web:one";
+    private String counterPartyDid = "did:web:two";
+    private String counterPartyToken = "siToken";
+    private List<String> scopes = List.of("scope1", "scope2");
+
+    private SecureTokenService secureTokenService = mock();
+    private CredentialServiceUrlResolver credentialServiceUrlResolver = mock();
+    private CredentialServiceClient credentialServiceClient = mock();
+
+    private DefaultPresentationRequestService service = new DefaultPresentationRequestService(secureTokenService, credentialServiceUrlResolver, credentialServiceClient);
+
+    @Test
+    void requestPresentation_shouldReturnPresentation() {
+        var token = "token";
+        var tr = TokenRepresentation.Builder.newInstance().token(token).build();
+        var url = "http://url";
+        var presentation = createPresentationContainer();
+
+        when(secureTokenService.createToken(any(), any(), any())).thenReturn(Result.success(tr));
+        when(credentialServiceUrlResolver.resolve(any())).thenReturn(Result.success(url));
+        when(credentialServiceClient.requestPresentation(any(), any(), isA(List.class))).thenReturn(Result.success(List.of(presentation)));
+
+        var result = service.requestPresentation(participantContextId, did, counterPartyDid, counterPartyToken, scopes);
+
+        assertThat(result).isSucceeded();
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0)).isEqualTo(presentation);
+
+        verify(secureTokenService, times(1)).createToken(eq(participantContextId),
+                argThat(claims -> claims.get(AUDIENCE).equals(counterPartyDid) && claims.get(ISSUER).equals(did) && claims.get(SUBJECT).equals(did)),
+                isNull());
+        verify(credentialServiceUrlResolver, times(1)).resolve(counterPartyDid);
+        verify(credentialServiceClient, times(1)).requestPresentation(url, token, scopes);
+    }
+
+    @Test
+    void requestPresentation_creatingSiTokenFails_shouldReturnFailure() {
+        when(secureTokenService.createToken(any(), any(), any())).thenReturn(Result.failure("error"));
+
+        var result = service.requestPresentation(participantContextId, did, counterPartyDid, counterPartyToken, scopes);
+
+        assertThat(result).isFailed();
+
+        verifyNoInteractions(credentialServiceUrlResolver);
+        verifyNoInteractions(credentialServiceClient);
+    }
+
+    @Test
+    void requestPresentation_urlNotResolvable_shouldReturnFailure() {
+        var token = "token";
+        var tr = TokenRepresentation.Builder.newInstance().token(token).build();
+
+        when(secureTokenService.createToken(any(), any(), any())).thenReturn(Result.success(tr));
+        when(credentialServiceUrlResolver.resolve(any())).thenReturn(Result.failure("error"));
+
+        var result = service.requestPresentation(participantContextId, did, counterPartyDid, counterPartyToken, scopes);
+
+        assertThat(result).isFailed();
+
+        verifyNoInteractions(credentialServiceClient);
+    }
+
+    @Test
+    void requestPresentation_presentationRequestFails_shouldReturnFailure() {
+        var token = "token";
+        var tr = TokenRepresentation.Builder.newInstance().token(token).build();
+        var url = "http://url";
+
+        when(secureTokenService.createToken(any(), any(), any())).thenReturn(Result.success(tr));
+        when(credentialServiceUrlResolver.resolve(any())).thenReturn(Result.success(url));
+        when(credentialServiceClient.requestPresentation(any(), any(), isA(List.class))).thenReturn(Result.failure("error"));
+
+        var result = service.requestPresentation(participantContextId, did, counterPartyDid, counterPartyToken, scopes);
+
+        assertThat(result).isFailed();
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -181,6 +181,8 @@ include(":extensions:common:iam:decentralized-claims:decentralized-claims-transf
 include(":extensions:common:iam:decentralized-claims:decentralized-claims-service")
 include(":extensions:common:iam:decentralized-claims:decentralized-claims-core")
 include(":extensions:common:iam:decentralized-claims:decentralized-claims-sts")
+include(":extensions:common:iam:decentralized-claims:lib")
+include(":extensions:common:iam:decentralized-claims:lib:decentralized-claims-lib")
 include(":extensions:common:iam:decentralized-claims:decentralized-claims-sts:decentralized-claims-sts-remote-client")
 include(":extensions:common:iam:decentralized-claims:decentralized-claims-sts:lib:decentralized-claims-sts-remote-lib")
 include(":extensions:common:iam:decentralized-claims:decentralized-claims-issuers-configuration")

--- a/spi/common/decentralized-claims-spi/src/main/java/org/eclipse/edc/iam/decentralizedclaims/spi/PresentationRequestService.java
+++ b/spi/common/decentralized-claims-spi/src/main/java/org/eclipse/edc/iam/decentralizedclaims/spi/PresentationRequestService.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.decentralizedclaims.spi;
+
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiablePresentationContainer;
+import org.eclipse.edc.spi.result.Result;
+
+import java.util.List;
+
+/**
+ * Service responsible for requesting Verifiable Presentations according to the DCP presentation
+ * flow.
+ */
+public interface PresentationRequestService {
+
+    /**
+     * Requests the Verifiable Presentation after receiving the SI token from the counter-party.
+     * This includes creating the own SI token, resolving the credential service URL and making the
+     * presentation request.
+     *
+     * @param participantContextId id of the participant context
+     * @param ownDid the participant's DID
+     * @param counterPartyDid the counter-party's DID
+     * @param counterPartyToken the counter-party's SI token
+     * @param scopes the scopes to request
+     * @return list of Verifiable Presentations
+     */
+    Result<List<VerifiablePresentationContainer>> requestPresentation(String participantContextId, String ownDid,
+                                                                      String counterPartyDid, String counterPartyToken,
+                                                                      List<String> scopes);
+
+}


### PR DESCRIPTION
## What this PR changes/adds

Extracts a service for presentation requests from the `DcpIdentityService` and makes the default implementation available in the new `decentralized-claims-lib` module as outlined in [this DR](https://github.com/eclipse-edc/Connector/tree/main/docs/developer/decision-records/2025-11-10-presentation-request-service).

## Why it does that

flexibility in the presentation request process


## Who will sponsor this feature?

me


## Linked Issue(s)

Closes #5330 

