### PR TITLE
fix: allow elevated access for provisioner role

### DIFF
--- a/extensions/common/auth/auth-authorization-oauth2-lib/src/main/java/org/eclipse/edc/api/authorization/service/AuthorizationServiceImpl.java
+++ b/extensions/common/auth/auth-authorization-oauth2-lib/src/main/java/org/eclipse/edc/api/authorization/service/AuthorizationServiceImpl.java
@@ -46,7 +46,7 @@ public class AuthorizationServiceImpl implements AuthorizationService {
             return ServiceResult.notFound("No Resource of type '%s' with ID '%s' was found for owner '%s'.".formatted(resourceClass, resourceId, resourceOwnerId));
         }
 
-        if (securityContext.isUserInRole(ParticipantPrincipal.ROLE_ADMIN)) {
+        if (securityContext.isUserInRole(ParticipantPrincipal.ROLE_ADMIN) || securityContext.isUserInRole(ParticipantPrincipal.ROLE_PROVISIONER)) {
             return ServiceResult.success();
         }
 


### PR DESCRIPTION
## What this PR changes/adds

allow elevated access (without an associated ParticipantContext) for the `provisioner` role

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
