### PR TITLE
feat: refactor participant context

### DIFF
--- a/core/common/participant-context-core/src/test/java/org/eclipse/edc/participantcontext/service/ParticipantContextServiceImplTest.java
+++ b/core/common/participant-context-core/src/test/java/org/eclipse/edc/participantcontext/service/ParticipantContextServiceImplTest.java
@@ -168,7 +168,7 @@ class ParticipantContextServiceImplTest {
     }
 
     private ParticipantContext createParticipantContextContext() {
-        return new ParticipantContext("test-id");
+        return ParticipantContext.Builder.newInstance().participantContextId("test-id").identity("test-id").build();
     }
 
 }

--- a/core/common/participant-context-single-core/src/main/java/org/eclipse/edc/participantcontext/single/SingleParticipantContextDefaultServicesExtension.java
+++ b/core/common/participant-context-single-core/src/main/java/org/eclipse/edc/participantcontext/single/SingleParticipantContextDefaultServicesExtension.java
@@ -54,7 +54,8 @@ public class SingleParticipantContextDefaultServicesExtension implements Service
     @Provider(isDefault = true)
     public SingleParticipantContextSupplier participantContextSupplier() {
         var contextId = participantContextId != null ? participantContextId : participantId;
-        var participantContext = new ParticipantContext(contextId);
+        var participantContext = ParticipantContext.Builder.newInstance().participantContextId(contextId)
+                .identity(participantId).build();
         return () -> ServiceResult.success(participantContext);
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogProtocolServiceImplTest.java
@@ -58,7 +58,10 @@ class CatalogProtocolServiceImplTest {
     private final ProtocolTokenValidator protocolTokenValidator = mock();
     private final ParticipantIdentityResolver identityResolver = mock();
     private final TransactionContext transactionContext = spy(new NoopTransactionContext());
-    private final ParticipantContext participantContext = new ParticipantContext("participantContextId");
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
 
     private final CatalogProtocolServiceImpl service = new CatalogProtocolServiceImpl(datasetResolver,
             dataServiceRegistry, protocolTokenValidator, identityResolver, transactionContext);

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogServiceImplTest.java
@@ -38,7 +38,10 @@ class CatalogServiceImplTest {
 
     private final RemoteMessageDispatcherRegistry dispatcher = mock(RemoteMessageDispatcherRegistry.class);
     private final CatalogService service = new CatalogServiceImpl(dispatcher);
-    private final ParticipantContext participantContext = new ParticipantContext("participantContextId");
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
 
     @Test
     void requestCatalog_shouldDispatchRequestAndReturnResult() {

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -78,6 +78,10 @@ class ContractNegotiationEventDispatchTest {
     private final IdentityService identityService = mock();
     private final ClaimToken token = ClaimToken.Builder.newInstance().claim("client_id", CONSUMER).build();
     private final TokenRepresentation tokenRepresentation = TokenRepresentation.Builder.newInstance().token(UUID.randomUUID().toString()).build();
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
     protected DataspaceProfileContextRegistry dataspaceProfileContextRegistry = mock();
     protected ParticipantIdentityResolver identityResolver = mock();
 
@@ -124,7 +128,7 @@ class ContractNegotiationEventDispatchTest {
         policyDefinitionStore.create(PolicyDefinition.Builder.newInstance().id("policyId").policy(policy).build());
         assetIndex.create(Asset.Builder.newInstance().id("assetId").dataAddress(DataAddress.Builder.newInstance().type("any").build()).build());
 
-        service.notifyRequested(new ParticipantContext("participantContextId"), createContractOfferRequest(policy, "assetId"), tokenRepresentation);
+        service.notifyRequested(participantContext, createContractOfferRequest(policy, "assetId"), tokenRepresentation);
 
         await().untilAsserted(() -> {
             verify(eventSubscriber).on(argThat(isEnvelopeOf(ContractNegotiationRequested.class)));

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -99,7 +99,10 @@ import static org.mockito.Mockito.when;
 class ContractNegotiationProtocolServiceImplTest {
 
     private static final String CONSUMER_ID = "consumer";
-    protected final ParticipantContext participantContext = new ParticipantContext("participantContextId");
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
     private final ContractNegotiationStore store = mock();
     private final TransactionContext transactionContext = spy(new NoopTransactionContext());
     private final ContractValidationService validationService = mock();
@@ -408,7 +411,10 @@ class ContractNegotiationProtocolServiceImplTest {
         var cn = createContractNegotiationOffered();
         when(store.findById(any())).thenReturn(cn);
         when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(cn));
-        var wrongParticipantContext = new ParticipantContext("wrongParticipantContext");
+        var wrongParticipantContext = ParticipantContext.Builder.newInstance()
+                .participantContextId("wrongParticipantContext")
+                .identity("wrongParticipantId")
+                .build();
         when(protocolTokenValidator.verify(eq(wrongParticipantContext), eq(tokenRepresentation), any(), any(), eq(message)))
                 .thenReturn(ServiceResult.success(participantAgent()));
         if (!(message instanceof ContractRequestMessage)) {

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImplTest.java
@@ -71,6 +71,10 @@ class ContractNegotiationServiceImplTest {
     private final QueryValidator queryValidator = mock();
 
     private final ContractNegotiationService service = new ContractNegotiationServiceImpl(store, consumerManager, transactionContext, commandHandlerRegistry, queryValidator);
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
 
     @Test
     void findById_filtersById() {
@@ -190,7 +194,7 @@ class ContractNegotiationServiceImplTest {
                 .contractOffer(createContractOffer())
                 .build();
 
-        var result = service.initiateNegotiation(new ParticipantContext("participantContextId"), request);
+        var result = service.initiateNegotiation(participantContext, request);
 
         assertThat(result).matches(it -> it.getId().equals("negotiationId"));
     }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/protocol/ProtocolTokenValidatorImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/protocol/ProtocolTokenValidatorImplTest.java
@@ -55,7 +55,10 @@ class ProtocolTokenValidatorImplTest {
     private final ProtocolTokenValidatorImpl validator = new ProtocolTokenValidatorImpl(identityService,
             policyEngine, mock(), agentService, dataspaceProfileContextRegistry);
 
-    private final ParticipantContext participantContext = new ParticipantContext("participantContextId");
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
 
     @Test
     void shouldVerifyToken() {

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -104,7 +104,10 @@ class TransferProcessProtocolServiceImplTest {
     private final DataAddressValidatorRegistry dataAddressValidator = mock();
     private final TransferProcessListener listener = mock();
     private final ProtocolTokenValidator protocolTokenValidator = mock();
-    private final ParticipantContext participantContext = new ParticipantContext("participantContextId");
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
     private TransferProcessProtocolService service;
 
     @BeforeEach
@@ -928,7 +931,10 @@ class TransferProcessProtocolServiceImplTest {
             var transferProcess = transferProcessBuilder().state(COMPLETED.code()).type(type).build();
 
 
-            var wrongParticipantContext = new ParticipantContext("wrongParticipantContext");
+            var wrongParticipantContext = ParticipantContext.Builder.newInstance()
+                    .participantContextId("wrongParticipantContext")
+                    .identity("wrongParticipantId")
+                    .build();
 
             when(protocolTokenValidator.verify(any(), any(), any(), any(), eq(message))).thenReturn(ServiceResult.success(participantAgent()));
             when(store.findById(any())).thenReturn(transferProcess);

--- a/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/ContractDefinitionResolverImplTest.java
+++ b/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/ContractDefinitionResolverImplTest.java
@@ -53,7 +53,10 @@ class ContractDefinitionResolverImplTest {
     private final PolicyDefinitionStore policyStore = mock();
     private final ContractDefinitionStore definitionStore = mock();
 
-    private final ParticipantContext participantContext = new ParticipantContext("participantContextId");
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
 
     private final ContractDefinitionResolverImpl resolver = new ContractDefinitionResolverImpl(definitionStore,
             policyEngine, policyStore);

--- a/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplIntegrationTest.java
+++ b/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplIntegrationTest.java
@@ -63,10 +63,9 @@ import static org.mockito.Mockito.when;
 class DatasetResolverImplIntegrationTest {
 
     private final ContractDefinitionResolver contractDefinitionResolver = mock();
+
     private AssetIndex assetIndex;
-
     private DatasetResolver resolver;
-
 
     @BeforeEach
     void setUp() {
@@ -176,7 +175,10 @@ class DatasetResolverImplIntegrationTest {
     }
 
     private ParticipantContext createParticipantContext() {
-        return new ParticipantContext("participantContextId");
+        return ParticipantContext.Builder.newInstance()
+                .participantContextId("participantContextId")
+                .identity("participantId")
+                .build();
     }
 
     private List<Criterion> selectorFrom(Collection<Asset> assets1) {

--- a/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplTest.java
+++ b/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplTest.java
@@ -84,9 +84,9 @@ class DatasetResolverImplTest {
 
     private ContractDefinition.Builder contractDefinitionBuilder(String id) {
         return ContractDefinition.Builder.newInstance()
-                       .id(id)
-                       .accessPolicyId("access")
-                       .contractPolicyId("contract");
+                .id(id)
+                .accessPolicyId("access")
+                .contractPolicyId("contract");
     }
 
     private Asset.Builder createAsset(String id) {
@@ -98,7 +98,8 @@ class DatasetResolverImplTest {
     }
 
     private ParticipantContext createParticipantContext() {
-        return ParticipantContext.Builder.newInstance().participantContextId("participantContextId").build();
+        return ParticipantContext.Builder.newInstance().participantContextId("participantContextId")
+                .identity("id").build();
     }
 
     private DataService createDataService() {
@@ -191,9 +192,9 @@ class DatasetResolverImplTest {
         void shouldFilterAssetsByPassedCriteria() {
             var definitionCriterion = new Criterion(EDC_NAMESPACE + "id", "=", "id");
             var contractDefinition = contractDefinitionBuilder("definitionId")
-                                             .assetsSelector(List.of(definitionCriterion))
-                                             .contractPolicyId("contractPolicyId")
-                                             .build();
+                    .assetsSelector(List.of(definitionCriterion))
+                    .contractPolicyId("contractPolicyId")
+                    .build();
             when(definitionResolver.resolveFor(any(), any())).thenReturn(new ResolvedContractDefinitions(List.of(contractDefinition)));
             when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(Stream.of(createAsset("id").property("key", "value").build()));
             when(policyStore.findById("contractPolicyId")).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build());
@@ -275,16 +276,16 @@ class DatasetResolverImplTest {
             var contractDefinition = contractDefinitionBuilder("definitionId").contractPolicyId("contractPolicyId").build();
             var contractPolicy = Policy.Builder.newInstance().build();
             var distribution = Distribution.Builder.newInstance().dataService(DataService.Builder.newInstance()
-                                                                                      .endpointDescription("test-asset-desc")
-                                                                                      .endpointUrl("https://foo.bar/baz")
-                                                                                      .build())
-                                       .format(HttpDataAddressSchema.HTTP_DATA_TYPE).build();
+                            .endpointDescription("test-asset-desc")
+                            .endpointUrl("https://foo.bar/baz")
+                            .build())
+                    .format(HttpDataAddressSchema.HTTP_DATA_TYPE).build();
 
             when(definitionResolver.resolveFor(any(), any())).thenReturn(new ResolvedContractDefinitions(List.of(contractDefinition)));
             when(assetIndex.queryAssets(isA(QuerySpec.class))).thenReturn(Stream.of(createAsset("assetId")
-                                                                                            .property(Asset.PROPERTY_IS_CATALOG, true)
-                                                                                            .dataAddress(DataAddress.Builder.newInstance().type(HttpDataAddressSchema.HTTP_DATA_TYPE).build())
-                                                                                            .build()));
+                    .property(Asset.PROPERTY_IS_CATALOG, true)
+                    .dataAddress(DataAddress.Builder.newInstance().type(HttpDataAddressSchema.HTTP_DATA_TYPE).build())
+                    .build()));
             when(policyStore.findById("contractPolicyId")).thenReturn(PolicyDefinition.Builder.newInstance().policy(contractPolicy).build());
             when(distributionResolver.getDistributions(any(), isA(Asset.class))).thenReturn(List.of(distribution));
 
@@ -380,12 +381,12 @@ class DatasetResolverImplTest {
             var participantAgent = createParticipantAgent();
 
             var contractDefinition = contractDefinitionBuilder("definition")
-                                             .assetsSelectorCriterion(Criterion.Builder.newInstance()
-                                                                              .operandRight(EDC_NAMESPACE + "id")
-                                                                              .operator("=")
-                                                                              .operandLeft("a-different-asset")
-                                                                              .build())
-                                             .build();
+                    .assetsSelectorCriterion(Criterion.Builder.newInstance()
+                            .operandRight(EDC_NAMESPACE + "id")
+                            .operator("=")
+                            .operandLeft("a-different-asset")
+                            .build())
+                    .build();
             when(definitionResolver.resolveFor(any(), any())).thenReturn(new ResolvedContractDefinitions(List.of(contractDefinition)));
             when(assetIndex.findById(any())).thenReturn(createAsset(assetId).build());
 

--- a/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -99,6 +99,10 @@ class ConsumerContractNegotiationManagerImplTest {
     private final ParticipantIdentityResolver identityResolver = mock();
     private final String protocolWebhookUrl = "http://protocol.webhook/url";
     private final ContractNegotiationPendingGuard pendingGuard = mock();
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId(PARTICIPANT_CONTEXT_ID)
+            .identity("participantId")
+            .build();
     private ConsumerContractNegotiationManagerImpl manager;
 
     @BeforeEach
@@ -132,7 +136,7 @@ class ConsumerContractNegotiationManagerImplTest {
                         .build()))
                 .build();
 
-        var result = manager.initiate(new ParticipantContext(PARTICIPANT_CONTEXT_ID), request);
+        var result = manager.initiate(participantContext, request);
 
         assertThat(result.succeeded()).isTrue();
         verify(store).save(argThat(negotiation ->

--- a/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -127,7 +127,10 @@ class ContractNegotiationIntegrationTest {
     private final ParticipantIdentityResolver identityResolver = mock();
     private final AtomicReference<String> providerNegotiationId = new AtomicReference<>(null);
     private final NoopTransactionContext transactionContext = new NoopTransactionContext();
-    private final ParticipantContext participantContext = new ParticipantContext("participantContextId");
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("identifier")
+            .build();
     protected ParticipantAgent participantAgent = new ParticipantAgent(Collections.emptyMap(), Collections.emptyMap());
     protected TokenRepresentation tokenRepresentation = TokenRepresentation.Builder.newInstance().build();
     private String consumerNegotiationId;
@@ -212,7 +215,7 @@ class ContractNegotiationIntegrationTest {
                 .callbackAddresses(List.of(CallbackAddress.Builder.newInstance().uri("local://test").build()))
                 .build();
 
-        consumerManager.initiate(new ParticipantContext("participantContextId"), request);
+        consumerManager.initiate(participantContext, request);
 
         await().atMost(DEFAULT_TEST_TIMEOUT).pollInterval(DEFAULT_POLL_INTERVAL).untilAsserted(() -> {
             assertThat(consumerNegotiationId).isNotNull();
@@ -264,7 +267,7 @@ class ContractNegotiationIntegrationTest {
                 .protocol("protocol")
                 .build();
 
-        consumerManager.initiate(new ParticipantContext("participantContextId"), request);
+        consumerManager.initiate(participantContext, request);
 
         await().atMost(DEFAULT_TEST_TIMEOUT)
                 .pollInterval(DEFAULT_POLL_INTERVAL)
@@ -301,7 +304,7 @@ class ContractNegotiationIntegrationTest {
                 .callbackAddresses(List.of(CallbackAddress.Builder.newInstance().uri("local://test").build()))
                 .build();
 
-        consumerManager.initiate(new ParticipantContext("participantContextId"), request);
+        consumerManager.initiate(participantContext, request);
 
         await().atMost(DEFAULT_TEST_TIMEOUT).pollInterval(DEFAULT_POLL_INTERVAL).untilAsserted(() -> {
             assertThat(consumerNegotiationId).isNotNull();

--- a/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
+++ b/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
@@ -414,15 +414,15 @@ class TransferProcessManagerImplTest {
     }
 
     private Criterion[] consumerStateIs(int state) {
-        return aryEq(new Criterion[]{ hasState(state), isNotPending(), criterion("type", "=", CONSUMER.name()) });
+        return aryEq(new Criterion[]{hasState(state), isNotPending(), criterion("type", "=", CONSUMER.name())});
     }
 
     private Criterion[] providerStateIs(int state) {
-        return aryEq(new Criterion[]{ hasState(state), isNotPending(), criterion("type", "=", PROVIDER.name()) });
+        return aryEq(new Criterion[]{hasState(state), isNotPending(), criterion("type", "=", PROVIDER.name())});
     }
 
     private Criterion[] stateIs(int state) {
-        return aryEq(new Criterion[]{ hasState(state), isNotPending() });
+        return aryEq(new Criterion[]{hasState(state), isNotPending()});
     }
 
     private TransferProcess createTransferProcess(TransferProcessStates inState) {
@@ -711,7 +711,9 @@ class TransferProcessManagerImplTest {
                     .callbackAddresses(List.of(callback))
                     .dataplaneMetadata(dataplaneMetadata)
                     .build();
-            var participantContext = ParticipantContext.Builder.newInstance().participantContextId("id").build();
+            var participantContext = ParticipantContext.Builder.newInstance().participantContextId("id")
+                    .identity("identity")
+                    .build();
 
             var result = manager.initiateConsumerRequest(participantContext, transferRequest);
 
@@ -738,7 +740,9 @@ class TransferProcessManagerImplTest {
                     .dataDestination(DataAddress.Builder.newInstance().type("test").build())
                     .build();
 
-            var result = manager.initiateConsumerRequest(new ParticipantContext("id"), transferRequest);
+            var participantContext = ParticipantContext.Builder.newInstance()
+                    .participantContextId("participantContextId").identity("id").build();
+            var result = manager.initiateConsumerRequest(participantContext, transferRequest);
 
             assertThat(result).isFailed();
         }

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/from/JsonObjectFromParticipantContextTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/from/JsonObjectFromParticipantContextTransformer.java
@@ -27,6 +27,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.JSON;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_IDENTITY_IRI;
 import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_PROPERTIES_IRI;
 import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_STATE_IRI;
 import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_TYPE_IRI;
@@ -45,6 +46,7 @@ public class JsonObjectFromParticipantContextTransformer extends AbstractJsonLdT
         return jsonFactory.createObjectBuilder()
                 .add(TYPE, PARTICIPANT_CONTEXT_TYPE_IRI)
                 .add(ID, participantContext.getParticipantContextId())
+                .add(PARTICIPANT_CONTEXT_IDENTITY_IRI, participantContext.getIdentity())
                 .add(PARTICIPANT_CONTEXT_PROPERTIES_IRI, createProperties(participantContext))
                 .add(PARTICIPANT_CONTEXT_STATE_IRI, createId(jsonFactory, ParticipantContextState.from(participantContext.getState()).name()))
                 .build();

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/to/JsonObjectToParticipantContextTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/to/JsonObjectToParticipantContextTransformer.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_IDENTITY_IRI;
 import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_PROPERTIES_IRI;
 
 public class JsonObjectToParticipantContextTransformer extends AbstractJsonLdTransformer<JsonObject, ParticipantContext> {
@@ -37,6 +38,8 @@ public class JsonObjectToParticipantContextTransformer extends AbstractJsonLdTra
         var id = nodeId != null ? nodeId : UUID.randomUUID().toString();
         participantContext.participantContextId(id);
         participantContext.id(id);
+
+        transformString(jsonObject.get(PARTICIPANT_CONTEXT_IDENTITY_IRI), participantContext::identity, context);
 
         var properties = jsonObject.get(PARTICIPANT_CONTEXT_PROPERTIES_IRI);
         if (properties != null) {

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/from/JsonObjectFromParticipantContextTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/from/JsonObjectFromParticipantContextTransformerTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_IDENTITY_IRI;
 import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_PROPERTIES_IRI;
 import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_STATE_IRI;
 import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_TYPE_IRI;
@@ -50,6 +51,7 @@ class JsonObjectFromParticipantContextTransformerTest {
         var participantContext = ParticipantContext.Builder.newInstance()
                 .participantContextId("participant-1")
                 .state(ParticipantContextState.ACTIVATED)
+                .identity("did:example:123")
                 .properties(Map.of("key1", "value1", "key2", "value2"))
                 .build();
 
@@ -57,6 +59,7 @@ class JsonObjectFromParticipantContextTransformerTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getString(ID)).isEqualTo("participant-1");
+        assertThat(result.getString(PARTICIPANT_CONTEXT_IDENTITY_IRI)).isEqualTo("did:example:123");
         assertThat(result.getString(TYPE)).isEqualTo(PARTICIPANT_CONTEXT_TYPE_IRI);
         assertThat(result.getJsonObject(PARTICIPANT_CONTEXT_STATE_IRI).getString(ID)).isEqualTo("ACTIVATED");
 
@@ -71,6 +74,7 @@ class JsonObjectFromParticipantContextTransformerTest {
         var participantContext = ParticipantContext.Builder.newInstance()
                 .participantContextId("participant-2")
                 .state(ParticipantContextState.ACTIVATED)
+                .identity("did:example:123")
                 .properties(Map.of())
                 .build();
 
@@ -87,6 +91,7 @@ class JsonObjectFromParticipantContextTransformerTest {
         var participantContext = ParticipantContext.Builder.newInstance()
                 .participantContextId("participant-3")
                 .state(ParticipantContextState.DEACTIVATED)
+                .identity("did:example:123")
                 .build();
 
         var result = transformer.transform(participantContext, context);

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/to/JsonObjectToParticipantContextTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/to/JsonObjectToParticipantContextTransformerTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_IDENTITY_IRI;
 import static org.eclipse.edc.participantcontext.spi.types.ParticipantContext.PARTICIPANT_CONTEXT_PROPERTIES_IRI;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -54,6 +55,7 @@ class JsonObjectToParticipantContextTransformerTest {
     void transform_shouldConvertJsonObjectToParticipantContext() {
         var jsonObject = createObjectBuilder()
                 .add(ID, "participant-1")
+                .add(PARTICIPANT_CONTEXT_IDENTITY_IRI, "did:example:123")
                 .add(PARTICIPANT_CONTEXT_PROPERTIES_IRI, createObjectBuilder()
                         .add(VALUE, createObjectBuilder()
                                 .add("key1", "value1")
@@ -65,6 +67,7 @@ class JsonObjectToParticipantContextTransformerTest {
         assertThat(result).isSucceeded()
                 .satisfies(participantContext -> {
                     assertThat(participantContext.getParticipantContextId()).isEqualTo("participant-1");
+                    assertThat(participantContext.getIdentity()).isEqualTo("did:example:123");
                     assertThat(participantContext.getProperties()).containsEntry("key1", "value1")
                             .containsEntry("key2", "value2");
                 });
@@ -75,6 +78,7 @@ class JsonObjectToParticipantContextTransformerTest {
         var jsonObject = createObjectBuilder()
                 .add(PARTICIPANT_CONTEXT_PROPERTIES_IRI, createObjectBuilder().add(VALUE, createObjectBuilder()
                         .add("key1", "value1")))
+                .add(PARTICIPANT_CONTEXT_IDENTITY_IRI, "did:example:123")
                 .build();
 
         var result = typeTransformerRegistry.transform(jsonObject, ParticipantContext.class);
@@ -89,6 +93,7 @@ class JsonObjectToParticipantContextTransformerTest {
     void transform_withEmptyProperties_shouldReturnParticipantContextWithEmptyProperties() {
         var jsonObject = createObjectBuilder()
                 .add(ID, "participant-2")
+                .add(PARTICIPANT_CONTEXT_IDENTITY_IRI, "did:example:123")
                 .add(PARTICIPANT_CONTEXT_PROPERTIES_IRI, createObjectBuilder().add(VALUE, createObjectBuilder()))
                 .build();
 
@@ -104,6 +109,7 @@ class JsonObjectToParticipantContextTransformerTest {
     void transform_withoutProperties_shouldReturnParticipantContext() {
         var jsonObject = createObjectBuilder()
                 .add(ID, "participant-3")
+                .add(PARTICIPANT_CONTEXT_IDENTITY_IRI, "did:example:123")
                 .build();
 
         var result = typeTransformerRegistry.transform(jsonObject, ParticipantContext.class);
@@ -119,6 +125,7 @@ class JsonObjectToParticipantContextTransformerTest {
     void transform_withInvalidProperties_shouldReportProblemAndReturnNull() {
         var jsonObject = createObjectBuilder()
                 .add(ID, "participant-4")
+                .add(PARTICIPANT_CONTEXT_IDENTITY_IRI, "did:example:123")
                 .add(PARTICIPANT_CONTEXT_PROPERTIES_IRI, createObjectBuilder().add(VALUE, "invalid-string"))
                 .build();
 
@@ -131,6 +138,7 @@ class JsonObjectToParticipantContextTransformerTest {
     void transform_withNestedProperties_shouldHandleComplexValues() {
         var jsonObject = createObjectBuilder()
                 .add(ID, "participant-5")
+                .add(PARTICIPANT_CONTEXT_IDENTITY_IRI, "did:example:123")
                 .add(PARTICIPANT_CONTEXT_PROPERTIES_IRI, createObjectBuilder()
                         .add(VALUE, createObjectBuilder()
                                 .add("simpleKey", "simpleValue")

--- a/data-protocols/dsp/dsp-core/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImplTest.java
+++ b/data-protocols/dsp/dsp-core/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImplTest.java
@@ -79,7 +79,10 @@ class DspHttpRemoteMessageDispatcherImplTest {
     private final AudienceResolver audienceResolver = mock();
     private final Duration timeout = Duration.of(5, SECONDS);
 
-    private final ParticipantContext participantContext = new ParticipantContext("id");
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
 
     private final DspHttpRemoteMessageDispatcher dispatcher =
             new DspHttpRemoteMessageDispatcherImpl(httpClient, identityService, tokenDecorator, policyEngine, audienceResolver);

--- a/data-protocols/dsp/dsp-core/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/message/DspRequestHandlerImplTest.java
+++ b/data-protocols/dsp/dsp-core/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/message/DspRequestHandlerImplTest.java
@@ -63,7 +63,11 @@ class DspRequestHandlerImplTest {
 
     private final DspRequestHandlerImpl handler = new DspRequestHandlerImpl(mock(), validatorRegistry, dspTransformerRegistry);
     private final String protocol = DATASPACE_PROTOCOL_HTTP;
-    private final ParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(new ParticipantContext("participantContextId"));
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
+    private final ParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);
 
     private static JsonObject error(String code, String reason, String processId) {
         var json = Json.createObjectBuilder()

--- a/data-protocols/dsp/dsp-lib/dsp-catalog-lib/dsp-catalog-http-api-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiControllerTestBase.java
+++ b/data-protocols/dsp/dsp-lib/dsp-catalog-lib/dsp-catalog-http-api-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiControllerTestBase.java
@@ -65,7 +65,11 @@ public abstract class DspCatalogApiControllerTestBase extends RestControllerTest
     protected final CatalogProtocolService service = mock();
     protected final DspRequestHandler dspRequestHandler = mock();
     protected final ContinuationTokenManager continuationTokenManager = mock();
-    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(new ParticipantContext("id"));
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
+    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);
 
     @Test
     void getDataset_shouldGetResource() {

--- a/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-http-api-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiControllerTestBase.java
+++ b/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-http-api-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiControllerTestBase.java
@@ -71,7 +71,11 @@ public abstract class DspNegotiationApiControllerTestBase extends RestController
 
     protected final ContractNegotiationProtocolService protocolService = mock();
     protected final DspRequestHandler dspRequestHandler = mock();
-    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(new ParticipantContext("id"));
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
+    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);
 
     @Test
     void getNegotiation_shouldGetResource() {

--- a/data-protocols/dsp/dsp-lib/dsp-transfer-process-lib/dsp-transfer-process-http-api-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiControllerBaseTest.java
+++ b/data-protocols/dsp/dsp-lib/dsp-transfer-process-lib/dsp-transfer-process-http-api-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiControllerBaseTest.java
@@ -69,7 +69,11 @@ public abstract class DspTransferProcessApiControllerBaseTest extends RestContro
     private static final String PROCESS_ID = "testId";
     protected final TransferProcessProtocolService protocolService = mock();
     protected final DspRequestHandler dspRequestHandler = mock();
-    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(new ParticipantContext("id"));
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
+    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);
 
     @Test
     void getTransferProcess_shouldGetResource() {

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/participant-context-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/participant-context-schema.json
@@ -22,6 +22,9 @@
         "@id": {
           "type": "string"
         },
+        "identity": {
+          "type": "string"
+        },
         "properties": {
           "type": "object"
         },
@@ -36,7 +39,8 @@
       },
       "required": [
         "@context",
-        "@type"
+        "@type",
+        "identity"
       ]
     }
   }

--- a/extensions/common/json-ld/src/main/resources/document/management-context-v2.jsonld
+++ b/extensions/common/json-ld/src/main/resources/document/management-context-v2.jsonld
@@ -464,6 +464,7 @@
           "@id": "edc:properties",
           "@type": "@json"
         },
+        "identity": "edc:identity",
         "state": {
           "@id": "edc:state",
           "@type": "@vocab"

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/BaseAssetApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/BaseAssetApiControllerTest.java
@@ -72,7 +72,11 @@ public abstract class BaseAssetApiControllerTest extends RestControllerTestBase 
     protected final AssetService service = mock(AssetService.class);
     protected final TypeTransformerRegistry transformerRegistry = mock(TypeTransformerRegistry.class);
     protected final JsonObjectValidatorRegistry validator = mock(JsonObjectValidatorRegistry.class);
-    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(new ParticipantContext("participantId"));
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
+    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);
 
     @BeforeEach
     void setup() {

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/BaseCatalogApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/BaseCatalogApiControllerTest.java
@@ -60,7 +60,11 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
     protected final CatalogService service = mock();
     protected final TypeTransformerRegistry transformerRegistry = mock();
     protected final JsonObjectValidatorRegistry validatorRegistry = mock();
-    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(new ParticipantContext("participantContext"));
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
+    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);
 
     @Test
     void requestCatalog() {

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/BaseContractDefinitionApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/BaseContractDefinitionApiControllerTest.java
@@ -68,7 +68,11 @@ public abstract class BaseContractDefinitionApiControllerTest extends RestContro
     protected final ContractDefinitionService service = mock();
     protected final TypeTransformerRegistry transformerRegistry = mock();
     protected final JsonObjectValidatorRegistry validatorRegistry = mock();
-    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(new ParticipantContext("participantId"));
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
+    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);
 
     @ParameterizedTest
     @ValueSource(strings = {"", "{}"})

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
@@ -71,7 +71,11 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
     protected final ContractNegotiationService service = mock();
     protected final TypeTransformerRegistry transformerRegistry = mock();
     protected final JsonObjectValidatorRegistry validatorRegistry = mock();
-    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(new ParticipantContext("participantId"));
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
+    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);
 
     @Test
     void getAll() {

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/BasePolicyDefinitionApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/BasePolicyDefinitionApiControllerTest.java
@@ -61,7 +61,11 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
     protected final TypeTransformerRegistry transformerRegistry = mock();
     protected final PolicyDefinitionService service = mock();
     protected final JsonObjectValidatorRegistry validatorRegistry = mock();
-    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(new ParticipantContext("participantId"));
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
+    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);
 
     @Test
     void create_shouldReturnDefinitionId() {

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/BaseTransferProcessApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/BaseTransferProcessApiControllerTest.java
@@ -66,7 +66,11 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
     protected final TypeTransformerRegistry transformerRegistry = mock();
     protected final TransferProcessService service = mock();
     protected final JsonObjectValidatorRegistry validatorRegistry = mock();
-    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(new ParticipantContext("participantId"));
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
+    protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);
 
     protected abstract RequestSpecification baseRequest();
 

--- a/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/controlplane/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
+++ b/extensions/control-plane/provision/provision-http/src/test/java/org/eclipse/edc/connector/controlplane/provision/http/impl/HttpProvisionerExtensionEndToEndTest.java
@@ -88,6 +88,10 @@ public class HttpProvisionerExtensionEndToEndTest {
     private final ContractValidationService contractValidationService = mock();
     private final IdentityService identityService = mock();
     private final DataspaceProfileContextRegistry dataspaceProfileContextRegistry = mock(DataspaceProfileContextRegistry.class);
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId(PARTICIPANT_CONTEXT_ID)
+            .identity("participantId")
+            .build();
 
     @BeforeEach
     void setup(RuntimeExtension extension) {
@@ -137,7 +141,7 @@ public class HttpProvisionerExtensionEndToEndTest {
         when(identityService.verifyJwtToken(any(), any(), isA(VerificationContext.class))).thenReturn(Result.success(ClaimToken.Builder.newInstance().build()));
         when(dataspaceProfileContextRegistry.getIdExtractionFunction(any())).thenReturn(ct -> "id");
 
-        var result = protocolService.notifyRequested(new ParticipantContext(PARTICIPANT_CONTEXT_ID), createTransferRequestMessage(), TokenRepresentation.Builder.newInstance().build());
+        var result = protocolService.notifyRequested(participantContext, createTransferRequestMessage(), TokenRepresentation.Builder.newInstance().build());
 
         assertThat(result).isSucceeded();
         await().untilAsserted(() -> {

--- a/extensions/control-plane/store/sql/participantcontext-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/BaseSqlDialectStatements.java
+++ b/extensions/control-plane/store/sql/participantcontext-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/BaseSqlDialectStatements.java
@@ -25,23 +25,25 @@ public class BaseSqlDialectStatements implements ParticipantContextStoreStatemen
     @Override
     public String getInsertTemplate() {
         return executeStatement()
-                       .column(getIdColumn())
-                       .column(getCreateTimestampColumn())
-                       .column(getLastModifiedTimestampColumn())
-                       .column(getStateColumn())
-                       .jsonColumn(getPropertiesColumn())
-                       .insertInto(getParticipantContextTable());
+                .column(getIdColumn())
+                .column(getIdentityColumn())
+                .column(getCreateTimestampColumn())
+                .column(getLastModifiedTimestampColumn())
+                .column(getStateColumn())
+                .jsonColumn(getPropertiesColumn())
+                .insertInto(getParticipantContextTable());
     }
 
     @Override
     public String getUpdateTemplate() {
         return executeStatement()
-                       .column(getIdColumn())
-                       .column(getCreateTimestampColumn())
-                       .column(getLastModifiedTimestampColumn())
-                       .column(getStateColumn())
-                       .jsonColumn(getPropertiesColumn())
-                       .update(getParticipantContextTable(), getIdColumn());
+                .column(getIdColumn())
+                .column(getIdentityColumn())
+                .column(getCreateTimestampColumn())
+                .column(getLastModifiedTimestampColumn())
+                .column(getStateColumn())
+                .jsonColumn(getPropertiesColumn())
+                .update(getParticipantContextTable(), getIdColumn());
     }
 
     @Override

--- a/extensions/control-plane/store/sql/participantcontext-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/ParticipantContextStoreStatements.java
+++ b/extensions/control-plane/store/sql/participantcontext-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/ParticipantContextStoreStatements.java
@@ -31,6 +31,10 @@ public interface ParticipantContextStoreStatements extends SqlStatements {
         return "participant_context_id";
     }
 
+    default String getIdentityColumn() {
+        return "identity";
+    }
+
     default String getCreateTimestampColumn() {
         return "created_date";
     }

--- a/extensions/control-plane/store/sql/participantcontext-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/SqlParticipantContextStore.java
+++ b/extensions/control-plane/store/sql/participantcontext-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/SqlParticipantContextStore.java
@@ -66,6 +66,7 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
                 var stmt = statements.getInsertTemplate();
                 queryExecutor.execute(connection, stmt,
                         participantContext.getParticipantContextId(),
+                        participantContext.getIdentity(),
                         participantContext.getCreatedAt(),
                         participantContext.getLastModified(),
                         participantContext.getState(),
@@ -103,6 +104,7 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
                     queryExecutor.execute(connection,
                             statements.getUpdateTemplate(),
                             id,
+                            participantContext.getIdentity(),
                             participantContext.getCreatedAt(),
                             participantContext.getLastModified(),
                             participantContext.getState(),
@@ -143,14 +145,16 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
 
     private ParticipantContext mapResultSet(ResultSet resultSet) throws Exception {
 
-        var id = resultSet.getString(statements.getIdColumn());
+        var participantContextId = resultSet.getString(statements.getIdColumn());
+        var identity = resultSet.getString(statements.getIdentityColumn());
         var created = resultSet.getLong(statements.getCreateTimestampColumn());
         var lastmodified = resultSet.getLong(statements.getLastModifiedTimestampColumn());
         var state = resultSet.getInt(statements.getStateColumn());
         Map<String, Object> props = fromJson(resultSet.getString(statements.getPropertiesColumn()), getTypeRef());
 
         return ParticipantContext.Builder.newInstance()
-                .participantContextId(id)
+                .participantContextId(participantContextId)
+                .identity(identity)
                 .createdAt(created)
                 .lastModified(lastmodified)
                 .state(ParticipantContextState.from(state))

--- a/extensions/control-plane/store/sql/participantcontext-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/schema/postgres/ParticipantContextMapping.java
+++ b/extensions/control-plane/store/sql/participantcontext-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/schema/postgres/ParticipantContextMapping.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.sql.translation.TranslationMapping;
 public class ParticipantContextMapping extends TranslationMapping {
 
     public static final String FIELD_ID = "participantContextId";
+    public static final String FIELD_IDENTITY = "identity";
     public static final String FIELD_CREATE_TIMESTAMP = "createdAt";
     public static final String FIELD_LASTMODIFIED_TIMESTAMP = "lastModified";
     public static final String FIELD_STATE = "state";
@@ -32,6 +33,7 @@ public class ParticipantContextMapping extends TranslationMapping {
         add(FIELD_ID, statements.getIdColumn());
         add(FIELD_CREATE_TIMESTAMP, statements.getCreateTimestampColumn());
         add(FIELD_STATE, statements.getStateColumn());
+        add(FIELD_IDENTITY, statements.getIdentityColumn());
         add(FIELD_LASTMODIFIED_TIMESTAMP, statements.getLastModifiedTimestampColumn());
     }
 }

--- a/extensions/control-plane/store/sql/participantcontext-store-sql/src/main/resources/participant-context-schema.sql
+++ b/extensions/control-plane/store/sql/participantcontext-store-sql/src/main/resources/participant-context-schema.sql
@@ -16,6 +16,7 @@
 CREATE TABLE IF NOT EXISTS participant_context
 (
     participant_context_id VARCHAR PRIMARY KEY NOT NULL, -- ID of the ParticipantContext
+    identity               VARCHAR UNIQUE NOT NULL,      -- identity of the Participant
     created_date           BIGINT              NOT NULL, -- POSIX timestamp of the creation of the PC
     last_modified_date     BIGINT,                       -- POSIX timestamp of the last modified date
     state                  INTEGER             NOT NULL, -- 0 = CREATED, 1 = ACTIVE, 2 = DEACTIVATED

--- a/extensions/data-plane-selector/data-plane-selector-client/src/test/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorServiceTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/test/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorServiceTest.java
@@ -61,7 +61,10 @@ class RemoteDataPlaneSelectorServiceTest {
     );
     private final DataPlaneSelectorService serverService = mock();
     private final JsonObjectValidatorRegistry validator = mock();
-    private final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(new ParticipantContext("participantContextId"));
+    private final SingleParticipantContextSupplier participantContextSupplier = () ->
+            ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId("participantContextId")
+                    .identity("participantId")
+                    .build());
 
     @RegisterExtension
     public final RuntimeExtension server = new RuntimePerMethodExtension(new EmbeddedRuntime(

--- a/extensions/data-plane-selector/data-plane-selector-control-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApiControllerTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-control-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/control/api/DataplaneSelectorControlApiControllerTest.java
@@ -55,9 +55,14 @@ class DataplaneSelectorControlApiControllerTest extends RestControllerTestBase {
     private final DataPlaneSelectorService service = mock();
     private final Clock clock = mock();
 
+    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
+            .participantContextId("participantContextId")
+            .identity("participantId")
+            .build();
+
     @Override
     protected Object controller() {
-        return new DataplaneSelectorControlApiController(validatorRegistry, typeTransformerRegistry, service, () -> ServiceResult.success(new ParticipantContext("participantContextId")), clock);
+        return new DataplaneSelectorControlApiController(validatorRegistry, typeTransformerRegistry, service, () -> ServiceResult.success(participantContext), clock);
     }
 
     @Nested

--- a/spi/common/connector-participant-context-spi/src/main/java/org/eclipse/edc/participantcontext/spi/types/ParticipantContext.java
+++ b/spi/common/connector-participant-context-spi/src/main/java/org/eclipse/edc/participantcontext/spi/types/ParticipantContext.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -36,11 +35,14 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 public class ParticipantContext extends AbstractParticipantResource {
     public static final String PARTICIPANT_CONTEXT_TYPE_TERM = "ParticipantContext";
     public static final String PARTICIPANT_CONTEXT_TYPE_IRI = EDC_NAMESPACE + PARTICIPANT_CONTEXT_TYPE_TERM;
+    public static final String PARTICIPANT_CONTEXT_IDENTITY_TERM = "identity";
+    public static final String PARTICIPANT_CONTEXT_IDENTITY_IRI = EDC_NAMESPACE + PARTICIPANT_CONTEXT_IDENTITY_TERM;
     public static final String PARTICIPANT_CONTEXT_PROPERTIES_TERM = "properties";
     public static final String PARTICIPANT_CONTEXT_PROPERTIES_IRI = EDC_NAMESPACE + PARTICIPANT_CONTEXT_PROPERTIES_TERM;
     public static final String PARTICIPANT_CONTEXT_STATE_TERM = "state";
     public static final String PARTICIPANT_CONTEXT_STATE_IRI = EDC_NAMESPACE + PARTICIPANT_CONTEXT_STATE_TERM;
 
+    private String identity;
     private Map<String, Object> properties = new HashMap<>();
     private long lastModified;
     private int state; // CREATED, ACTIVATED, DEACTIVATED
@@ -49,22 +51,10 @@ public class ParticipantContext extends AbstractParticipantResource {
     }
 
     /**
-     * Construct a new ParticipantContext
-     *
-     * @deprecated use {@link ParticipantContext.Builder} instead.
+     * The unique identity for this ParticipantContext
      */
-    @Deprecated
-    public ParticipantContext(String participantContextId) {
-        this.participantContextId = participantContextId;
-        createdAt = Instant.now().toEpochMilli();
-
-        if (getLastModified() == 0L) {
-            lastModified = getCreatedAt();
-        }
-
-        clock = Objects.requireNonNullElse(clock, Clock.systemUTC());
-
-
+    public String getIdentity() {
+        return identity;
     }
 
     /**
@@ -146,7 +136,8 @@ public class ParticipantContext extends AbstractParticipantResource {
 
         @Override
         public ParticipantContext build() {
-            Objects.requireNonNull(entity.participantContextId, "Participant ID cannot be null");
+            Objects.requireNonNull(entity.participantContextId, "Participant Context ID cannot be null");
+            Objects.requireNonNull(entity.identity, "identity cannot be null");
 
             if (entity.state == 0) {
                 entity.state = CREATED.code();
@@ -159,6 +150,11 @@ public class ParticipantContext extends AbstractParticipantResource {
 
         public Builder state(ParticipantContextState state) {
             this.entity.state = state.code();
+            return this;
+        }
+
+        public Builder identity(String identity) {
+            entity.identity = identity;
             return this;
         }
 

--- a/spi/common/connector-participant-context-spi/src/test/java/org/eclipse/edc/participantcontext/spi/types/ParticipantContextTest.java
+++ b/spi/common/connector-participant-context-spi/src/test/java/org/eclipse/edc/participantcontext/spi/types/ParticipantContextTest.java
@@ -29,12 +29,14 @@ class ParticipantContextTest {
     void verifyCreateTimestamp() {
         var context = ParticipantContext.Builder.newInstance()
                 .participantContextId("test-id")
+                .identity("test-identity")
                 .build();
 
         assertThat(context.getCreatedAt()).isNotZero().isLessThanOrEqualTo(Instant.now().toEpochMilli());
 
         var context2 = ParticipantContext.Builder.newInstance()
                 .participantContextId("test-id")
+                .identity("test-identity")
                 .createdAt(42)
                 .build();
 
@@ -45,12 +47,14 @@ class ParticipantContextTest {
     void verifyLastModifiedTimestamp() {
         var context = ParticipantContext.Builder.newInstance()
                 .participantContextId("test-id")
+                .identity("test-identity")
                 .build();
 
         assertThat(context.getLastModified()).isNotZero().isEqualTo(context.getCreatedAt());
 
         var context2 = ParticipantContext.Builder.newInstance()
                 .participantContextId("test-id")
+                .identity("test-identity")
                 .lastModified(42)
                 .build();
 
@@ -61,6 +65,7 @@ class ParticipantContextTest {
     void verifyState() {
         var context = ParticipantContext.Builder.newInstance()
                 .participantContextId("test-id")
+                .identity("test-identity")
                 .state(CREATED);
 
         assertThat(context.build().getState()).isEqualTo(CREATED.code());

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
@@ -153,6 +153,7 @@ public class TestFunctions {
                 .add(CONTEXT, createContextBuilder(context).build())
                 .add(TYPE, "ParticipantContext")
                 .add(ID, "participant-context-id")
+                .add("identity", "did:example:123456789")
                 .add("properties", createObjectBuilder()
                         .add("name", TEST_ASSET_NAME)
                         .add("id", TEST_ASSET_ID)


### PR DESCRIPTION
## What this PR changes/adds

refactor participant context:

- removes the constructor `new ParticipantContext` 
- add `identity` field to `ParticipantContext` mandatory, which is the participant id in the dataspace
- refactor due removal of `new ParticipantContext`

## Why it does that

_Briefly state why the change was necessary._

## Further notes

This refactor should be enough to harmonize the usage of `ParticipantContext` across multiple components

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5358 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
