### PR TITLE
fix: allow null setting for sensitive string

### DIFF
--- a/core/common/participant-context-config-core/src/main/java/org/eclipse/edc/participantcontext/config/ParticipantContextConfigImpl.java
+++ b/core/common/participant-context-config-core/src/main/java/org/eclipse/edc/participantcontext/config/ParticipantContextConfigImpl.java
@@ -85,7 +85,10 @@ public class ParticipantContextConfigImpl implements ParticipantContextConfig {
 
     @Override
     public String getSensitiveString(String participantContextId, String key) {
-        var encryptedValue = privateConfig(participantContextId).getString(key);
+        var encryptedValue = privateConfig(participantContextId).getString(key, null);
+        if (encryptedValue == null) {
+            return null;
+        }
         return encryptionService.decrypt(encryptedValue)
                 .orElseThrow(f -> new EdcException(format("Failed to decrypt sensitive config value for key %s and participant context %s", key, participantContextId)));
     }

--- a/spi/common/participant-context-config-spi/src/main/java/org/eclipse/edc/participantcontext/spi/config/ParticipantContextConfig.java
+++ b/spi/common/participant-context-config-spi/src/main/java/org/eclipse/edc/participantcontext/spi/config/ParticipantContextConfig.java
@@ -106,8 +106,8 @@ public interface ParticipantContextConfig {
      *
      * @param participantContextId the participant context identifier
      * @param key                  of the setting
-     * @return a String representation of the setting
-     * @throws EdcException if no setting is found
+     * @return a String representation of the setting, null if the setting does not exist
+     * @throws EdcException if the setting cannot be decrypted
      */
     String getSensitiveString(String participantContextId, String key);
 }


### PR DESCRIPTION
## What this PR changes/adds

Avoid exception thrown in the case of a sensitive setting is not in the configuration

## Why it does that

Permit fallback hashicorp vault configuration

## Further notes
- the `getSensitiveString` value could return a `Result`, in that way it will be easier to separate the failure cases (e.g. the setting is not decryptable) and the "success" ones (either the sensitive value, or null, in the case there's no such setting). let me know what do you think, I can eventually change the signature right away


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5401

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
