### PR TITLE
feat: jsonld-fy of participant context

### DIFF
--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/from/JsonObjectFromParticipantContextTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/from/JsonObjectFromParticipantContextTransformer.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.transform.edc.participantcontext.from;
+
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContextState;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.JSON;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_PROPERTIES_IRI;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_STATE_IRI;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_TYPE_IRI;
+
+public class JsonObjectFromParticipantContextTransformer extends AbstractJsonLdTransformer<ParticipantContext, JsonObject> {
+
+    private final JsonBuilderFactory jsonFactory;
+
+    public JsonObjectFromParticipantContextTransformer(JsonBuilderFactory jsonFactory) {
+        super(ParticipantContext.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull ParticipantContext participantContext, @NotNull TransformerContext context) {
+        return jsonFactory.createObjectBuilder()
+                .add(TYPE, PARTICIPANT_CONTEXT_TYPE_IRI)
+                .add(ID, participantContext.getParticipantContextId())
+                .add(PARTICIPANT_CONTEXT_PROPERTIES_IRI, createProperties(participantContext))
+                .add(PARTICIPANT_CONTEXT_STATE_IRI, createId(jsonFactory, ParticipantContextState.from(participantContext.getState()).name()))
+                .build();
+    }
+
+    private JsonObject createProperties(ParticipantContext participantContext) {
+        return jsonFactory.createObjectBuilder()
+                .add(VALUE, jsonFactory.createObjectBuilder(participantContext.getProperties()))
+                .add(TYPE, JSON)
+                .build();
+    }
+}

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/to/JsonObjectToParticipantContextTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/to/JsonObjectToParticipantContextTransformer.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.transform.edc.participantcontext.to;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_PROPERTIES_IRI;
+
+public class JsonObjectToParticipantContextTransformer extends AbstractJsonLdTransformer<JsonObject, ParticipantContext> {
+    public JsonObjectToParticipantContextTransformer() {
+        super(JsonObject.class, ParticipantContext.class);
+    }
+
+    @Override
+    public @Nullable ParticipantContext transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext context) {
+        var participantContext = ParticipantContext.Builder.newInstance();
+        var nodeId = nodeId(jsonObject);
+        var id = nodeId != null ? nodeId : UUID.randomUUID().toString();
+        participantContext.participantContextId(id);
+        participantContext.id(id);
+
+        var properties = jsonObject.get(PARTICIPANT_CONTEXT_PROPERTIES_IRI);
+        if (properties != null) {
+            var jsonValue = nodeJsonValue(properties);
+            if (jsonValue instanceof JsonObject json) {
+                visitProperties(json, (key, value) -> participantContext.property(key, transformGenericProperty(value, context)));
+            } else {
+                context.reportProblem("Expected properties to be a JsonObject");
+                return null;
+            }
+        }
+
+        return participantContext.build();
+    }
+}

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/from/JsonObjectFromParticipantContextTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/from/JsonObjectFromParticipantContextTransformerTest.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.transform.edc.participantcontext.from;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContextState;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_PROPERTIES_IRI;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_STATE_IRI;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_TYPE_IRI;
+import static org.mockito.Mockito.mock;
+
+class JsonObjectFromParticipantContextTransformerTest {
+
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private JsonObjectFromParticipantContextTransformer transformer;
+    private TransformerContext context;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectFromParticipantContextTransformer(jsonFactory);
+        context = mock(TransformerContext.class);
+    }
+
+    @Test
+    void transform_shouldConvertParticipantContextToJsonObject() {
+        var participantContext = ParticipantContext.Builder.newInstance()
+                .participantContextId("participant-1")
+                .state(ParticipantContextState.ACTIVATED)
+                .properties(Map.of("key1", "value1", "key2", "value2"))
+                .build();
+
+        var result = transformer.transform(participantContext, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getString(ID)).isEqualTo("participant-1");
+        assertThat(result.getString(TYPE)).isEqualTo(PARTICIPANT_CONTEXT_TYPE_IRI);
+        assertThat(result.getJsonObject(PARTICIPANT_CONTEXT_STATE_IRI).getString(ID)).isEqualTo("ACTIVATED");
+
+        var properties = result.getJsonObject(PARTICIPANT_CONTEXT_PROPERTIES_IRI).getJsonObject(VALUE);
+        assertThat(properties).isNotNull();
+        assertThat(properties.getString("key1")).isEqualTo("value1");
+        assertThat(properties.getString("key2")).isEqualTo("value2");
+    }
+
+    @Test
+    void transform_withEmptyProperties_shouldReturnJsonObjectWithEmptyProperties() {
+        var participantContext = ParticipantContext.Builder.newInstance()
+                .participantContextId("participant-2")
+                .state(ParticipantContextState.ACTIVATED)
+                .properties(Map.of())
+                .build();
+
+        var result = transformer.transform(participantContext, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getString(ID)).isEqualTo("participant-2");
+        var properties = result.getJsonObject(PARTICIPANT_CONTEXT_PROPERTIES_IRI).getJsonObject(VALUE);
+        assertThat(properties).isNotNull().isEmpty();
+    }
+
+    @Test
+    void transform_shouldIncludeCorrectState() {
+        var participantContext = ParticipantContext.Builder.newInstance()
+                .participantContextId("participant-3")
+                .state(ParticipantContextState.DEACTIVATED)
+                .build();
+
+        var result = transformer.transform(participantContext, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getJsonObject(PARTICIPANT_CONTEXT_STATE_IRI).getString(ID)).isEqualTo("DEACTIVATED");
+    }
+}

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/to/JsonObjectToParticipantContextTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/to/JsonObjectToParticipantContextTransformerTest.java
@@ -1,0 +1,149 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.transform.edc.participantcontext.to;
+
+import org.eclipse.edc.connector.controlplane.transform.edc.to.JsonObjectToDataplaneMetadataTransformer;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.TypeTransformerRegistryImpl;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToDataAddressTransformer;
+import org.eclipse.edc.transform.transformer.edc.to.JsonValueToGenericTypeTransformer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_PROPERTIES_IRI;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JsonObjectToParticipantContextTransformerTest {
+
+    private final TypeManager typeManager = mock();
+    private TypeTransformerRegistry typeTransformerRegistry;
+
+    @BeforeEach
+    void setUp() {
+        var transformer = new JsonObjectToParticipantContextTransformer();
+        typeTransformerRegistry = new TypeTransformerRegistryImpl();
+        typeTransformerRegistry.register(new JsonValueToGenericTypeTransformer(typeManager, "test"));
+        typeTransformerRegistry.register(transformer);
+        typeTransformerRegistry.register(new JsonObjectToDataAddressTransformer());
+        typeTransformerRegistry.register(new JsonObjectToDataplaneMetadataTransformer());
+        when(typeManager.getMapper("test")).thenReturn(JacksonJsonLd.createObjectMapper());
+    }
+
+    @Test
+    void transform_shouldConvertJsonObjectToParticipantContext() {
+        var jsonObject = createObjectBuilder()
+                .add(ID, "participant-1")
+                .add(PARTICIPANT_CONTEXT_PROPERTIES_IRI, createObjectBuilder()
+                        .add(VALUE, createObjectBuilder()
+                                .add("key1", "value1")
+                                .add("key2", "value2")))
+                .build();
+
+        var result = typeTransformerRegistry.transform(jsonObject, ParticipantContext.class);
+
+        assertThat(result).isSucceeded()
+                .satisfies(participantContext -> {
+                    assertThat(participantContext.getParticipantContextId()).isEqualTo("participant-1");
+                    assertThat(participantContext.getProperties()).containsEntry("key1", "value1")
+                            .containsEntry("key2", "value2");
+                });
+    }
+
+    @Test
+    void transform_withoutId_shouldGenerateRandomId() {
+        var jsonObject = createObjectBuilder()
+                .add(PARTICIPANT_CONTEXT_PROPERTIES_IRI, createObjectBuilder().add(VALUE, createObjectBuilder()
+                        .add("key1", "value1")))
+                .build();
+
+        var result = typeTransformerRegistry.transform(jsonObject, ParticipantContext.class);
+
+        assertThat(result).isSucceeded().satisfies(participantContext -> {
+            assertThat(participantContext.getParticipantContextId()).isNotNull().isNotEmpty();
+            assertThat(participantContext.getProperties()).containsEntry("key1", "value1");
+        });
+    }
+
+    @Test
+    void transform_withEmptyProperties_shouldReturnParticipantContextWithEmptyProperties() {
+        var jsonObject = createObjectBuilder()
+                .add(ID, "participant-2")
+                .add(PARTICIPANT_CONTEXT_PROPERTIES_IRI, createObjectBuilder().add(VALUE, createObjectBuilder()))
+                .build();
+
+        var result = typeTransformerRegistry.transform(jsonObject, ParticipantContext.class);
+
+        assertThat(result).isSucceeded().satisfies(participantContext -> {
+            assertThat(participantContext.getParticipantContextId()).isNotNull().isNotEmpty();
+            assertThat(participantContext.getProperties()).isEmpty();
+        });
+    }
+
+    @Test
+    void transform_withoutProperties_shouldReturnParticipantContext() {
+        var jsonObject = createObjectBuilder()
+                .add(ID, "participant-3")
+                .build();
+
+        var result = typeTransformerRegistry.transform(jsonObject, ParticipantContext.class);
+
+        assertThat(result).isSucceeded().satisfies(participantContext -> {
+            assertThat(participantContext.getParticipantContextId()).isEqualTo("participant-3");
+            assertThat(participantContext.getProperties()).isEmpty();
+        });
+
+    }
+
+    @Test
+    void transform_withInvalidProperties_shouldReportProblemAndReturnNull() {
+        var jsonObject = createObjectBuilder()
+                .add(ID, "participant-4")
+                .add(PARTICIPANT_CONTEXT_PROPERTIES_IRI, createObjectBuilder().add(VALUE, "invalid-string"))
+                .build();
+
+        var result = typeTransformerRegistry.transform(jsonObject, ParticipantContext.class);
+
+        assertThat(result).isFailed().detail().contains("Expected properties to be a JsonObject");
+    }
+
+    @Test
+    void transform_withNestedProperties_shouldHandleComplexValues() {
+        var jsonObject = createObjectBuilder()
+                .add(ID, "participant-5")
+                .add(PARTICIPANT_CONTEXT_PROPERTIES_IRI, createObjectBuilder()
+                        .add(VALUE, createObjectBuilder()
+                                .add("simpleKey", "simpleValue")
+                                .add("booleanKey", true)))
+                .build();
+
+
+        var result = typeTransformerRegistry.transform(jsonObject, ParticipantContext.class);
+
+        assertThat(result).isSucceeded().satisfies(participantContext -> {
+            assertThat(participantContext.getParticipantContextId()).isEqualTo("participant-5");
+            assertThat(participantContext.getProperties()).containsEntry("simpleKey", "simpleValue")
+                    .containsEntry("booleanKey", true);
+        });
+    }
+}

--- a/extensions/common/api/lib/management-api-lib/src/main/java/org/eclipse/edc/api/management/schema/ManagementApiJsonSchema.java
+++ b/extensions/common/api/lib/management-api-lib/src/main/java/org/eclipse/edc/api/management/schema/ManagementApiJsonSchema.java
@@ -46,6 +46,8 @@ public interface ManagementApiJsonSchema {
         String TRANSFER_PROCESS_STATE = EDC_MGMT_V4_SCHEMA_PREFIX + "/transfer-process-schema.json#/definitions/TransferState";
         String TERMINATE_TRANSFER = EDC_MGMT_V4_SCHEMA_PREFIX + "/transfer-terminate-schema.json";
         String SUSPEND_TRANSFER = EDC_MGMT_V4_SCHEMA_PREFIX + "/transfer-suspend-schema.json";
+        String PARTICIPANT_CONTEXT = EDC_MGMT_V4_SCHEMA_PREFIX + "/participant-context-schema.json";
+
 
         static String version() {
             return "v4";

--- a/extensions/common/api/management-api-schema-validator/src/main/java/org/eclipse/edc/connector/api/management/schema/ManagementApiSchemaValidatorExtension.java
+++ b/extensions/common/api/management-api-schema-validator/src/main/java/org/eclipse/edc/connector/api/management/schema/ManagementApiSchemaValidatorExtension.java
@@ -38,6 +38,7 @@ import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.D
 import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.DATASET_REQUEST;
 import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.EDR_ENTRY;
 import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.ID_RESPONSE;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.PARTICIPANT_CONTEXT;
 import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.POLICY_DEFINITION;
 import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.POLICY_EVALUATION_PLAN;
 import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.POLICY_EVALUATION_REQUEST;
@@ -59,12 +60,14 @@ import static org.eclipse.edc.connector.controlplane.contract.spi.types.agreemen
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.command.TerminateNegotiationCommand.TERMINATE_NEGOTIATION_TYPE_TERM;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_TYPE_TERM;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest.CONTRACT_REQUEST_TYPE_TERM;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.NegotiationState.NEGOTIATION_STATE_TYPE_TERM;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_TYPE_TERM;
 import static org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_TYPE_TERM;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.TRANSFER_PROCESS_TYPE_TERM;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_TYPE_TERM;
 import static org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance.DATAPLANE_INSTANCE_TYPE_TERM;
 import static org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry.EDR_ENTRY_TYPE_TERM;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_TYPE_TERM;
 import static org.eclipse.edc.policy.engine.spi.plan.PolicyEvaluationPlan.EDC_POLICY_EVALUATION_PLAN_TYPE_TERM;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
@@ -97,7 +100,7 @@ public class ManagementApiSchemaValidatorExtension implements ServiceExtension {
             put(DATASET_REQUEST_TYPE_TERM, DATASET_REQUEST);
             put(CONTRACT_REQUEST_TYPE_TERM, CONTRACT_REQUEST);
             put(CONTRACT_NEGOTIATION_TYPE_TERM, CONTRACT_NEGOTIATION);
-            put("NegotiationState", CONTRACT_NEGOTIATION_STATE);
+            put(NEGOTIATION_STATE_TYPE_TERM, CONTRACT_NEGOTIATION_STATE);
             put(TERMINATE_NEGOTIATION_TYPE_TERM, TERMINATE_NEGOTIATION);
             put(CONTRACT_AGREEMENT_TYPE_TERM, CONTRACT_AGREEMENT);
             put(TRANSFER_REQUEST_TYPE_TERM, TRANSFER_REQUEST);
@@ -105,6 +108,7 @@ public class ManagementApiSchemaValidatorExtension implements ServiceExtension {
             put("TransferState", TRANSFER_PROCESS_STATE);
             put("TerminateTransfer", TERMINATE_TRANSFER);
             put("SuspendTransfer", SUSPEND_TRANSFER);
+            put(PARTICIPANT_CONTEXT_TYPE_TERM, PARTICIPANT_CONTEXT);
 
 
         }

--- a/extensions/common/api/management-api-schema-validator/src/main/java/org/eclipse/edc/connector/api/management/schema/ManagementApiSchemaValidatorProvider.java
+++ b/extensions/common/api/management-api-schema-validator/src/main/java/org/eclipse/edc/connector/api/management/schema/ManagementApiSchemaValidatorProvider.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.connector.api.management.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.networknt.schema.Error;
 import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.SchemaRegistry;
 import com.networknt.schema.dialect.Dialects;
@@ -48,8 +47,7 @@ public class ManagementApiSchemaValidatorProvider {
             }
 
             var violations = response.stream()
-                    .map(Error::getMessage)
-                    .map(msg -> Violation.violation(msg, null))
+                    .map(error -> Violation.violation(error.getMessage(), error.getInstanceLocation().toString()))
                     .toList();
 
             return ValidationResult.failure(violations);

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/participant-context-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/participant-context-schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "ParticipantContextSchema",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/ParticipantContext"
+    }
+  ],
+  "$id": "https://w3id.org/edc/connector/management/schema/v4/participant-context-schema.json",
+  "definitions": {
+    "ParticipantContext": {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "$ref": "https://w3id.org/edc/connector/management/schema/v4/context-schema.json"
+        },
+        "@type": {
+          "type": "string",
+          "const": "ParticipantContext"
+        },
+        "@id": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "CREATED",
+            "ACTIVATED",
+            "DEACTIVATED"
+          ]
+        }
+      },
+      "required": [
+        "@context",
+        "@type"
+      ]
+    }
+  }
+}

--- a/extensions/common/json-ld/src/main/resources/document/management-context-v2.jsonld
+++ b/extensions/common/json-ld/src/main/resources/document/management-context-v2.jsonld
@@ -444,6 +444,22 @@
         "createdAt": "edc:createdAt"
       }
     },
+    "ParticipantContext": {
+      "@id": "edc:ParticipantContext",
+      "@context": {
+        "properties": {
+          "@id": "edc:properties",
+          "@type": "@json"
+        },
+        "state": {
+          "@id": "edc:state",
+          "@type": "@vocab"
+        },
+        "CREATED": "edc:CREATED",
+        "ACTIVATED": "edc:ACTIVATED",
+        "DEACTIVATED": "edc:DEACTIVATED"
+      }
+    },
     "inForceDate": "edc:inForceDate",
     "ruleFunctions": {
       "@id": "edc:ruleFunctions",

--- a/extensions/control-plane/store/sql/participantcontext-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/SqlParticipantContextStore.java
+++ b/extensions/control-plane/store/sql/participantcontext-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/SqlParticipantContextStore.java
@@ -150,11 +150,11 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
         Map<String, Object> props = fromJson(resultSet.getString(statements.getPropertiesColumn()), getTypeRef());
 
         return ParticipantContext.Builder.newInstance()
-                       .participantContextId(id)
-                       .createdAt(created)
-                       .lastModified(lastmodified)
-                       .state(ParticipantContextState.values()[state])
-                       .properties(props)
-                       .build();
+                .participantContextId(id)
+                .createdAt(created)
+                .lastModified(lastmodified)
+                .state(ParticipantContextState.from(state))
+                .properties(props)
+                .build();
     }
 }

--- a/spi/common/connector-participant-context-spi/src/main/java/org/eclipse/edc/participantcontext/spi/types/ParticipantContextState.java
+++ b/spi/common/connector-participant-context-spi/src/main/java/org/eclipse/edc/participantcontext/spi/types/ParticipantContextState.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.participantcontext.spi.types;
 
+import java.util.Arrays;
+
 /**
  * The state a {@link ParticipantContext} entry is in.
  */
@@ -21,13 +23,27 @@ public enum ParticipantContextState {
     /**
      * The {@link ParticipantContext} was created in the database, but is not yet operational.
      */
-    CREATED,
+    CREATED(100),
     /**
      * The {@link ParticipantContext} is operational and can be used.
      */
-    ACTIVATED,
+    ACTIVATED(200),
     /**
      * The {@link ParticipantContext} is disabled and cannot be used currently.
      */
-    DEACTIVATED
+    DEACTIVATED(300);
+
+    private final int code;
+
+    ParticipantContextState(int code) {
+        this.code = code;
+    }
+
+    public static ParticipantContextState from(int code) {
+        return Arrays.stream(values()).filter(pcs -> pcs.code == code).findFirst().orElse(null);
+    }
+
+    public int code() {
+        return code;
+    }
 }

--- a/spi/common/connector-participant-context-spi/src/test/java/org/eclipse/edc/participantcontext/spi/types/ParticipantContextTest.java
+++ b/spi/common/connector-participant-context-spi/src/test/java/org/eclipse/edc/participantcontext/spi/types/ParticipantContextTest.java
@@ -19,21 +19,24 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantContextState.ACTIVATED;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantContextState.CREATED;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantContextState.DEACTIVATED;
 
 class ParticipantContextTest {
 
     @Test
     void verifyCreateTimestamp() {
         var context = ParticipantContext.Builder.newInstance()
-                              .participantContextId("test-id")
-                              .build();
+                .participantContextId("test-id")
+                .build();
 
         assertThat(context.getCreatedAt()).isNotZero().isLessThanOrEqualTo(Instant.now().toEpochMilli());
 
         var context2 = ParticipantContext.Builder.newInstance()
-                               .participantContextId("test-id")
-                               .createdAt(42)
-                               .build();
+                .participantContextId("test-id")
+                .createdAt(42)
+                .build();
 
         assertThat(context2.getCreatedAt()).isEqualTo(42);
     }
@@ -41,15 +44,15 @@ class ParticipantContextTest {
     @Test
     void verifyLastModifiedTimestamp() {
         var context = ParticipantContext.Builder.newInstance()
-                              .participantContextId("test-id")
-                              .build();
+                .participantContextId("test-id")
+                .build();
 
         assertThat(context.getLastModified()).isNotZero().isEqualTo(context.getCreatedAt());
 
         var context2 = ParticipantContext.Builder.newInstance()
-                               .participantContextId("test-id")
-                               .lastModified(42)
-                               .build();
+                .participantContextId("test-id")
+                .lastModified(42)
+                .build();
 
         assertThat(context2.getLastModified()).isEqualTo(42);
     }
@@ -57,12 +60,12 @@ class ParticipantContextTest {
     @Test
     void verifyState() {
         var context = ParticipantContext.Builder.newInstance()
-                              .participantContextId("test-id")
-                              .state(ParticipantContextState.CREATED);
+                .participantContextId("test-id")
+                .state(CREATED);
 
-        assertThat(context.build().getState()).isEqualTo(0);
-        assertThat(context.state(ParticipantContextState.ACTIVATED).build().getState()).isEqualTo(1);
-        assertThat(context.state(ParticipantContextState.DEACTIVATED).build().getState()).isEqualTo(2);
+        assertThat(context.build().getState()).isEqualTo(CREATED.code());
+        assertThat(context.state(ACTIVATED).build().getState()).isEqualTo(ACTIVATED.code());
+        assertThat(context.state(DEACTIVATED).build().getState()).isEqualTo(DEACTIVATED.code());
 
     }
 

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/transformer/AbstractJsonLdTransformer.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/transformer/AbstractJsonLdTransformer.java
@@ -492,6 +492,17 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
     }
 
     /**
+     * Returns the @value of the JSON object of type @json.
+     */
+    protected JsonValue nodeJsonValue(JsonValue object) {
+        if (object instanceof JsonArray) {
+            return nodeJsonValue(object.asJsonArray().get(0));
+        } else {
+            return object.asJsonObject().get(JsonLdKeywords.VALUE);
+        }
+    }
+
+    /**
      * Tries to return the instance given by a supplier (a builder's build method). If this fails due to validation errors, e.g. a required property is missing,
      * reports a problem to the context.
      *

--- a/spi/common/json-ld-spi/src/test/java/org/eclipse/edc/jsonld/spi/transformer/AbstractJsonLdTransformerReturnObjectTest.java
+++ b/spi/common/json-ld-spi/src/test/java/org/eclipse/edc/jsonld/spi/transformer/AbstractJsonLdTransformerReturnObjectTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.jsonld.spi.transformer;
 
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
 import org.eclipse.edc.transform.spi.ProblemBuilder;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
@@ -27,6 +28,7 @@ import java.util.Map;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -113,6 +115,18 @@ class AbstractJsonLdTransformerReturnObjectTest {
 
         assertThat(result).isNull();
         verify(context, times(1)).reportProblem(eq(format("Property '%s' contains an empty array", TEST_PROPERTY)));
+    }
+
+    @Test
+    void verify_nodeJsonValue() {
+
+        var object = jsonFactory.createObjectBuilder().add("name", "value").build();
+        var array = jsonFactory.createObjectBuilder().add(VALUE, object).build();
+
+        var result = transformer.nodeJsonValue(array);
+
+        assertThat(result).isInstanceOf(JsonObject.class)
+                .isEqualTo(object);
     }
 
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/NegotiationState.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/NegotiationState.java
@@ -21,7 +21,8 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
  */
 public record NegotiationState(String state) {
 
-    public static final String NEGOTIATION_STATE_TYPE = EDC_NAMESPACE + "NegotiationState";
+    public static final String NEGOTIATION_STATE_TYPE_TERM = "NegotiationState";
+    public static final String NEGOTIATION_STATE_TYPE = EDC_NAMESPACE + NEGOTIATION_STATE_TYPE_TERM;
     public static final String NEGOTIATION_STATE_STATE = EDC_NAMESPACE + "state";
 
 }

--- a/system-tests/management-api/management-api-test-runner/build.gradle.kts
+++ b/system-tests/management-api/management-api-test-runner/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     testImplementation(project(":spi:data-plane-selector:data-plane-selector-spi"))
     testImplementation(project(":core:common:connector-core"))
     testImplementation(project(":core:common:edr-store-core"))
+    testImplementation(project(":core:control-plane:control-plane-transform"))
 
     //useful for generic DTOs etc.
     testImplementation(project(":spi:control-plane:policy-spi"))

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
@@ -148,6 +148,22 @@ public class TestFunctions {
                 .build();
     }
 
+    public static JsonObject participantContextObject(String context) {
+        return createObjectBuilder()
+                .add(CONTEXT, createContextBuilder(context).build())
+                .add(TYPE, "ParticipantContext")
+                .add(ID, "participant-context-id")
+                .add("properties", createObjectBuilder()
+                        .add("name", TEST_ASSET_NAME)
+                        .add("id", TEST_ASSET_ID)
+                        .add("description", TEST_ASSET_DESCRIPTION)
+                        .add("version", TEST_ASSET_VERSION)
+                        .add("contenttype", TEST_ASSET_CONTENTTYPE)
+                        .build())
+                .add("state", "CREATED")
+                .build();
+    }
+
     public static JsonObject contractDefinitionObject(String context) {
         var criterion = Json.createObjectBuilder()
                 .add(TYPE, "Criterion")


### PR DESCRIPTION
## What this PR changes/adds

- Adds `ParticipantContext` in the v2 JSON-LD context
- Adds transformers from/to
- Add JSON schema for `ParticipantContext`

## Why it does that

_Briefly state why the change was necessary._

## Further notes

Refactored the `ParticipantContextState` in line with other states enum with specific code instead of ordinal


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5346 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
