### PR TITLE
feat(dps): implement data plane registration endpoint

### DIFF
--- a/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/service/EmbeddedDataPlaneSelectorService.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/service/EmbeddedDataPlaneSelectorService.java
@@ -75,7 +75,7 @@ public class EmbeddedDataPlaneSelectorService implements DataPlaneSelectorServic
     }
 
     @Override
-    public ServiceResult<Void> addInstance(DataPlaneInstance instance) {
+    public ServiceResult<Void> register(DataPlaneInstance instance) {
         return transactionContext.execute(() -> {
             instance.transitionToRegistered();
             store.save(instance);
@@ -100,6 +100,17 @@ public class EmbeddedDataPlaneSelectorService implements DataPlaneSelectorServic
 
             return ServiceResult.from(operation);
         });
+    }
+
+    @Override
+    public ServiceResult<Void> update(DataPlaneInstance instance) {
+        return transactionContext.execute(() -> store.findByIdAndLease(instance.getId())
+                .map(stored -> stored.toBuilder()
+                        .url(instance.getUrl())
+                        .allowedTransferType(instance.getAllowedTransferTypes())
+                        .build())
+                .compose(store::save)
+                .flatMap(ServiceResult::from));
     }
 
     @Override

--- a/data-protocols/data-plane-signaling/build.gradle.kts
+++ b/data-protocols/data-plane-signaling/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    id(libs.plugins.swagger.get().pluginId)
+}
+
+dependencies {
+    api(project(":spi:common:core-spi"))
+    api(project(":spi:common:web-spi"))
+    api(project(":spi:control-plane:contract-spi"))
+    api(project(":spi:control-plane:transfer-spi"))
+    api(project(":spi:data-plane-selector:data-plane-selector-spi"))
+    implementation(project(":core:common:lib:api-lib"))
+
+    testImplementation(project(":core:common:junit"))
+    testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
+    testImplementation(libs.restAssured)
+}

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingExtension.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingExtension.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.signaling;
+
+import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.signaling.port.DataPlaneRegistrationApiController;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+
+import static org.eclipse.edc.signaling.DataPlaneSignalingExtension.NAME;
+
+@Extension(NAME)
+public class DataPlaneSignalingExtension implements ServiceExtension {
+
+    public static final String NAME = "Data Plane Signaling";
+
+    @Inject
+    private WebService webService;
+    @Inject
+    private DataPlaneSelectorService dataPlaneSelectorService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        webService.registerResource(ApiContext.CONTROL, new DataPlaneRegistrationApiController(dataPlaneSelectorService));
+    }
+}

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/domain/DataPlaneRegistrationMessage.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/domain/DataPlaneRegistrationMessage.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.signaling.domain;
+
+import java.util.Set;
+
+public record DataPlaneRegistrationMessage(
+        String dataplaneId,
+        String name,
+        String description,
+        String endpoint,
+        Set<String> transferTypes,
+        Set<String> labels
+) {
+}

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/port/DataPlaneRegistrationApi.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/port/DataPlaneRegistrationApi.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.signaling.port;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.edc.api.model.ApiCoreSchema;
+import org.eclipse.edc.signaling.domain.DataPlaneRegistrationMessage;
+
+import static jakarta.ws.rs.HttpMethod.DELETE;
+import static jakarta.ws.rs.HttpMethod.POST;
+import static jakarta.ws.rs.HttpMethod.PUT;
+
+@OpenAPIDefinition
+@Tag(name = "Dataplane Signaling Registration")
+public interface DataPlaneRegistrationApi {
+
+    @Operation(
+            method = POST,
+            description = "Register a new Dataplane instance",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DataPlaneRegistrationMessage.class))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Dataplane instance correctly registered"),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    Response register(DataPlaneRegistrationMessage registration);
+
+    @Operation(
+            method = PUT,
+            description = "Update a Dataplane instance",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DataPlaneRegistrationMessage.class))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Dataplane instance correctly updated"),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "Not found",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    Response update(String dataplaneId, DataPlaneRegistrationMessage registration);
+
+
+    @Operation(
+            method = DELETE,
+            description = "Update a Dataplane instance",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Dataplane instance correctly deleted"),
+                    @ApiResponse(responseCode = "404", description = "Not found",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    Response delete(String dataplaneId);
+
+}

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/port/DataPlaneRegistrationApiController.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/port/DataPlaneRegistrationApiController.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.signaling.port;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.signaling.domain.DataPlaneRegistrationMessage;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.mapToException;
+
+@Path("/dataplanes")
+@Produces(APPLICATION_JSON)
+@Consumes(APPLICATION_JSON)
+public class DataPlaneRegistrationApiController implements DataPlaneRegistrationApi {
+
+    private final DataPlaneSelectorService dataPlaneSelectorService;
+
+    public DataPlaneRegistrationApiController(DataPlaneSelectorService dataPlaneSelectorService) {
+        this.dataPlaneSelectorService = dataPlaneSelectorService;
+    }
+
+    @Path("/register")
+    @POST
+    @Override
+    public Response register(DataPlaneRegistrationMessage registration) {
+        var dataPlaneInstance = toDataPlaneInstance(registration.dataplaneId(), registration);
+
+        dataPlaneSelectorService.register(dataPlaneInstance)
+                .orElseThrow(it -> mapToException(it, DataPlaneInstance.class, registration.dataplaneId()));
+
+        return Response.ok().build();
+    }
+
+    @Path("/{dataplaneId}")
+    @PUT
+    @Override
+    public Response update(@PathParam("dataplaneId") String dataplaneId, DataPlaneRegistrationMessage registration) {
+        var dataPlaneInstance = toDataPlaneInstance(dataplaneId, registration);
+
+        dataPlaneSelectorService.update(dataPlaneInstance)
+                .orElseThrow(it -> mapToException(it, DataPlaneInstance.class, dataplaneId));
+
+        return Response.ok().build();
+    }
+
+    @Path("/{dataplaneId}")
+    @DELETE
+    @Override
+    public Response delete(@PathParam("dataplaneId") String dataplaneId) {
+        dataPlaneSelectorService.delete(dataplaneId)
+                .orElseThrow(it -> mapToException(it, DataPlaneInstance.class, dataplaneId));
+
+        return Response.ok().build();
+    }
+
+    private DataPlaneInstance toDataPlaneInstance(String dataplaneId, DataPlaneRegistrationMessage registration) {
+        return DataPlaneInstance.Builder.newInstance()
+                .id(dataplaneId)
+                .url(registration.endpoint())
+                .allowedTransferType(registration.transferTypes())
+                .build();
+    }
+}

--- a/data-protocols/data-plane-signaling/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/data-plane-signaling/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,1 @@
+org.eclipse.edc.signaling.DataPlaneSignalingExtension

--- a/data-protocols/data-plane-signaling/src/test/java/org/eclipse/edc/signaling/DataPlaneRegistrationApiControllerTest.java
+++ b/data-protocols/data-plane-signaling/src/test/java/org/eclipse/edc/signaling/DataPlaneRegistrationApiControllerTest.java
@@ -1,0 +1,181 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.signaling;
+
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.signaling.port.DataPlaneRegistrationApiController;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DataPlaneRegistrationApiControllerTest extends RestControllerTestBase {
+
+    private final DataPlaneSelectorService dataPlaneSelectorService = mock();
+
+    @Nested
+    class Register {
+        @Test
+        void shouldRegisterNewDataplane() {
+            when(dataPlaneSelectorService.register(any())).thenReturn(ServiceResult.success());
+            var requestBody = Map.of(
+                    "dataplaneId", "dataplane-id",
+                    "name", "dataplane-name",
+                    "description", "dataplane-description",
+                    "endpoint", "http://dataplane-endpoint",
+                    "transferTypes", List.of("transferType-PUSH", "transferType-PULL"),
+                    "labels", List.of("label-1", "label-2")
+            );
+
+            baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(requestBody)
+                    .post("/dataplanes/register")
+                    .then()
+                    .statusCode(200);
+
+            var captor = ArgumentCaptor.forClass(DataPlaneInstance.class);
+            verify(dataPlaneSelectorService).register(captor.capture());
+            var instance = captor.getValue();
+            assertThat(instance.getId()).isEqualTo("dataplane-id");
+            assertThat(instance.getUrl().toString()).isEqualTo("http://dataplane-endpoint");
+            assertThat(instance.getAllowedTransferTypes()).containsExactly("transferType-PUSH", "transferType-PULL");
+        }
+
+        @Test
+        void shouldReturnError_whenRegistrationFails() {
+            when(dataPlaneSelectorService.register(any())).thenReturn(ServiceResult.conflict("error"));
+
+            var requestBody = Map.of(
+                    "dataplaneId", "dataplane-id",
+                    "name", "dataplane-name",
+                    "description", "dataplane-description",
+                    "endpoint", "http://dataplane-endpoint",
+                    "transferTypes", List.of("transferType-PUSH", "transferType-PULL"),
+                    "labels", List.of("label-1", "label-2")
+            );
+
+            baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(requestBody)
+                    .post("/dataplanes/register")
+                    .then()
+                    .statusCode(409);
+        }
+    }
+
+    @Nested
+    class Update {
+        @Test
+        void shouldUpdateExistingDataPlan() {
+            when(dataPlaneSelectorService.update(any())).thenReturn(ServiceResult.success());
+            var requestBody = Map.of(
+                    "dataplaneId", "dataplane-id",
+                    "name", "dataplane-name",
+                    "description", "dataplane-description",
+                    "endpoint", "http://dataplane-endpoint",
+                    "transferTypes", List.of("transferType-PUSH", "transferType-PULL"),
+                    "labels", List.of("label-1", "label-2")
+            );
+
+            baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(requestBody)
+                    .put("/dataplanes/dataplane-id")
+                    .then()
+                    .statusCode(200);
+
+            var captor = ArgumentCaptor.forClass(DataPlaneInstance.class);
+            verify(dataPlaneSelectorService).update(captor.capture());
+            var instance = captor.getValue();
+            assertThat(instance.getId()).isEqualTo("dataplane-id");
+            assertThat(instance.getUrl().toString()).isEqualTo("http://dataplane-endpoint");
+            assertThat(instance.getAllowedTransferTypes()).containsExactly("transferType-PUSH", "transferType-PULL");
+        }
+
+        @Test
+        void shouldReturnError_whenUpdateFails() {
+            when(dataPlaneSelectorService.update(any())).thenReturn(ServiceResult.conflict("error"));
+
+            var requestBody = Map.of(
+                    "dataplaneId", "dataplane-id",
+                    "name", "dataplane-name",
+                    "description", "dataplane-description",
+                    "endpoint", "http://dataplane-endpoint",
+                    "transferTypes", List.of("transferType-PUSH", "transferType-PULL"),
+                    "labels", List.of("label-1", "label-2")
+            );
+
+            baseRequest()
+                    .contentType(ContentType.JSON)
+                    .body(requestBody)
+                    .put("/dataplanes/dataplane-id")
+                    .then()
+                    .statusCode(409);
+        }
+    }
+
+    @Nested
+    class Delete {
+        @Test
+        void shouldDeleteDataPlane() {
+            when(dataPlaneSelectorService.delete(any())).thenReturn(ServiceResult.success());
+
+            baseRequest()
+                    .contentType(ContentType.JSON)
+                    .delete("/dataplanes/dataplane-id")
+                    .then()
+                    .statusCode(200);
+
+            verify(dataPlaneSelectorService).delete("dataplane-id");
+        }
+
+        @Test
+        void shouldReturnError_whenDeletionFails() {
+            when(dataPlaneSelectorService.delete(any())).thenReturn(ServiceResult.conflict("error"));
+
+            baseRequest()
+                    .contentType(ContentType.JSON)
+                    .delete("/dataplanes/dataplane-id")
+                    .then()
+                    .statusCode(409);
+        }
+    }
+
+    @Override
+    protected Object controller() {
+        return new DataPlaneRegistrationApiController(dataPlaneSelectorService);
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port)
+                .when();
+    }
+}

--- a/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorService.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorService.java
@@ -82,7 +82,7 @@ public class RemoteDataPlaneSelectorService implements DataPlaneSelectorService 
     }
 
     @Override
-    public ServiceResult<Void> addInstance(DataPlaneInstance instance) {
+    public ServiceResult<Void> register(DataPlaneInstance instance) {
         var transform = typeTransformerRegistry.transform(instance, JsonObject.class);
         if (transform.failed()) {
             return ServiceResult.badRequest(transform.getFailureDetail());
@@ -110,6 +110,11 @@ public class RemoteDataPlaneSelectorService implements DataPlaneSelectorService 
         var requestBuilder = new Request.Builder().put(RequestBody.create(new byte[0])).url("%s/%s/unregister".formatted(url, instanceId));
 
         return httpClient.request(requestBuilder).mapEmpty();
+    }
+
+    @Override
+    public ServiceResult<Void> update(DataPlaneInstance instance) {
+        return ServiceResult.unexpected("DataPlaneSelectorService.update can only be called as embedded in the control-plane");
     }
 
     @Override

--- a/extensions/data-plane-selector/data-plane-selector-client/src/test/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorServiceTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/test/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorServiceTest.java
@@ -84,15 +84,15 @@ class RemoteDataPlaneSelectorServiceTest {
     );
 
     @Test
-    void addInstance() {
+    void register() {
         when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
-        when(serverService.addInstance(any())).thenReturn(ServiceResult.success());
+        when(serverService.register(any())).thenReturn(ServiceResult.success());
         var instance = createInstance("dataPlaneId");
 
-        var result = service().addInstance(instance);
+        var result = service().register(instance);
 
         assertThat(result).isSucceeded();
-        verify(serverService).addInstance(any());
+        verify(serverService).register(any());
     }
 
     private DataPlaneSelectorService service() {

--- a/extensions/data-plane-selector/data-plane-selector-control-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApiController.java
+++ b/extensions/data-plane-selector/data-plane-selector-control-api/src/main/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApiController.java
@@ -77,7 +77,7 @@ public class DataplaneSelectorControlApiController implements DataplaneSelectorC
                 .participantContextId(participantContext.getParticipantContextId())
                 .build();
 
-        service.addInstance(dataplane)
+        service.register(dataplane)
                 .orElseThrow(exceptionMapper(DataPlaneInstance.class, dataplane.getId()));
 
         var idResponse = IdResponse.Builder.newInstance()

--- a/extensions/data-plane-selector/data-plane-selector-control-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApiControllerTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-control-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApiControllerTest.java
@@ -71,7 +71,7 @@ class DataplaneSelectorControlApiControllerTest extends RestControllerTestBase {
             var response = Json.createObjectBuilder().add(ID, "id").build();
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(typeTransformerRegistry.transform(any(), eq(DataPlaneInstance.class))).thenReturn(Result.success(dataplaneInstance));
-            when(service.addInstance(any())).thenReturn(ServiceResult.success());
+            when(service.register(any())).thenReturn(ServiceResult.success());
             when(typeTransformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(response));
 
             given()
@@ -84,7 +84,7 @@ class DataplaneSelectorControlApiControllerTest extends RestControllerTestBase {
                     .body(ID, is("id"));
 
             var captor = ArgumentCaptor.forClass(DataPlaneInstance.class);
-            verify(service).addInstance(captor.capture());
+            verify(service).register(captor.capture());
 
             assertThat(captor.getValue()).usingRecursiveComparison()
                     .isEqualTo(dataplaneInstance);
@@ -126,7 +126,7 @@ class DataplaneSelectorControlApiControllerTest extends RestControllerTestBase {
             var dataplaneInstance = DataPlaneInstance.Builder.newInstance().url("http://url").build();
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(typeTransformerRegistry.transform(any(), eq(DataPlaneInstance.class))).thenReturn(Result.success(dataplaneInstance));
-            when(service.addInstance(any())).thenReturn(ServiceResult.conflict("conflict"));
+            when(service.register(any())).thenReturn(ServiceResult.conflict("conflict"));
 
             given()
                     .port(port)
@@ -142,7 +142,7 @@ class DataplaneSelectorControlApiControllerTest extends RestControllerTestBase {
             var dataplaneInstance = DataPlaneInstance.Builder.newInstance().url("http://url").build();
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(typeTransformerRegistry.transform(any(), eq(DataPlaneInstance.class))).thenReturn(Result.success(dataplaneInstance));
-            when(service.addInstance(any())).thenReturn(ServiceResult.success());
+            when(service.register(any())).thenReturn(ServiceResult.success());
             when(typeTransformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.failure("error"));
 
             given()

--- a/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
+++ b/extensions/data-plane/data-plane-self-registration/src/main/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtension.java
@@ -102,7 +102,7 @@ public class DataplaneSelfRegistrationExtension implements ServiceExtension {
 
         var monitor = context.getMonitor().withPrefix("DataPlaneSelfRegistration");
         monitor.debug("Initiate data plane registration.");
-        dataPlaneSelectorService.addInstance(instance)
+        dataPlaneSelectorService.register(instance)
                 .onSuccess(it -> {
                     monitor.debug("data plane registered to control plane");
                     isRegistered.set(true);

--- a/extensions/data-plane/data-plane-self-registration/src/test/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtensionTest.java
+++ b/extensions/data-plane/data-plane-self-registration/src/test/java/org/eclipse/edc/connector/dataplane/registration/DataplaneSelfRegistrationExtensionTest.java
@@ -81,13 +81,13 @@ class DataplaneSelfRegistrationExtensionTest {
         when(endpointDataReferenceServiceRegistry.supportedResponseTypes()).thenReturn(Set.of("responseType", "anotherResponseType"));
         when(resourceDefinitionGeneratorManager.sourceTypes()).thenReturn(Set.of("supportedSourceProvisionType"));
         when(resourceDefinitionGeneratorManager.destinationTypes()).thenReturn(Set.of("supportedDestinationProvisionType"));
-        when(dataPlaneSelectorService.addInstance(any())).thenReturn(ServiceResult.success());
+        when(dataPlaneSelectorService.register(any())).thenReturn(ServiceResult.success());
 
         extension.initialize(context);
         extension.start();
 
         var captor = ArgumentCaptor.forClass(DataPlaneInstance.class);
-        verify(dataPlaneSelectorService).addInstance(captor.capture());
+        verify(dataPlaneSelectorService).register(captor.capture());
         var dataPlaneInstance = captor.getValue();
         assertThat(dataPlaneInstance.getId()).isEqualTo("componentId");
         assertThat(dataPlaneInstance.getUrl()).isEqualTo(new URL("http://control/api/url/v1/dataflows"));
@@ -115,7 +115,7 @@ class DataplaneSelfRegistrationExtensionTest {
     @Test
     void shouldNotStart_whenRegistrationFails(DataplaneSelfRegistrationExtension extension, ServiceExtensionContext context) {
         when(controlApiUrl.get()).thenReturn(URI.create("http://control/api/url"));
-        when(dataPlaneSelectorService.addInstance(any())).thenReturn(ServiceResult.conflict("cannot register"));
+        when(dataPlaneSelectorService.register(any())).thenReturn(ServiceResult.conflict("cannot register"));
 
         extension.initialize(context);
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -76,6 +76,8 @@ include(":core:data-plane-selector:data-plane-selector-core")
 
 include(":core:policy-monitor:policy-monitor-core")
 
+// data plane signaling
+include(":data-protocols:data-plane-signaling")
 
 // modules that provide implementations for data ingress/egress ------------------------------------
 include(":data-protocols:dsp:dsp-spi")
@@ -314,24 +316,25 @@ include(":spi:policy-monitor:policy-monitor-spi")
 include(":tests:junit-base")
 
 // modules for system tests ------------------------------------------------------------------------
+include(":system-tests:bom-tests")
+include(":system-tests:dcp-tck-tests:presentation")
+include(":system-tests:dsp-compatibility-tests:compatibility-test-runner")
+include(":system-tests:dsp-compatibility-tests:connector-under-test")
+include(":system-tests:e2e-dataplane-tests:runtimes:data-plane")
+include(":system-tests:e2e-dataplane-tests:tests")
 include(":system-tests:e2e-transfer-test:control-plane")
 include(":system-tests:e2e-transfer-test:data-plane")
 include(":system-tests:e2e-transfer-test:runner")
-include(":system-tests:e2e-dataplane-tests:runtimes:data-plane")
-include(":system-tests:e2e-dataplane-tests:tests")
+include(":system-tests:e2e-transfer-test:signaling-data-plane")
 include(":system-tests:management-api:management-api-test-runner")
 include(":system-tests:management-api:management-api-test-runtime")
-include(":system-tests:version-api:version-api-test-runtime")
-include(":system-tests:version-api:version-api-test-runner")
-include(":system-tests:protocol-test")
 include(":system-tests:protocol-2025-test")
+include(":system-tests:protocol-tck:tck-extension")
+include(":system-tests:protocol-test")
 include(":system-tests:telemetry:telemetry-test-runner")
 include(":system-tests:telemetry:telemetry-test-runtime")
-include(":system-tests:bom-tests")
-include(":system-tests:dsp-compatibility-tests:connector-under-test")
-include(":system-tests:dsp-compatibility-tests:compatibility-test-runner")
-include(":system-tests:protocol-tck:tck-extension")
-include(":system-tests:dcp-tck-tests:presentation")
+include(":system-tests:version-api:version-api-test-runner")
+include(":system-tests:version-api:version-api-test-runtime")
 
 // BOM modules ----------------------------------------------------------------
 include(":dist:bom:controlplane-base-bom")

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
@@ -46,17 +46,14 @@ public interface DataPlaneSelectorService {
     ServiceResult<DataPlaneInstance> select(@Nullable String selectionStrategy, Predicate<DataPlaneInstance> filter);
 
     /**
-     * Add a data plane instance
+     * Register a data plane instance
      */
-    ServiceResult<Void> addInstance(DataPlaneInstance instance);
+    ServiceResult<Void> register(DataPlaneInstance instance);
 
-    /**
-     * Delete a Data Plane instance.
-     *
-     * @param instanceId the instance id.
-     * @return successful result if operation completed, failure otherwise.
-     */
-    ServiceResult<Void> delete(String instanceId);
+    @Deprecated(since = "0.15.0")
+    default ServiceResult<Void> addInstance(DataPlaneInstance instance) {
+        return register(instance);
+    }
 
     /**
      * Unregister a Data Plane instance. The state will transition to {@link DataPlaneInstanceStates#UNREGISTERED}.
@@ -65,6 +62,22 @@ public interface DataPlaneSelectorService {
      * @return successful result if operation completed, failure otherwise.
      */
     ServiceResult<Void> unregister(String instanceId);
+
+    /**
+     * Update a Data Plane instance.
+     *
+     * @param instance the updated instance;
+     * @return successful result if operation completed, failure otherwise
+     */
+    ServiceResult<Void> update(DataPlaneInstance instance);
+
+    /**
+     * Delete a Data Plane instance.
+     *
+     * @param instanceId the instance id.
+     * @return successful result if operation completed, failure otherwise.
+     */
+    ServiceResult<Void> delete(String instanceId);
 
     /**
      * Find a Data Plane instance by id.

--- a/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataPlaneSelectorEndToEndTest.java
+++ b/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataPlaneSelectorEndToEndTest.java
@@ -97,8 +97,8 @@ public class DataPlaneSelectorEndToEndTest {
         controlPlane.getService(SelectionStrategyRegistry.class).add(new SelectFirst());
 
         var selectorService = controlPlane.getService(DataPlaneSelectorService.class);
-        selectorService.addInstance(createDataPlaneInstance("not-available", "http://localhost:" + getFreePort()));
-        selectorService.addInstance(createDataPlaneInstance("available", "http://localhost:" + dataPlaneControlPort + "/control/v1/dataflows"));
+        selectorService.register(createDataPlaneInstance("not-available", "http://localhost:" + getFreePort()));
+        selectorService.register(createDataPlaneInstance("available", "http://localhost:" + dataPlaneControlPort + "/control/v1/dataflows"));
 
         await().atMost(30, SECONDS).untilAsserted(() -> {
             var start = controlPlane.getService(DataFlowManager.class).start(transferProcess, policy);

--- a/system-tests/e2e-transfer-test/runner/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/runner/build.gradle.kts
@@ -30,10 +30,10 @@ dependencies {
     testImplementation(testFixtures(project(":extensions:control-plane:api:management-api:management-api-test-fixtures")))
     testImplementation(project(":extensions:common:json-ld"))
 
-    testImplementation(libs.postgres)
-    testImplementation(libs.restAssured)
     testImplementation(libs.awaitility)
     testImplementation(libs.kafkaClients)
+    testImplementation(libs.postgres)
+    testImplementation(libs.restAssured)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.kafka)
     testImplementation(libs.testcontainers.postgres)
@@ -41,6 +41,7 @@ dependencies {
 
     testCompileOnly(project(":system-tests:e2e-transfer-test:control-plane"))
     testCompileOnly(project(":system-tests:e2e-transfer-test:data-plane"))
+    testCompileOnly(project(":system-tests:e2e-transfer-test:signaling-data-plane"))
 }
 
 edcBuild {

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Runtimes.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Runtimes.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import static java.util.Collections.emptyMap;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 
 public interface Runtimes {
@@ -32,6 +33,11 @@ public interface Runtimes {
         String[] MODULES = new String[]{
                 ":system-tests:e2e-transfer-test:control-plane",
                 ":extensions:data-plane:data-plane-signaling:data-plane-signaling-client"
+        };
+
+        String[] SIGNALING_MODULES = new String[]{
+                ":system-tests:e2e-transfer-test:control-plane",
+                ":data-protocols:data-plane-signaling"
         };
 
         String[] EMBEDDED_DP_MODULES = new String[]{
@@ -73,6 +79,13 @@ public interface Runtimes {
                     "edc.dpf.selector.url", controlEndpoint.get() + "/v1/dataplanes"
             ));
         }
+
+        static Config controlPlaneEndpointOf(Endpoints endpoints) {
+            var controlEndpoint = Objects.requireNonNull(endpoints.getEndpoint("control"));
+            return ConfigFactory.fromMap(Map.of(
+                    "signaling.dataplane.controlplane.endpoint", controlEndpoint.get().toString()
+            ));
+        }
     }
 
     interface DataPlane {
@@ -103,5 +116,18 @@ public interface Runtimes {
             });
         }
 
+    }
+
+    interface SignalingDataPlane {
+        String[] MODULES = new String[] {
+                ":system-tests:e2e-transfer-test:signaling-data-plane"
+        };
+
+        Endpoints.Builder ENDPOINTS = Endpoints.Builder.newInstance()
+                .endpoint("default", () -> URI.create("http://localhost:" + getFreePort() + "/api"));
+
+        static Config config() {
+            return ConfigFactory.fromMap(emptyMap());
+        }
     }
 }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/signaling/TransferPushSignalingTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/signaling/TransferPushSignalingTest.java
@@ -1,0 +1,136 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.signaling;
+
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.junit.annotations.Runtime;
+import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.utils.Endpoints;
+import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
+import org.eclipse.edc.test.e2e.Runtimes;
+import org.eclipse.edc.test.e2e.TransferEndToEndParticipant;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.eclipse.edc.test.e2e.TransferEndToEndTestBase.CONSUMER_CP;
+import static org.eclipse.edc.test.e2e.TransferEndToEndTestBase.CONSUMER_ID;
+import static org.eclipse.edc.test.e2e.TransferEndToEndTestBase.PROVIDER_CP;
+import static org.eclipse.edc.test.e2e.TransferEndToEndTestBase.PROVIDER_DP;
+import static org.eclipse.edc.test.e2e.TransferEndToEndTestBase.PROVIDER_ID;
+import static org.hamcrest.Matchers.greaterThan;
+
+
+interface TransferPushSignalingTest {
+
+    @Test
+    default void shouldRegisterDataPlaneThroughSignaling(@Runtime(PROVIDER_CP) TransferEndToEndParticipant provider) {
+        provider.baseManagementRequest()
+                .get("/v4beta/dataplanes")
+                .then()
+                .body("size()", greaterThan(0));
+    }
+
+    @Nested
+    @EndToEndTest
+    class InMemory implements TransferPushSignalingTest {
+
+        @RegisterExtension
+        static final RuntimeExtension CONSUMER_CONTROL_PLANE = ComponentRuntimeExtension.Builder.newInstance()
+                .name(CONSUMER_CP)
+                .modules(Runtimes.ControlPlane.SIGNALING_MODULES)
+                .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
+                .configurationProvider(() -> Runtimes.ControlPlane.config(CONSUMER_ID))
+                .paramProvider(TransferEndToEndParticipant.class, TransferEndToEndParticipant::forContext)
+                .build();
+
+        static final Endpoints PROVIDER_ENDPOINTS = Runtimes.ControlPlane.ENDPOINTS.build();
+
+        @RegisterExtension
+        static final RuntimeExtension PROVIDER_CONTROL_PLANE = ComponentRuntimeExtension.Builder.newInstance()
+                .name(PROVIDER_CP)
+                .modules(Runtimes.ControlPlane.SIGNALING_MODULES)
+                .endpoints(PROVIDER_ENDPOINTS)
+                .configurationProvider(() -> Runtimes.ControlPlane.config(PROVIDER_ID))
+                .paramProvider(TransferEndToEndParticipant.class, TransferEndToEndParticipant::forContext)
+                .build();
+
+        @RegisterExtension
+        static final RuntimeExtension PROVIDER_DATA_PLANE = ComponentRuntimeExtension.Builder.newInstance()
+                .name(PROVIDER_DP)
+                .modules(Runtimes.SignalingDataPlane.MODULES)
+                .endpoints(Runtimes.SignalingDataPlane.ENDPOINTS.build())
+                .configurationProvider(Runtimes.SignalingDataPlane::config)
+                .configurationProvider(() -> Runtimes.ControlPlane.controlPlaneEndpointOf(PROVIDER_ENDPOINTS))
+                .build();
+    }
+
+    @Nested
+    @PostgresqlIntegrationTest
+    class Postgres implements TransferPushSignalingTest {
+
+        static final String CONSUMER_DB = "consumer";
+        static final String PROVIDER_DB = "provider";
+
+        @Order(0)
+        @RegisterExtension
+        static final PostgresqlEndToEndExtension POSTGRESQL_EXTENSION = new PostgresqlEndToEndExtension();
+
+        @Order(1)
+        @RegisterExtension
+        static final BeforeAllCallback CREATE_DATABASES = context -> {
+            POSTGRESQL_EXTENSION.createDatabase(CONSUMER_DB);
+            POSTGRESQL_EXTENSION.createDatabase(PROVIDER_DB);
+        };
+
+        @RegisterExtension
+        static final RuntimeExtension CONSUMER_CONTROL_PLANE = ComponentRuntimeExtension.Builder.newInstance()
+                .name(CONSUMER_CP)
+                .modules(Runtimes.ControlPlane.SIGNALING_MODULES)
+                .modules(Runtimes.ControlPlane.SQL_MODULES)
+                .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
+                .configurationProvider(() -> Runtimes.ControlPlane.config(CONSUMER_ID))
+                .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(CONSUMER_DB))
+                .paramProvider(TransferEndToEndParticipant.class, TransferEndToEndParticipant::forContext)
+                .build();
+
+        static final Endpoints PROVIDER_ENDPOINTS = Runtimes.ControlPlane.ENDPOINTS.build();
+
+        @RegisterExtension
+        static final RuntimeExtension PROVIDER_CONTROL_PLANE = ComponentRuntimeExtension.Builder.newInstance()
+                .name(PROVIDER_CP)
+                .modules(Runtimes.ControlPlane.SIGNALING_MODULES)
+                .modules(Runtimes.ControlPlane.SQL_MODULES)
+                .endpoints(PROVIDER_ENDPOINTS)
+                .configurationProvider(() -> Runtimes.ControlPlane.config(PROVIDER_ID))
+                .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(PROVIDER_DB))
+                .paramProvider(TransferEndToEndParticipant.class, TransferEndToEndParticipant::forContext)
+                .build();
+
+        @RegisterExtension
+        static final RuntimeExtension PROVIDER_DATA_PLANE = ComponentRuntimeExtension.Builder.newInstance()
+                .name(PROVIDER_DP)
+                .modules(Runtimes.SignalingDataPlane.MODULES)
+                .endpoints(Runtimes.SignalingDataPlane.ENDPOINTS.build())
+                .configurationProvider(Runtimes.SignalingDataPlane::config)
+                .configurationProvider(() -> Runtimes.ControlPlane.controlPlaneEndpointOf(PROVIDER_ENDPOINTS))
+                .build();
+    }
+
+}

--- a/system-tests/e2e-transfer-test/signaling-data-plane/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/signaling-data-plane/build.gradle.kts
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    implementation(project(":core:common:runtime-core"))
+    implementation(project(":extensions:common:http"))
+    implementation("org.eclipse.dataplane-core:dataplane-sdk:0.0.1-SNAPSHOT") // TODO: put in version catalog
+}
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/e2e-transfer-test/signaling-data-plane/src/main/java/org/eclipse/edc/test/runtime/signaling/DataPlaneSignalingExtension.java
+++ b/system-tests/e2e-transfer-test/signaling-data-plane/src/main/java/org/eclipse/edc/test/runtime/signaling/DataPlaneSignalingExtension.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.runtime.signaling;
+
+import org.eclipse.dataplane.Dataplane;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.web.spi.WebService;
+
+public class DataPlaneSignalingExtension implements ServiceExtension {
+
+    @Setting(key = "signaling.dataplane.controlplane.endpoint")
+    private String controlplaneEndpoint;
+
+    @Inject
+    private WebService webService;
+
+    private Dataplane dataplane = Dataplane.newInstance()
+            .endpoint("http://localhost")
+            .build();
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        webService.registerResource(dataplane.controller());
+    }
+
+    @Override
+    public void start() {
+        dataplane.registerOn(controlplaneEndpoint)
+                .orElseThrow(e -> new RuntimeException("Cannot register dataplane on controlplane", e));
+    }
+}

--- a/system-tests/e2e-transfer-test/signaling-data-plane/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/system-tests/e2e-transfer-test/signaling-data-plane/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,1 @@
+org.eclipse.edc.test.runtime.signaling.DataPlaneSignalingExtension


### PR DESCRIPTION
## What this PR changes/adds

Implement [data plane signaling registration endpoint](https://github.com/eclipse-dataplane-signaling/dataplane-signaling/blob/main/docs/signaling.md#registration)

## Why it does that

data plane signaling

## Further notes
- this PR has been kept as simple as possible, various details will be tackled in subsequent PRs (please follow #5323 for more info)
- renamed `DataPlaneSelectorService.addInstance` to `register`, to better follow the correct semantics (plus, there already was an `unregister` method.


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #5323

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
