### PR TITLE
fix: provide fallback partition for single partition context runtimes

### DIFF
--- a/core/common/boot/build.gradle.kts
+++ b/core/common/boot/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 
 dependencies {
     api(project(":spi:common:boot-spi"))
+    api(project(":spi:common:participant-context-single-spi"))
 
     implementation(project(":core:common:lib:boot-lib"))
 

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/BootServicesExtension.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/BootServicesExtension.java
@@ -18,7 +18,9 @@ import org.eclipse.edc.boot.apiversion.ApiVersionServiceImpl;
 import org.eclipse.edc.boot.health.HealthCheckServiceImpl;
 import org.eclipse.edc.boot.system.ExtensionLoader;
 import org.eclipse.edc.boot.vault.InMemoryVault;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.security.Vault;
@@ -43,6 +45,9 @@ public class BootServicesExtension implements ServiceExtension {
     @Setting(description = "Configures this component's ID. This should be a unique, stable and deterministic identifier.", defaultValue = "<random UUID>")
     public static final String COMPONENT_ID = "edc.component.id";
 
+    @Inject(required = false)
+    private SingleParticipantContextSupplier singleParticipantContextSupplier;
+
     private HealthCheckServiceImpl healthCheckService;
 
     @Override
@@ -54,7 +59,6 @@ public class BootServicesExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         healthCheckService = new HealthCheckServiceImpl();
     }
-
 
     @Provider
     public Clock clock() {
@@ -84,7 +88,7 @@ public class BootServicesExtension implements ServiceExtension {
     @Provider(isDefault = true)
     public Vault createInmemVault(ServiceExtensionContext context) {
         context.getMonitor().warning("Using the InMemoryVault is not suitable for production scenarios and should be replaced with an actual Vault!");
-        return new InMemoryVault(context.getMonitor());
+        return new InMemoryVault(context.getMonitor(), singleParticipantContextSupplier);
     }
 
     @Provider

--- a/core/common/edr-store-core/src/test/java/org/eclipse/edc/edr/store/EndpointDataReferenceStoreImplTest.java
+++ b/core/common/edr-store-core/src/test/java/org/eclipse/edc/edr/store/EndpointDataReferenceStoreImplTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.mock;
 public class EndpointDataReferenceStoreImplTest extends EndpointDataReferenceStoreTestBase {
 
     private final InMemoryEndpointDataReferenceEntryIndex store = new InMemoryEndpointDataReferenceEntryIndex(CriterionOperatorRegistryImpl.ofDefaults());
-    private final VaultEndpointDataReferenceCache cache = new VaultEndpointDataReferenceCache(new InMemoryVault(mock()), "", new ObjectMapper());
+    private final VaultEndpointDataReferenceCache cache = new VaultEndpointDataReferenceCache(new InMemoryVault(mock(), null), "", new ObjectMapper());
     private final EndpointDataReferenceStoreImpl endpointDataReferenceService = new EndpointDataReferenceStoreImpl(store, cache, new NoopTransactionContext());
 
     @Override

--- a/core/common/edr-store-core/src/test/java/org/eclipse/edc/edr/store/defaults/VaultEndpointDataReferenceCacheTest.java
+++ b/core/common/edr-store-core/src/test/java/org/eclipse/edc/edr/store/defaults/VaultEndpointDataReferenceCacheTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.mock;
 
 public class VaultEndpointDataReferenceCacheTest extends EndpointDataReferenceCacheTestBase {
 
-    private final VaultEndpointDataReferenceCache cache = new VaultEndpointDataReferenceCache(new InMemoryVault(mock()), "", new ObjectMapper());
+    private final VaultEndpointDataReferenceCache cache = new VaultEndpointDataReferenceCache(new InMemoryVault(mock(), null), "", new ObjectMapper());
 
     @Override
     protected EndpointDataReferenceCache getCache() {

--- a/core/common/lib/boot-lib/build.gradle.kts
+++ b/core/common/lib/boot-lib/build.gradle.kts
@@ -19,8 +19,8 @@ plugins {
 }
 
 dependencies {
-
     api(project(":spi:common:boot-spi"))
+    api(project(":spi:common:connector-participant-context-spi"))
 
     testImplementation(libs.awaitility)
 }

--- a/core/common/lib/boot-lib/src/test/java/org/eclipse/edc/boot/vault/InMemoryVaultTest.java
+++ b/core/common/lib/boot-lib/src/test/java/org/eclipse/edc/boot/vault/InMemoryVaultTest.java
@@ -14,8 +14,11 @@
 
 package org.eclipse.edc.boot.vault;
 
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.junit.jupiter.api.BeforeEach;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,63 +26,97 @@ import static org.mockito.Mockito.mock;
 
 class InMemoryVaultTest {
 
-    private InMemoryVault vault;
+    @Nested
+    class NoParticipantContextSupplier {
+        private final InMemoryVault vault = new InMemoryVault(mock(Monitor.class), null);
 
-    @BeforeEach
-    void setUp() {
-        vault = new InMemoryVault(mock(Monitor.class));
+        @Test
+        void resolveSecret() {
+            assertThat(vault.resolveSecret("key")).isNull();
+            vault.storeSecret("key", "secret");
+            assertThat(vault.resolveSecret("key")).isEqualTo("secret");
+        }
+
+        @Test
+        void resolveSecret_partitioned() {
+            assertThat(vault.resolveSecret("key")).isNull();
+            vault.storeSecret("partition", "key", "secret");
+            assertThat(vault.resolveSecret("partition", "key")).isEqualTo("secret");
+            assertThat(vault.resolveSecret("another", "key")).isNull();
+        }
+
+        @Test
+        void storeSecret() {
+            assertThat(vault.storeSecret("key", "value1").succeeded()).isTrue();
+            assertThat(vault.resolveSecret("key")).isEqualTo("value1");
+            assertThat(vault.storeSecret("key", "value2").succeeded()).isTrue();
+            assertThat(vault.resolveSecret("key")).isEqualTo("value2");
+        }
+
+        @Test
+        void storeSecret_partitioned() {
+            assertThat(vault.storeSecret("partition", "key", "value1").succeeded()).isTrue();
+            assertThat(vault.resolveSecret("partition", "key")).isEqualTo("value1");
+            assertThat(vault.storeSecret("partition", "key", "value2").succeeded()).isTrue();
+            assertThat(vault.resolveSecret("partition", "key")).isEqualTo("value2");
+
+            assertThat(vault.storeSecret("partition", "key", "value2").succeeded()).isTrue();
+        }
+
+        @Test
+        void deleteSecret() {
+            assertThat(vault.deleteSecret("key").succeeded()).isFalse();
+            assertThat(vault.storeSecret("key", "value1").succeeded()).isTrue();
+            assertThat(vault.deleteSecret("key").succeeded()).isTrue();
+            assertThat(vault.resolveSecret("key")).isNull();
+
+        }
+
+        @Test
+        void deleteSecret_partitioned() {
+            assertThat(vault.deleteSecret("partition", "key").succeeded()).isFalse();
+            assertThat(vault.storeSecret("partition", "key", "value1").succeeded()).isTrue();
+            assertThat(vault.deleteSecret("partition", "key").succeeded()).isTrue();
+            assertThat(vault.resolveSecret("partition", "key")).isNull();
+
+            assertThat(vault.storeSecret("partition", "key", "value1").succeeded()).isTrue();
+            assertThat(vault.deleteSecret("another", "key").succeeded()).isFalse();
+        }
     }
 
-    @Test
-    void resolveSecret() {
-        assertThat(vault.resolveSecret("key")).isNull();
-        vault.storeSecret("key", "secret");
-        assertThat(vault.resolveSecret("key")).isEqualTo("secret");
+    @Nested
+    class WithParticipantContextSupplier {
+        private final ParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(
+                ParticipantContext.Builder.newInstance().participantContextId("participantContextId").identity("identity").build()
+        );
+        private final InMemoryVault vault = new InMemoryVault(mock(Monitor.class), participantContextSupplier);
+
+        @Test
+        void shouldResolveFromParticipantContextIdPartition() {
+            vault.storeSecret("participantContextId", "key", "secret");
+
+            var resolved = vault.resolveSecret("key");
+
+            assertThat(resolved).isEqualTo("secret");
+        }
+
+        @Test
+        void shouldStoreOnTheParticipantContextIdPartition() {
+            vault.storeSecret("key", "secret");
+
+            var resolved = vault.resolveSecret("participantContextId", "key");
+            assertThat(resolved).isEqualTo("secret");
+        }
+
+        @Test
+        void shouldDeleteFromTheParticipantContextIdPartition() {
+            vault.storeSecret("participantContextId", "key", "secret");
+
+            var result = vault.deleteSecret("key");
+
+            assertThat(result.succeeded());
+            assertThat(vault.resolveSecret("participantContextId", "key")).isNull();
+        }
     }
 
-    @Test
-    void resolveSecret_partitioned() {
-        assertThat(vault.resolveSecret("key")).isNull();
-        vault.storeSecret("partition", "key", "secret");
-        assertThat(vault.resolveSecret("partition", "key")).isEqualTo("secret");
-        assertThat(vault.resolveSecret("another", "key")).isNull();
-    }
-
-    @Test
-    void storeSecret() {
-        assertThat(vault.storeSecret("key", "value1").succeeded()).isTrue();
-        assertThat(vault.resolveSecret("key")).isEqualTo("value1");
-        assertThat(vault.storeSecret("key", "value2").succeeded()).isTrue();
-        assertThat(vault.resolveSecret("key")).isEqualTo("value2");
-    }
-
-    @Test
-    void storeSecret_partitioned() {
-        assertThat(vault.storeSecret("partition", "key", "value1").succeeded()).isTrue();
-        assertThat(vault.resolveSecret("partition", "key")).isEqualTo("value1");
-        assertThat(vault.storeSecret("partition", "key", "value2").succeeded()).isTrue();
-        assertThat(vault.resolveSecret("partition", "key")).isEqualTo("value2");
-
-        assertThat(vault.storeSecret("partition", "key", "value2").succeeded()).isTrue();
-    }
-
-    @Test
-    void deleteSecret() {
-        assertThat(vault.deleteSecret("key").succeeded()).isFalse();
-        assertThat(vault.storeSecret("key", "value1").succeeded()).isTrue();
-        assertThat(vault.deleteSecret("key").succeeded()).isTrue();
-        assertThat(vault.resolveSecret("key")).isNull();
-
-    }
-
-    @Test
-    void deleteSecret_partitioned() {
-        assertThat(vault.deleteSecret("partition", "key").succeeded()).isFalse();
-        assertThat(vault.storeSecret("partition", "key", "value1").succeeded()).isTrue();
-        assertThat(vault.deleteSecret("partition", "key").succeeded()).isTrue();
-        assertThat(vault.resolveSecret("partition", "key")).isNull();
-
-        assertThat(vault.storeSecret("partition", "key", "value1").succeeded()).isTrue();
-        assertThat(vault.deleteSecret("another", "key").succeeded()).isFalse();
-    }
 }

--- a/extensions/common/sql/sql-pool/sql-pool-apache-commons/src/test/java/org/eclipse/edc/sql/pool/commons/CommonsConnectionPoolServiceExtensionTest.java
+++ b/extensions/common/sql/sql-pool/sql-pool-apache-commons/src/test/java/org/eclipse/edc/sql/pool/commons/CommonsConnectionPoolServiceExtensionTest.java
@@ -65,7 +65,7 @@ class CommonsConnectionPoolServiceExtensionTest {
     @BeforeEach
     void setUp(ServiceExtensionContext context) {
         context.registerService(DataSourceRegistry.class, dataSourceRegistry);
-        context.registerService(Vault.class, new InMemoryVault(mock()));
+        context.registerService(Vault.class, new InMemoryVault(mock(), null));
         context.registerService(ConnectionFactory.class, connectionFactory);
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Provides default partition for `InMemoryVault` when the `SingleParticipantContextSupplier` is used

## Why it does that

Temporary fix while all the vault interactions will have the correct partition passed

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #5395 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
