### PR TITLE
feat: make DataAddress optional in Asset

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/asset/AssetServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/asset/AssetServiceImpl.java
@@ -75,9 +75,11 @@ public class AssetServiceImpl implements AssetService {
             return ServiceResult.badRequest(DUPLICATED_KEYS_MESSAGE);
         }
 
-        var validDataAddress = dataAddressValidator.validateSource(asset.getDataAddress());
-        if (validDataAddress.failed()) {
-            return ServiceResult.badRequest(validDataAddress.getFailureMessages());
+        if (asset.getDataAddress() != null) {
+            var validDataAddress = dataAddressValidator.validateSource(asset.getDataAddress());
+            if (validDataAddress.failed()) {
+                return ServiceResult.badRequest(validDataAddress.getFailureMessages());
+            }
         }
 
         return transactionContext.execute(() -> {

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/asset-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/asset-schema.json
@@ -38,8 +38,7 @@
       "required": [
         "@context",
         "@type",
-        "properties",
-        "dataAddress"
+        "properties"
       ]
     }
   }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/validation/AssetValidator.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/validation/AssetValidator.java
@@ -36,7 +36,6 @@ public class AssetValidator {
         return JsonObjectValidator.newValidator()
                 .verifyId(OptionalIdNotBlank::new)
                 .verify(EDC_ASSET_PROPERTIES, MandatoryObject::new)
-                .verify(EDC_ASSET_DATA_ADDRESS, MandatoryObject::new)
                 .verify(path -> new AssetPropertiesUniqueness())
                 .verifyObject(EDC_ASSET_DATA_ADDRESS, DataAddressValidator::instance)
                 .build();

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/validation/AssetValidatorTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/validation/AssetValidatorTest.java
@@ -51,7 +51,6 @@ class AssetValidatorTest {
         var input = createObjectBuilder()
                 .add(ID, " ")
                 .add(EDC_ASSET_PROPERTIES, createArrayBuilder().add(createObjectBuilder()))
-                .add(EDC_ASSET_DATA_ADDRESS, validDataAddress())
                 .build();
 
         var result = validator.validate(input);
@@ -114,10 +113,4 @@ class AssetValidatorTest {
         );
     }
 
-    private JsonArrayBuilder validAsset() {
-        return createArrayBuilder()
-                .add(createObjectBuilder()
-                        .add(EDC_ASSET_PROPERTIES, createArrayBuilder().add(createObjectBuilder()))
-                );
-    }
 }

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/assetindex/SqlAssetIndex.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/assetindex/SqlAssetIndex.java
@@ -84,13 +84,10 @@ public class SqlAssetIndex extends AbstractSqlStore implements AssetIndex {
     @Override
     public StoreResult<Void> create(Asset asset) {
         Objects.requireNonNull(asset);
-        var dataAddress = asset.getDataAddress();
 
-        Objects.requireNonNull(dataAddress);
-
-        var assetId = asset.getId();
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {
+                var assetId = asset.getId();
                 if (existsById(assetId, connection)) {
                     var msg = format(ASSET_EXISTS_TEMPLATE, assetId);
                     return StoreResult.alreadyExists(msg);
@@ -101,7 +98,7 @@ public class SqlAssetIndex extends AbstractSqlStore implements AssetIndex {
                         asset.getCreatedAt(),
                         toJson(asset.getProperties()),
                         toJson(asset.getPrivateProperties()),
-                        toJson(asset.getDataAddress().getProperties()),
+                        toJson(Optional.ofNullable(asset.getDataAddress()).map(DataAddress::getProperties).orElse(null)),
                         asset.getParticipantContextId(),
                         toJson(asset.getDataplaneMetadata())
                 );

--- a/spi/control-plane/asset-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/asset/spi/testfixtures/AssetIndexTestBase.java
+++ b/spi/control-plane/asset-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/asset/spi/testfixtures/AssetIndexTestBase.java
@@ -153,7 +153,7 @@ public abstract class AssetIndexTestBase {
 
             var assetDeleted = getAssetIndex().deleteById("id1");
 
-            Assertions.assertThat(assetDeleted).isNotNull().extracting(StoreResult::succeeded).isEqualTo(true);
+            assertThat(assetDeleted).isNotNull().extracting(StoreResult::succeeded).isEqualTo(true);
             assertThat(assetDeleted.getContent()).usingRecursiveComparison().isEqualTo(asset);
 
             assertThat(getAssetIndex().queryAssets(QuerySpec.none())).isEmpty();

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
@@ -46,6 +46,15 @@ public class TransferEndToEndParticipant extends Participant {
                 .build();
     }
 
+    public static TransferEndToEndParticipant.Builder newInstance(ComponentRuntimeContext ctx) {
+        var id = ctx.getConfig().getString("edc.participant.id");
+        return TransferEndToEndParticipant.Builder.newInstance()
+                .id(id)
+                .name(ctx.getName())
+                .managementUrl(ctx.getEndpoint(MANAGEMENT))
+                .protocolUrl(ctx.getEndpoint(PROTOCOL));
+    }
+
     /**
      * Get the EDR from the EDR cache by transfer process id.
      *
@@ -56,7 +65,7 @@ public class TransferEndToEndParticipant extends Participant {
         var dataAddressRaw = baseManagementRequest()
                 .contentType(JSON)
                 .when()
-                .get("/v3/edrs/{id}/dataaddress", transferProcessId)
+                .get("/edrs/{id}/dataaddress", transferProcessId)
                 .then()
                 .log().ifError()
                 .statusCode(200)


### PR DESCRIPTION
## What this PR changes/adds

Makes `dataAddress` attribute in `Asset` optional

## Why it does that

In the upcoming data plane signaling spec the data address will be managed by the data-plane in its entirety

## Further notes
- replaced `BadRequestException` with `InvalidRequestException` in the `JerseyJsonLdInterceptor` so the client will be able to get the error message in the response body (because of `EdcApiExceptionMapper`)
- made the management version base path (e.g. `/v3` or `/v4alpha`) configurable on `Participant`, this permits to switch the API version in the test declaration. The same pattern could be applied for the protocol version (at the moment it can be changed using a setter method)


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #5323 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
