### PR TITLE
refactor: clean up RemoteMessage hierarchy

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/protocol/ProtocolTokenValidatorImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/protocol/ProtocolTokenValidatorImplTest.java
@@ -104,7 +104,7 @@ class ProtocolTokenValidatorImplTest {
         assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(BAD_REQUEST);
     }
 
-    static class TestMessage implements RemoteMessage {
+    static class TestMessage extends RemoteMessage {
         @Override
         public String getProtocol() {
             return "protocol";
@@ -115,10 +115,6 @@ class ProtocolTokenValidatorImplTest {
             return "http://connector";
         }
 
-        @Override
-        public String getCounterPartyId() {
-            return null;
-        }
     }
 
     private static class TestRequestPolicyContext extends RequestPolicyContext {

--- a/data-protocols/dsp/dsp-core/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImpl.java
+++ b/data-protocols/dsp/dsp-core/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImpl.java
@@ -31,6 +31,7 @@ import org.eclipse.edc.spi.iam.RequestContext;
 import org.eclipse.edc.spi.iam.RequestScope;
 import org.eclipse.edc.spi.iam.TokenParameters;
 import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.types.domain.message.ProtocolRemoteMessage;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 import org.eclipse.edc.token.spi.TokenDecorator;
 import org.jetbrains.annotations.NotNull;
@@ -77,7 +78,7 @@ public class DspHttpRemoteMessageDispatcherImpl implements DspHttpRemoteMessageD
     }
 
     @Override
-    public <T, M extends RemoteMessage> CompletableFuture<StatusResult<T>> dispatch(String participantContextId, Class<T> responseType, M message) {
+    public <T, M extends ProtocolRemoteMessage> CompletableFuture<StatusResult<T>> dispatch(String participantContextId, Class<T> responseType, M message) {
         var handler = (MessageHandler<M, T>) this.handlers.get(message.getClass());
         if (handler == null) {
             return failedFuture(new EdcException(format("No DSP message dispatcher found for message type %s", message.getClass())));
@@ -127,13 +128,13 @@ public class DspHttpRemoteMessageDispatcherImpl implements DspHttpRemoteMessageD
     }
 
     @Override
-    public <M extends RemoteMessage, R> void registerMessage(Class<M> clazz, DspHttpRequestFactory<M> requestFactory,
+    public <M extends ProtocolRemoteMessage, R> void registerMessage(Class<M> clazz, DspHttpRequestFactory<M> requestFactory,
                                                              DspHttpResponseBodyExtractor<R> bodyExtractor) {
         handlers.put(clazz, new MessageHandler<>(requestFactory, bodyExtractor));
     }
 
     @Override
-    public <M extends RemoteMessage> void registerPolicyScope(Class<M> messageClass,
+    public <M extends ProtocolRemoteMessage> void registerPolicyScope(Class<M> messageClass,
                                                               Function<M, Policy> policyProvider,
                                                               RequestPolicyContext.Provider contextProvider) {
         policyScopes.put(messageClass, new PolicyScope<>(messageClass, policyProvider, contextProvider));

--- a/data-protocols/dsp/dsp-core/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/TestMessage.java
+++ b/data-protocols/dsp/dsp-core/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/TestMessage.java
@@ -14,21 +14,39 @@
 
 package org.eclipse.edc.protocol.dsp.http;
 
-import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+import org.eclipse.edc.spi.types.domain.message.ProtocolRemoteMessage;
 
-public record TestMessage(String protocol, String counterPartyAddress, String counterPartyId) implements RemoteMessage {
-    @Override
-    public String getProtocol() {
-        return protocol;
+import java.util.Objects;
+
+public final class TestMessage extends ProtocolRemoteMessage {
+
+    public TestMessage(String protocol, String counterPartyAddress, String counterPartyId) {
+        this.protocol = protocol;
+        this.counterPartyAddress = counterPartyAddress;
+        this.counterPartyId = counterPartyId;
     }
 
     @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (TestMessage) obj;
+        return Objects.equals(this.protocol, that.protocol) &&
+                Objects.equals(this.counterPartyAddress, that.counterPartyAddress) &&
+                Objects.equals(this.counterPartyId, that.counterPartyId);
     }
 
     @Override
-    public String getCounterPartyId() {
-        return counterPartyId;
+    public int hashCode() {
+        return Objects.hash(protocol, counterPartyAddress, counterPartyId);
     }
+
+    @Override
+    public String toString() {
+        return "TestMessage[" +
+                "protocol=" + protocol + ", " +
+                "counterPartyAddress=" + counterPartyAddress + ", " +
+                "counterPartyId=" + counterPartyId + ']';
+    }
+
 }

--- a/data-protocols/dsp/dsp-core/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImplTest.java
+++ b/data-protocols/dsp/dsp-core/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImplTest.java
@@ -36,7 +36,7 @@ import org.eclipse.edc.spi.iam.RequestScope;
 import org.eclipse.edc.spi.iam.TokenParameters;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+import org.eclipse.edc.spi.types.domain.message.ProtocolRemoteMessage;
 import org.eclipse.edc.token.spi.TokenDecorator;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -340,21 +340,13 @@ class DspHttpRemoteMessageDispatcherImplTest {
         });
     }
 
-    static class TestMessage implements RemoteMessage {
-        @Override
-        public String getProtocol() {
-            return null;
-        }
+    static class TestMessage extends ProtocolRemoteMessage {
 
         @Override
         public String getCounterPartyAddress() {
             return "http://connector";
         }
 
-        @Override
-        public String getCounterPartyId() {
-            return null;
-        }
     }
 
     static class TestPolicyContext extends RequestPolicyContext {

--- a/data-protocols/dsp/dsp-core/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/message/DspRequestHandlerImplTest.java
+++ b/data-protocols/dsp/dsp-core/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/message/DspRequestHandlerImplTest.java
@@ -101,6 +101,11 @@ class DspRequestHandlerImplTest {
             public static Builder newInstance() {
                 return new Builder();
             }
+
+            @Override
+            public Builder self() {
+                return this;
+            }
         }
     }
 

--- a/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/dispatcher/DspHttpRemoteMessageDispatcher.java
+++ b/data-protocols/dsp/dsp-http-spi/src/main/java/org/eclipse/edc/protocol/dsp/http/spi/dispatcher/DspHttpRemoteMessageDispatcher.java
@@ -18,14 +18,14 @@ import org.eclipse.edc.policy.context.request.spi.RequestPolicyContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.dsp.http.spi.dispatcher.response.DspHttpResponseBodyExtractor;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcher;
-import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+import org.eclipse.edc.spi.types.domain.message.ProtocolRemoteMessage;
 
 import java.util.function.Function;
 
 /**
  * {@link RemoteMessageDispatcher} for sending dataspace protocol messages.
  */
-public interface DspHttpRemoteMessageDispatcher extends RemoteMessageDispatcher {
+public interface DspHttpRemoteMessageDispatcher extends RemoteMessageDispatcher<ProtocolRemoteMessage> {
 
     /**
      * Registers a message request factory and response parser
@@ -36,7 +36,7 @@ public interface DspHttpRemoteMessageDispatcher extends RemoteMessageDispatcher 
      * @param requestFactory the request factory.
      * @param bodyExtractor  the body extractor function.
      */
-    <M extends RemoteMessage, R> void registerMessage(Class<M> clazz, DspHttpRequestFactory<M> requestFactory,
+    <M extends ProtocolRemoteMessage, R> void registerMessage(Class<M> clazz, DspHttpRequestFactory<M> requestFactory,
                                                       DspHttpResponseBodyExtractor<R> bodyExtractor);
 
     /**
@@ -46,6 +46,6 @@ public interface DspHttpRemoteMessageDispatcher extends RemoteMessageDispatcher 
      * @param messageClass   the message type for which evaluate the policy.
      * @param policyProvider function that extracts the Policy from the message.
      */
-    <M extends RemoteMessage> void registerPolicyScope(Class<M> messageClass, Function<M, Policy> policyProvider,
+    <M extends ProtocolRemoteMessage> void registerPolicyScope(Class<M> messageClass, Function<M, Policy> policyProvider,
                                                        RequestPolicyContext.Provider contextProvider);
 }

--- a/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-transform-lib/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-transform-lib/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementMessageTransformerTest.java
@@ -114,7 +114,6 @@ class JsonObjectToContractAgreementMessageTransformerTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getClass()).isEqualTo(ContractAgreementMessage.class);
-        assertThat(result.getProtocol()).isNotEmpty();
         assertThat(result.getConsumerPid()).isEqualTo("consumerPid");
         assertThat(result.getProviderPid()).isEqualTo("providerPid");
 

--- a/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-transform-lib/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementVerificationMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-transform-lib/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractAgreementVerificationMessageTransformerTest.java
@@ -65,7 +65,6 @@ class JsonObjectToContractAgreementVerificationMessageTransformerTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getClass()).isEqualTo(ContractAgreementVerificationMessage.class);
-        assertThat(result.getProtocol()).isNotEmpty();
         assertThat(result.getConsumerPid()).isEqualTo("consumerPid");
         assertThat(result.getProviderPid()).isEqualTo("providerPid");
 

--- a/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-transform-lib/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationEventMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-transform-lib/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationEventMessageTransformerTest.java
@@ -68,7 +68,6 @@ class JsonObjectToContractNegotiationEventMessageTransformerTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getClass()).isEqualTo(ContractNegotiationEventMessage.class);
-        assertThat(result.getProtocol()).isNotEmpty();
         assertThat(result.getConsumerPid()).isEqualTo("consumerPid");
         assertThat(result.getProviderPid()).isEqualTo("providerPid");
         assertThat(result.getType()).isEqualTo(ContractNegotiationEventMessage.Type.ACCEPTED);

--- a/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-transform-lib/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationTerminationMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-transform-lib/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractNegotiationTerminationMessageTransformerTest.java
@@ -63,7 +63,6 @@ class JsonObjectToContractNegotiationTerminationMessageTransformerTest {
 
         assertThat(result).isNotNull();
 
-        assertThat(result.getProtocol()).isNotNull();
         assertThat(result.getCounterPartyAddress()).isNull();
         assertThat(result.getConsumerPid()).isEqualTo("consumerPid");
         assertThat(result.getProviderPid()).isEqualTo("providerPid");
@@ -87,7 +86,6 @@ class JsonObjectToContractNegotiationTerminationMessageTransformerTest {
 
         assertThat(result).isNotNull();
 
-        assertThat(result.getProtocol()).isNotNull();
         assertThat(result.getCounterPartyAddress()).isNull();
         assertThat(result.getCode()).isNull();
         assertThat(result.getRejectionReason()).isNull();

--- a/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-transform-lib/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-transform-lib/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractOfferMessageTransformerTest.java
@@ -82,7 +82,6 @@ class JsonObjectToContractOfferMessageTransformerTest {
         var result = transformer.transform(message, context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getProtocol()).isNotEmpty();
         assertThat(result.getConsumerPid()).isEqualTo("consumerPid");
         assertThat(result.getProviderPid()).isEqualTo("providerPid");
         assertThat(result.getCallbackAddress()).isEqualTo(CALLBACK_ADDRESS);

--- a/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-transform-lib/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-transform-lib/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/transform/to/JsonObjectToContractRequestMessageTransformerTest.java
@@ -82,7 +82,6 @@ class JsonObjectToContractRequestMessageTransformerTest {
         var result = transformer.transform(getExpanded(message), context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getProtocol()).isNotEmpty();
         assertThat(result.getConsumerPid()).isEqualTo("consumerPid");
         assertThat(result.getProviderPid()).isEqualTo("providerPid");
         assertThat(result.getCallbackAddress()).isEqualTo(CALLBACK);

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpDefaultServicesExtensionTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpDefaultServicesExtensionTest.java
@@ -26,7 +26,7 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
-import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+import org.eclipse.edc.spi.types.domain.message.ProtocolRemoteMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -82,10 +83,23 @@ class DcpDefaultServicesExtensionTest {
     @Test
     void verify_defaultAudienceResolver(DcpDefaultServicesExtension ext) {
         var id = "counterPartyId";
-        var remoteMessage = mock(RemoteMessage.class);
-        when(remoteMessage.getCounterPartyId()).thenReturn(id);
-        assertThat(ext.defaultAudienceResolver().resolve(remoteMessage))
-                .extracting(Result::getContent)
-                .isEqualTo(id);
+        var message = new TestMessage(id);
+
+        var result = ext.defaultAudienceResolver().resolve(message);
+
+        assertThat(result).isSucceeded().isEqualTo(id);
+    }
+
+    private static class TestMessage extends ProtocolRemoteMessage {
+        private final String counterPartyId;
+
+        TestMessage(String counterPartyId) {
+            this.counterPartyId = counterPartyId;
+        }
+
+        @Override
+        public String getCounterPartyId() {
+            return counterPartyId;
+        }
     }
 }

--- a/extensions/control-plane/callback/callback-http-dispatcher/src/main/java/org/eclipse/edc/connector/controlplane/callback/dispatcher/http/GenericHttpRemoteDispatcher.java
+++ b/extensions/control-plane/callback/callback-http-dispatcher/src/main/java/org/eclipse/edc/connector/controlplane/callback/dispatcher/http/GenericHttpRemoteDispatcher.java
@@ -20,7 +20,7 @@ import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 /**
  * Generic HTTP Remote dispatcher
  */
-public interface GenericHttpRemoteDispatcher extends RemoteMessageDispatcher {
+public interface GenericHttpRemoteDispatcher extends RemoteMessageDispatcher<RemoteMessage> {
 
     /**
      * Registers a {@link GenericHttpDispatcherDelegate} for supporting a specific type of remote message.

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/AudienceResolver.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/iam/AudienceResolver.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.spi.iam;
 
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.domain.message.ProtocolRemoteMessage;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 
 /**
@@ -28,6 +29,6 @@ import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 @ExtensionPoint
 public interface AudienceResolver {
 
-    Result<String> resolve(RemoteMessage remoteMessage);
+    Result<String> resolve(ProtocolRemoteMessage remoteMessage);
 
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/message/RemoteMessageDispatcher.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/message/RemoteMessageDispatcher.java
@@ -22,7 +22,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Dispatches remote messages to a destination.
  */
-public interface RemoteMessageDispatcher {
+public interface RemoteMessageDispatcher<RM extends RemoteMessage> {
 
 
     /**
@@ -32,6 +32,6 @@ public interface RemoteMessageDispatcher {
      * @param message      the message
      * @return a future that can be used to retrieve the response when the operation has completed
      */
-    <T, M extends RemoteMessage> CompletableFuture<StatusResult<T>> dispatch(String participantContextId, Class<T> responseType, M message);
+    <T, M extends RM> CompletableFuture<StatusResult<T>> dispatch(String participantContextId, Class<T> responseType, M message);
 
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/ProcessRemoteMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/ProcessRemoteMessage.java
@@ -33,8 +33,6 @@ public abstract class ProcessRemoteMessage extends ProtocolRemoteMessage {
     protected String processId;
     protected String consumerPid;
     protected String providerPid;
-    protected String counterPartyAddress;
-    protected String counterPartyId;
 
     /**
      * Returns the {@link Policy} associated with the process.
@@ -74,16 +72,6 @@ public abstract class ProcessRemoteMessage extends ProtocolRemoteMessage {
         return providerPid;
     }
 
-    @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
-    }
-
-    @Override
-    public String getCounterPartyId() {
-        return counterPartyId;
-    }
-
     /**
      * Verifies if the passed processId can be considered a valid one.
      *
@@ -98,31 +86,25 @@ public abstract class ProcessRemoteMessage extends ProtocolRemoteMessage {
         }
     }
 
-    public static class Builder<M extends ProcessRemoteMessage, B extends Builder<M, B>> {
-        protected final M message;
+    public abstract static class Builder<M extends ProcessRemoteMessage, B extends Builder<M, B>> extends ProtocolRemoteMessage.Builder<M, B> {
 
         protected Builder(M message) {
-            this.message = message;
+            super(message);
         }
 
         public B id(String id) {
             message.id = id;
-            return (B) this;
+            return self();
         }
 
         public B consumerPid(String consumerPid) {
             message.consumerPid = consumerPid;
-            return (B) this;
+            return self();
         }
 
         public B providerPid(String providerPid) {
             message.providerPid = providerPid;
-            return (B) this;
-        }
-
-        public B protocol(String protocol) {
-            this.message.protocol = protocol;
-            return (B) this;
+            return self();
         }
 
         /**
@@ -132,25 +114,16 @@ public abstract class ProcessRemoteMessage extends ProtocolRemoteMessage {
          * @return the builder.
          */
         public B processId(String processId) {
-            this.message.processId = processId;
-            return (B) this;
+            message.processId = processId;
+            return self();
         }
 
-        public B counterPartyAddress(String counterPartyAddress) {
-            this.message.counterPartyAddress = counterPartyAddress;
-            return (B) this;
-        }
-
-        public B counterPartyId(String counterPartyId) {
-            this.message.counterPartyId = counterPartyId;
-            return (B) this;
-        }
-
+        @Override
         public M build() {
             if (message.id == null) {
                 message.id = randomUUID().toString();
             }
-            return message;
+            return super.build();
         }
     }
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/ProtocolRemoteMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/ProtocolRemoteMessage.java
@@ -14,19 +14,31 @@
 
 package org.eclipse.edc.spi.types.domain.message;
 
-import java.util.Objects;
+/**
+ * Envelope that represent a message that is sent through the Dataspace Protocol
+ */
+public abstract class ProtocolRemoteMessage extends RemoteMessage {
 
-public abstract class ProtocolRemoteMessage implements RemoteMessage {
+    protected String counterPartyId;
 
-    protected String protocol = "unknown";
-    
-    @Override
-    public String getProtocol() {
-        return protocol;
+    /**
+     * Returns the recipient's id.
+     */
+    public String getCounterPartyId() {
+        return counterPartyId;
     }
 
-    public void setProtocol(String protocol) {
-        Objects.requireNonNull(protocol);
-        this.protocol = protocol;
+    public abstract static class Builder<RM extends ProtocolRemoteMessage, B extends Builder<RM, B>> extends RemoteMessage.Builder<RM, B> {
+
+        protected Builder(RM message) {
+            super(message);
+        }
+
+        public B counterPartyId(String counterPartyId) {
+            message.counterPartyId = counterPartyId;
+            return self();
+        }
+
     }
+
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/RemoteMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/message/RemoteMessage.java
@@ -14,24 +14,64 @@
 
 package org.eclipse.edc.spi.types.domain.message;
 
+import java.util.Objects;
+
 /**
- * A remote message that is to be sent to another system. Dispatchers are responsible for binding the remote message to the specific transport protocol specified by the message.
+ * A remote message that is to be sent to another system. Dispatchers are responsible for binding the remote message to
+ * the specific transport protocol specified by the message.
  */
-public interface RemoteMessage {
+public abstract class RemoteMessage {
+
+    protected RemoteMessage() {
+
+    }
+
+    protected String protocol;
+    protected String counterPartyAddress;
 
     /**
      * Returns the transport protocol this message must be sent over.
      */
-    String getProtocol();
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        Objects.requireNonNull(protocol);
+        this.protocol = protocol;
+    }
 
     /**
      * Returns the recipient's callback address.
      */
-    String getCounterPartyAddress();
-    
-    /**
-     * Returns the recipient's id.
-     */
-    String getCounterPartyId();
+    public String getCounterPartyAddress() {
+        return counterPartyAddress;
+    }
+
+    public abstract static class Builder<RM extends RemoteMessage, B extends Builder<RM, B>> {
+
+        protected RM message;
+
+        protected Builder(RM message) {
+            this.message = message;
+        }
+
+        public abstract B self();
+
+        public RM build() {
+            return message;
+        }
+
+        public B protocol(String protocol) {
+            message.protocol = protocol;
+            return self();
+        }
+
+        public B counterPartyAddress(String counterPartyAddress) {
+            message.counterPartyAddress = counterPartyAddress;
+            return self();
+        }
+
+    }
 
 }

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/CatalogRequestMessage.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/CatalogRequestMessage.java
@@ -19,12 +19,10 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.types.domain.message.ProtocolRemoteMessage;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * A request for a participant's {@link Catalog}.
@@ -34,9 +32,6 @@ public class CatalogRequestMessage extends ProtocolRemoteMessage {
 
     private final Policy policy;
     private List<String> additionalScopes = new ArrayList<>();
-    private String protocol = "unknown";
-    private String counterPartyAddress;
-    private String counterPartyId;
     private QuerySpec querySpec;
 
 
@@ -44,29 +39,6 @@ public class CatalogRequestMessage extends ProtocolRemoteMessage {
         // at this time, this is just a placeholder.
         policy = Policy.Builder.newInstance().build();
     }
-
-    @NotNull
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
-
-    public void setProtocol(String protocol) {
-        this.protocol = protocol;
-    }
-
-    @NotNull
-    @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
-    }
-
-    @NotNull
-    @Override
-    public String getCounterPartyId() {
-        return counterPartyId;
-    }
-
 
     public QuerySpec getQuerySpec() {
         return querySpec;
@@ -85,11 +57,10 @@ public class CatalogRequestMessage extends ProtocolRemoteMessage {
         return additionalScopes;
     }
 
-    public static class Builder {
-        private final CatalogRequestMessage message;
+    public static class Builder extends ProtocolRemoteMessage.Builder<CatalogRequestMessage, Builder> {
 
         private Builder() {
-            message = new CatalogRequestMessage();
+            super(new CatalogRequestMessage());
         }
 
         @JsonCreator
@@ -97,19 +68,18 @@ public class CatalogRequestMessage extends ProtocolRemoteMessage {
             return new CatalogRequestMessage.Builder();
         }
 
-        public CatalogRequestMessage.Builder protocol(String protocol) {
-            this.message.protocol = protocol;
+        @Override
+        public Builder self() {
             return this;
         }
 
-        public CatalogRequestMessage.Builder counterPartyAddress(String callbackAddress) {
-            this.message.counterPartyAddress = callbackAddress;
-            return this;
-        }
+        @Override
+        public CatalogRequestMessage build() {
+            if (message.querySpec == null) {
+                message.querySpec = QuerySpec.none();
+            }
 
-        public CatalogRequestMessage.Builder counterPartyId(String counterPartyId) {
-            this.message.counterPartyId = counterPartyId;
-            return this;
+            return super.build();
         }
 
         public CatalogRequestMessage.Builder querySpec(QuerySpec querySpec) {
@@ -120,16 +90,6 @@ public class CatalogRequestMessage extends ProtocolRemoteMessage {
         public CatalogRequestMessage.Builder additionalScopes(String... additionalScopes) {
             this.message.additionalScopes = Arrays.asList(additionalScopes);
             return this;
-        }
-
-        public CatalogRequestMessage build() {
-            Objects.requireNonNull(message.protocol, "protocol");
-
-            if (message.querySpec == null) {
-                message.querySpec = QuerySpec.none();
-            }
-
-            return message;
         }
 
     }

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/DatasetRequestMessage.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/DatasetRequestMessage.java
@@ -16,20 +16,16 @@ package org.eclipse.edc.connector.controlplane.catalog.spi;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
-import org.jetbrains.annotations.NotNull;
+import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
 
 import java.util.Objects;
 
 /**
  * A request for a participant's {@link Dataset}.
  */
-public class DatasetRequestMessage implements RemoteMessage {
+public class DatasetRequestMessage extends ProcessRemoteMessage {
 
     private String datasetId;
-    private String protocol;
-    private String counterPartyAddress;
-    private String counterPartyId;
     private final Policy policy;
 
     private DatasetRequestMessage() {
@@ -39,28 +35,6 @@ public class DatasetRequestMessage implements RemoteMessage {
 
     public String getDatasetId() {
         return datasetId;
-    }
-
-    @NotNull
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
-
-    public void setProtocol(String protocol) {
-        this.protocol = protocol;
-    }
-
-    @NotNull
-    @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
-    }
-
-    @NotNull
-    @Override
-    public String getCounterPartyId() {
-        return counterPartyId;
     }
 
     /**
@@ -73,11 +47,10 @@ public class DatasetRequestMessage implements RemoteMessage {
         return policy;
     }
 
-    public static class Builder {
-        private final DatasetRequestMessage message;
+    public static class Builder extends ProcessRemoteMessage.Builder<DatasetRequestMessage, Builder> {
 
         private Builder() {
-            message = new DatasetRequestMessage();
+            super(new DatasetRequestMessage());
         }
 
         @JsonCreator
@@ -90,18 +63,8 @@ public class DatasetRequestMessage implements RemoteMessage {
             return this;
         }
 
-        public DatasetRequestMessage.Builder protocol(String protocol) {
-            this.message.protocol = protocol;
-            return this;
-        }
-
-        public DatasetRequestMessage.Builder counterPartyAddress(String callbackAddress) {
-            this.message.counterPartyAddress = callbackAddress;
-            return this;
-        }
-
-        public DatasetRequestMessage.Builder counterPartyId(String counterPartyId) {
-            this.message.counterPartyId = counterPartyId;
+        @Override
+        public Builder self() {
             return this;
         }
 

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/agreement/ContractAgreementMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/agreement/ContractAgreementMessage.java
@@ -57,6 +57,11 @@ public class ContractAgreementMessage extends ContractRemoteMessage {
             return this;
         }
 
+        @Override
+        public Builder self() {
+            return this;
+        }
+
         public ContractAgreementMessage build() {
             Objects.requireNonNull(message.contractAgreement, "contractAgreement");
             return super.build();

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/agreement/ContractAgreementVerificationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/agreement/ContractAgreementVerificationMessage.java
@@ -18,29 +18,9 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.protocol.Contra
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
 
-import java.util.Objects;
-
 public class ContractAgreementVerificationMessage extends ContractRemoteMessage {
 
-    private String protocol = "unknown";
-    private String counterPartyAddress;
     private Policy policy;
-
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
-
-    @Override
-    public void setProtocol(String protocol) {
-        Objects.requireNonNull(protocol);
-        this.protocol = protocol;
-    }
-
-    @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
-    }
 
     @Override
     public Policy getPolicy() {
@@ -57,23 +37,15 @@ public class ContractAgreementVerificationMessage extends ContractRemoteMessage 
             return new Builder();
         }
 
-        public Builder protocol(String protocol) {
-            message.protocol = protocol;
-            return this;
-        }
-
-        public Builder counterPartyAddress(String counterPartyAddress) {
-            message.counterPartyAddress = counterPartyAddress;
-            return this;
-        }
-
         public Builder policy(Policy policy) {
             message.policy = policy;
             return this;
         }
 
-        public ContractAgreementVerificationMessage build() {
-            return super.build();
+        @Override
+        public Builder self() {
+            return this;
         }
+
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/agreement/ContractNegotiationEventMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/agreement/ContractNegotiationEventMessage.java
@@ -55,6 +55,11 @@ public class ContractNegotiationEventMessage extends ContractRemoteMessage {
             return this;
         }
 
+        @Override
+        public Builder self() {
+            return this;
+        }
+
         public ContractNegotiationEventMessage build() {
             Objects.requireNonNull(message.type, "type");
             return super.build();

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractNegotiationRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractNegotiationRequestMessage.java
@@ -15,44 +15,25 @@
 package org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+import org.eclipse.edc.spi.types.domain.message.ProtocolRemoteMessage;
 
 import java.util.Objects;
 
 /**
  * A message for requesting information about an existing negotiation from the counter-party.
  */
-public class ContractNegotiationRequestMessage implements RemoteMessage {
+public class ContractNegotiationRequestMessage extends ProtocolRemoteMessage {
     
     private String negotiationId;
-    private String protocol;
-    private String counterPartyAddress;
-    private String counterPartyId;
-    
+
     public String getNegotiationId() {
         return negotiationId;
     }
-    
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
-    
-    @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
-    }
-    
-    @Override
-    public String getCounterPartyId() {
-        return counterPartyId;
-    }
-    
-    public static class Builder {
-        private final ContractNegotiationRequestMessage message;
-        
+
+    public static class Builder extends ProtocolRemoteMessage.Builder<ContractNegotiationRequestMessage, Builder> {
+
         private Builder() {
-            this.message = new ContractNegotiationRequestMessage();
+            super(new ContractNegotiationRequestMessage());
         }
         
         @JsonCreator
@@ -60,31 +41,20 @@ public class ContractNegotiationRequestMessage implements RemoteMessage {
             return new Builder();
         }
         
+        @Override
+        public Builder self() {
+            return this;
+        }
+
+        @Override
+        public ContractNegotiationRequestMessage build() {
+            Objects.requireNonNull(message.negotiationId, "negotiationId");
+            return super.build();
+        }
+
         public Builder negotiationId(String negotiationId) {
             this.message.negotiationId = negotiationId;
             return this;
-        }
-        
-        public Builder protocol(String protocol) {
-            this.message.protocol = protocol;
-            return this;
-        }
-        
-        public Builder counterPartyAddress(String counterPartyAddress) {
-            this.message.counterPartyAddress = counterPartyAddress;
-            return this;
-        }
-        
-        public Builder counterPartyId(String counterPartyId) {
-            this.message.counterPartyId = counterPartyId;
-            return this;
-        }
-        
-        public ContractNegotiationRequestMessage build() {
-            Objects.requireNonNull(message.negotiationId, "negotiationId");
-            Objects.requireNonNull(message.protocol, "protocol");
-            
-            return message;
         }
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractNegotiationTerminationMessage.java
@@ -65,8 +65,9 @@ public class ContractNegotiationTerminationMessage extends ContractRemoteMessage
             return this;
         }
 
-        public ContractNegotiationTerminationMessage build() {
-            return super.build();
+        @Override
+        public Builder self() {
+            return this;
         }
     }
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractOfferMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractOfferMessage.java
@@ -63,6 +63,11 @@ public class ContractOfferMessage extends ContractRemoteMessage {
             return this;
         }
 
+        @Override
+        public Builder self() {
+            return this;
+        }
+
         public ContractOfferMessage build() {
             requireNonNull(message.contractOffer, "contractOffer");
             return super.build();

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractRequestMessage.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractRequestMessage.java
@@ -81,6 +81,11 @@ public class ContractRequestMessage extends ContractRemoteMessage {
             return this;
         }
 
+        @Override
+        public Builder self() {
+            return this;
+        }
+
         public ContractRequestMessage build() {
             if (message.type == Type.INITIAL) {
                 requireNonNull(message.callbackAddress, "callbackAddress");

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/callback/CallbackEventRemoteMessage.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/callback/CallbackEventRemoteMessage.java
@@ -23,26 +23,16 @@ import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 /**
  * Envelope for implementors {@link Event} for sending event to external systems via {@link RemoteMessageDispatcherRegistry}
  */
-public class CallbackEventRemoteMessage<T extends Event> implements RemoteMessage {
+public class CallbackEventRemoteMessage<T extends Event> extends RemoteMessage {
 
-    private final String protocol;
     private final EventEnvelope<T> envelope;
     private final CallbackAddress callbackAddress;
 
     public CallbackEventRemoteMessage(CallbackAddress callbackAddress, EventEnvelope<T> envelope, String protocol) {
         this.callbackAddress = callbackAddress;
+        this.counterPartyAddress = callbackAddress.getUri();
         this.protocol = protocol;
         this.envelope = envelope;
-    }
-
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
-
-    @Override
-    public String getCounterPartyAddress() {
-        return callbackAddress.getUri();
     }
 
     public String getAuthKey() {
@@ -57,8 +47,4 @@ public class CallbackEventRemoteMessage<T extends Event> implements RemoteMessag
         return envelope;
     }
 
-    @Override
-    public String getCounterPartyId() {
-        return null;
-    }
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/protocol/TransferCompletionMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/protocol/TransferCompletionMessage.java
@@ -36,5 +36,9 @@ public class TransferCompletionMessage extends TransferRemoteMessage {
             return new Builder();
         }
 
+        @Override
+        public Builder self() {
+            return this;
+        }
     }
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/protocol/TransferProcessRequestMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/protocol/TransferProcessRequestMessage.java
@@ -15,44 +15,25 @@
 package org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
+import org.eclipse.edc.spi.types.domain.message.ProtocolRemoteMessage;
 
 import java.util.Objects;
 
 /**
  * A message for requesting information about an existing transfer process from the counter-party.
  */
-public class TransferProcessRequestMessage implements RemoteMessage {
+public class TransferProcessRequestMessage extends ProtocolRemoteMessage {
     
     private String transferProcessId;
-    private String protocol;
-    private String counterPartyAddress;
-    private String counterPartyId;
-    
+
     public String getTransferProcessId() {
         return transferProcessId;
     }
-    
-    @Override
-    public String getProtocol() {
-        return protocol;
-    }
-    
-    @Override
-    public String getCounterPartyAddress() {
-        return counterPartyAddress;
-    }
-    
-    @Override
-    public String getCounterPartyId() {
-        return counterPartyId;
-    }
-    
-    public static class Builder {
-        private final TransferProcessRequestMessage message;
-        
+
+    public static class Builder extends ProtocolRemoteMessage.Builder<TransferProcessRequestMessage, Builder> {
+
         private Builder() {
-            this.message = new TransferProcessRequestMessage();
+            super(new TransferProcessRequestMessage());
         }
         
         @JsonCreator
@@ -61,29 +42,19 @@ public class TransferProcessRequestMessage implements RemoteMessage {
         }
         
         public Builder transferProcessId(String transferProcessId) {
-            this.message.transferProcessId = transferProcessId;
+            message.transferProcessId = transferProcessId;
             return this;
         }
-        
-        public Builder protocol(String protocol) {
-            this.message.protocol = protocol;
+
+        @Override
+        public Builder self() {
             return this;
         }
-        
-        public Builder counterPartyAddress(String counterPartyAddress) {
-            this.message.counterPartyAddress = counterPartyAddress;
-            return this;
-        }
-        
-        public Builder counterPartyId(String counterPartyId) {
-            this.message.counterPartyId = counterPartyId;
-            return this;
-        }
-        
+
+        @Override
         public TransferProcessRequestMessage build() {
             Objects.requireNonNull(message.transferProcessId, "transferProcessId");
-            Objects.requireNonNull(message.protocol, "protocol");
-            
+
             return message;
         }
     }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/protocol/TransferRemoteMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/protocol/TransferRemoteMessage.java
@@ -29,7 +29,7 @@ public abstract class TransferRemoteMessage extends ProcessRemoteMessage {
         return policy;
     }
 
-    public static class Builder<M extends TransferRemoteMessage, B extends TransferRemoteMessage.Builder<M, B>> extends ProcessRemoteMessage.Builder<M, B> {
+    public abstract static class Builder<M extends TransferRemoteMessage, B extends Builder<M, B>> extends ProcessRemoteMessage.Builder<M, B> {
 
         protected Builder(M message) {
             super(message);
@@ -37,7 +37,7 @@ public abstract class TransferRemoteMessage extends ProcessRemoteMessage {
 
         public B policy(Policy policy) {
             message.policy = policy;
-            return (B) this;
+            return self();
         }
     }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/protocol/TransferRequestMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/protocol/TransferRequestMessage.java
@@ -79,6 +79,11 @@ public class TransferRequestMessage extends TransferRemoteMessage {
         }
 
         @Override
+        public Builder self() {
+            return this;
+        }
+
+        @Override
         public TransferRequestMessage build() {
             Objects.requireNonNull(message.callbackAddress, "The callbackAddress must be specified");
             return super.build();

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/protocol/TransferStartMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/protocol/TransferStartMessage.java
@@ -43,8 +43,12 @@ public class TransferStartMessage extends TransferRemoteMessage {
 
         public Builder dataAddress(DataAddress dataAddress) {
             message.dataAddress = dataAddress;
-            return this;
+            return self();
         }
 
+        @Override
+        public Builder self() {
+            return this;
+        }
     }
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/protocol/TransferSuspensionMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/protocol/TransferSuspensionMessage.java
@@ -60,5 +60,9 @@ public class TransferSuspensionMessage extends TransferRemoteMessage {
             return this;
         }
 
+        @Override
+        public Builder self() {
+            return this;
+        }
     }
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/protocol/TransferTerminationMessage.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/protocol/TransferTerminationMessage.java
@@ -49,13 +49,17 @@ public class TransferTerminationMessage extends TransferRemoteMessage {
 
         public Builder code(String code) {
             message.code = code;
-            return this;
+            return self();
         }
 
         public Builder reason(String reason) {
             message.reason = reason;
-            return this;
+            return self();
         }
 
+        @Override
+        public Builder self() {
+            return this;
+        }
     }
 }

--- a/system-tests/dsp-compatibility-tests/compatibility-test-runner/build.gradle.kts
+++ b/system-tests/dsp-compatibility-tests/compatibility-test-runner/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
     testImplementation(libs.junit.platform.launcher)
     testImplementation(testFixtures(project(":extensions:common:sql:sql-test-fixtures")))
     runtimeOnly(libs.parsson)
+
+    testCompileOnly(project(":system-tests:dsp-compatibility-tests:connector-under-test"))
 }
 
 edcBuild {


### PR DESCRIPTION
## What this PR changes/adds

Cleans up the `RemoteMessage` hierarchy.
The first work done has been to make the `RemoteMessage` an abstract class instead of an interface, this because there's no real value in represent a data object as an interface, plus it saves a lot of code (getters/setters/builders).

With the current PR we'll have:
- `RemoteMessage`: root class, represents a generic remote message that can be sent/received over a protocol
  - `ProtocolRemoteMessage`: represent a message that could be received/sent on the dataspace protocol
  - `CallbackEventRemoteMessage`: represent a message that could be sent after a specific event happens

## Why it does that

clearly separates responsibilities.

## Further notes
- Maybe the way we designed the `ProtocolRemoteMessage` is not the best, because we're forcing the actual messages (like `ContractRequestMessage` or `TransferStartMessage` to contain the protocol and counter part address info, but that's simply the metadata that gets transmitted through headers/path, while the message itself is the payload that gets transformed from/to json. We should have 2 sub-classes of `RemoteMessage` called `IngressDataspaceMessage` and `EgressDataspaceMessage` that contains the metadata and the instance of the actual message that has been deserialized/will be serialized. Eventually to be done in a separate PR.

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #3791

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
