### PR TITLE
fix: offload eventual secret from transfer destination to vault before storage

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -271,7 +271,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     public TransferProcessProtocolService transferProcessProtocolService() {
         return new TransferProcessProtocolServiceImpl(transferProcessStore, transactionContext, contractNegotiationStore,
                 contractValidationService, protocolTokenValidator(), dataAddressValidator, transferProcessObservable, clock,
-                monitor, telemetry);
+                monitor, telemetry, vault);
     }
 
     @Provider

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -41,7 +41,9 @@ import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.telemetry.Telemetry;
+import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
@@ -72,13 +74,14 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     private final Clock clock;
     private final Monitor monitor;
     private final Telemetry telemetry;
+    private final Vault vault;
 
     public TransferProcessProtocolServiceImpl(TransferProcessStore transferProcessStore,
                                               TransactionContext transactionContext, ContractNegotiationStore negotiationStore,
                                               ContractValidationService contractValidationService,
                                               ProtocolTokenValidator protocolTokenValidator,
                                               DataAddressValidatorRegistry dataAddressValidator, TransferProcessObservable observable,
-                                              Clock clock, Monitor monitor, Telemetry telemetry) {
+                                              Clock clock, Monitor monitor, Telemetry telemetry, Vault vault) {
         this.transferProcessStore = transferProcessStore;
         this.transactionContext = transactionContext;
         this.negotiationStore = negotiationStore;
@@ -89,6 +92,7 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
         this.clock = clock;
         this.monitor = monitor;
         this.telemetry = telemetry;
+        this.vault = vault;
     }
 
     @Override
@@ -160,27 +164,58 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
         if (existingTransferProcess != null) {
             return ServiceResult.success(existingTransferProcess);
         }
-        var process = TransferProcess.Builder.newInstance()
-                .id(randomUUID().toString())
-                .protocol(message.getProtocol())
-                .correlationId(message.getConsumerPid())
-                .counterPartyAddress(message.getCallbackAddress())
-                .dataDestination(message.getDataDestination())
-                .assetId(contractAgreement.getAssetId())
-                .contractId(contractAgreement.getId())
-                .transferType(message.getTransferType())
-                .type(PROVIDER)
-                .clock(clock)
-                .traceContext(telemetry.getCurrentTraceContext())
-                .participantContextId(participantContext.getParticipantContextId())
+
+        var id = randomUUID().toString();
+
+        return offloadEventualSecretToVault(id, participantContext, message.getDataDestination())
+                .map(destination -> {
+                    var process = TransferProcess.Builder.newInstance()
+                            .id(id)
+                            .protocol(message.getProtocol())
+                            .correlationId(message.getConsumerPid())
+                            .counterPartyAddress(message.getCallbackAddress())
+                            .dataDestination(destination)
+                            .assetId(contractAgreement.getAssetId())
+                            .contractId(contractAgreement.getId())
+                            .transferType(message.getTransferType())
+                            .type(PROVIDER)
+                            .clock(clock)
+                            .traceContext(telemetry.getCurrentTraceContext())
+                            .participantContextId(participantContext.getParticipantContextId())
+                            .build();
+
+                    observable.invokeForEach(l -> l.preCreated(process));
+                    process.protocolMessageReceived(message.getId());
+                    update(process);
+                    observable.invokeForEach(l -> l.initiated(process));
+
+                    return process;
+                });
+    }
+
+    private ServiceResult<DataAddress> offloadEventualSecretToVault(String id, ParticipantContext participantContext, DataAddress destination) {
+        if (destination == null) {
+            return ServiceResult.success(null);
+        }
+
+        var secret = destination.getStringProperty(DataAddress.EDC_DATA_ADDRESS_SECRET);
+        if (secret == null) {
+            return ServiceResult.success(destination);
+        }
+
+        var keyName = "transfer-process-" + id + "-destination-secret";
+
+        var storeSecret = vault.storeSecret(participantContext.getParticipantContextId(), keyName, secret);
+        if (storeSecret.failed()) {
+            return ServiceResult.unexpected("cannot store destination secret: ", storeSecret.getFailureDetail());
+        }
+
+        var newDestination = destination.toBuilder()
+                .keyName(keyName)
+                .property(DataAddress.EDC_DATA_ADDRESS_SECRET, null)
                 .build();
 
-        observable.invokeForEach(l -> l.preCreated(process));
-        process.protocolMessageReceived(message.getId());
-        update(process);
-        observable.invokeForEach(l -> l.initiated(process));
-
-        return ServiceResult.success(process);
+        return ServiceResult.success(newDestination);
     }
 
     @NotNull

--- a/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
@@ -243,14 +243,6 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
             // default the content address to the asset address; this may be overridden during provisioning
             process.setContentDataAddress(dataAddress);
 
-            var dataDestination = process.getDataDestination();
-            if (dataDestination != null) {
-                var secret = dataDestination.getStringProperty(EDC_DATA_ADDRESS_SECRET);
-                if (secret != null) {
-                    vault.storeSecret(process.getParticipantContextId(), dataDestination.getKeyName(), secret);
-                }
-            }
-
             var manifest = manifestGenerator.generateProviderResourceManifest(process, dataAddress, policy);
             if (!manifest.empty()) {
                 monitor.warning("control-plane provisioning has been deprecated, please convert your provision extensions to the data-plane model and deploy them there.");
@@ -331,7 +323,7 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
             var dataDestination = Optional.ofNullable(originalDestination)
                     .map(DataAddress::getKeyName)
                     .map(key -> vault.resolveSecret(process.getParticipantContextId(), key))
-                    .map(secret -> DataAddress.Builder.newInstance().properties(originalDestination.getProperties()).property(EDC_DATA_ADDRESS_SECRET, secret).build())
+                    .map(secret -> originalDestination.toBuilder().property(EDC_DATA_ADDRESS_SECRET, secret).build())
                     .orElse(originalDestination);
 
             var messageBuilder = TransferRequestMessage.Builder.newInstance()

--- a/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
+++ b/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
@@ -900,29 +900,6 @@ class TransferProcessManagerImplTest {
         }
 
         @Test
-        void shouldStoreSecret_whenItIsFoundInTheDataAddress() {
-            var destinationDataAddress = DataAddress.Builder.newInstance()
-                    .keyName("keyName")
-                    .type("type")
-                    .property(EDC_DATA_ADDRESS_SECRET, "secret")
-                    .build();
-            var transferProcess = builder.dataDestination(destinationDataAddress).build();
-            when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
-            when(transferProcessStore.nextNotLeased(anyInt(), stateIs(INITIAL.code()))).thenReturn(List.of(transferProcess)).thenReturn(emptyList());
-            when(addressResolver.resolveForAsset(any())).thenReturn(DataAddress.Builder.newInstance().type("type").build());
-            var resourceManifest = ResourceManifest.Builder.newInstance().definitions(List.of(new TestResourceDefinition())).build();
-            when(manifestGenerator.generateProviderResourceManifest(any(TransferProcess.class), any(), any()))
-                    .thenReturn(resourceManifest);
-
-            manager.start();
-
-            await().untilAsserted(() -> {
-                verify(vault).storeSecret(anyString(), eq("keyName"), eq("secret"));
-                verify(transferProcessStore).save(any());
-            });
-        }
-
-        @Test
         void shouldTransitionToTerminating_whenAssetIsNotResolved() {
             var transferProcess = builder.build();
             when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiController.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.command.Termina
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.NegotiationState;
-import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.spi.EdcException;
@@ -109,7 +108,7 @@ public class BaseContractNegotiationApiController {
                 .orElseThrow(ValidationFailureException::new);
 
         var participantContext = participantContextSupplier.get()
-                .orElseThrow(exceptionMapper(ContractDefinition.class));
+                .orElseThrow(exceptionMapper(ContractNegotiation.class));
 
         var contractRequest = transformerRegistry.transform(requestObject, ContractRequest.class)
                 .orElseThrow(InvalidRequestException::new);

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/DataAddress.java
@@ -103,6 +103,10 @@ public class DataAddress {
         properties.put(EDC_DATA_ADDRESS_KEY_NAME, keyName);
     }
 
+    public DataAddress.Builder toBuilder() {
+        return DataAddress.Builder.newInstance().properties(properties);
+    }
+
     /**
      * Returns true if there's a property with the specified key
      *


### PR DESCRIPTION
## What this PR changes/adds

When present, offload `secret` from `dataDestination` object received in a `TransferRequestMessage` into the `Vault`

## Why it does that

Avoid storage of plain secrets in database

## Further notes
- added a `toBuilder` method on `DataAddress`, I think it's well deserved


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5380
Closes #4521

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
