### PR TITLE
feat: data plane signaling data flow controller selection

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImpl.java
@@ -136,11 +136,7 @@ public class TransferProcessServiceImpl implements TransferProcessService {
 
         var flowType = transferTypeParse.getContent().flowType();
 
-        if (flowType == FlowType.PUSH) {
-            if (request.getDataDestination() == null) {
-                return ServiceResult.badRequest("For PUSH transfers dataDestination must be defined");
-            }
-
+        if (flowType == FlowType.PUSH && request.getDataDestination() != null) {
             var validDestination = dataAddressValidator.validateDestination(request.getDataDestination());
             if (validDestination.failed()) {
                 return ServiceResult.badRequest(validDestination.getFailureMessages());

--- a/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
@@ -237,7 +237,7 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
             var assetId = process.getAssetId();
             var dataAddress = addressResolver.resolveForAsset(assetId);
             if (dataAddress == null) {
-                transitionToTerminating(process, "Asset not found: " + assetId);
+                transitionToStarting(process);
                 return true;
             }
             // default the content address to the asset address; this may be overridden during provisioning

--- a/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
+++ b/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
@@ -900,7 +900,7 @@ class TransferProcessManagerImplTest {
         }
 
         @Test
-        void shouldTransitionToTerminating_whenAssetIsNotResolved() {
+        void shouldTransitionToStarting_whenTransferHasNoDataAddress() {
             var transferProcess = builder.build();
             when(policyArchive.findPolicyForContract(anyString())).thenReturn(Policy.Builder.newInstance().build());
             when(transferProcessStore.nextNotLeased(anyInt(), stateIs(INITIAL.code()))).thenReturn(List.of(transferProcess)).thenReturn(emptyList());
@@ -914,7 +914,7 @@ class TransferProcessManagerImplTest {
                 verify(transferProcessStore).save(captor.capture());
                 verifyNoInteractions(manifestGenerator, provisionManager);
                 var actualTransferProcess = captor.getValue();
-                assertThat(actualTransferProcess.getState()).isEqualTo(TERMINATING.code());
+                assertThat(actualTransferProcess.getState()).isEqualTo(STARTING.code());
             });
         }
     }

--- a/data-protocols/data-plane-signaling/build.gradle.kts
+++ b/data-protocols/data-plane-signaling/build.gradle.kts
@@ -29,3 +29,9 @@ dependencies {
     testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
     testImplementation(libs.restAssured)
 }
+
+edcBuild {
+    swagger {
+        apiGroup.set("control-api")
+    }
+}

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingExtension.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingExtension.java
@@ -14,9 +14,12 @@
 
 package org.eclipse.edc.signaling;
 
+import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowManager;
+import org.eclipse.edc.connector.controlplane.transfer.spi.flow.TransferTypeParser;
 import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.signaling.logic.DataPlaneSignalingFlowController;
 import org.eclipse.edc.signaling.port.DataPlaneRegistrationApiController;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -34,6 +37,10 @@ public class DataPlaneSignalingExtension implements ServiceExtension {
     private WebService webService;
     @Inject
     private DataPlaneSelectorService dataPlaneSelectorService;
+    @Inject
+    private DataFlowManager dataFlowManager;
+    @Inject
+    private TransferTypeParser transferTypeParser;
 
     @Override
     public String name() {
@@ -43,5 +50,7 @@ public class DataPlaneSignalingExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         webService.registerResource(ApiContext.CONTROL, new DataPlaneRegistrationApiController(dataPlaneSelectorService));
+        dataFlowManager.register(10, new DataPlaneSignalingFlowController(dataPlaneSelectorService, transferTypeParser));
     }
+
 }

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowController.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowController.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.signaling.logic;
+
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowController;
+import org.eclipse.edc.connector.controlplane.transfer.spi.flow.TransferTypeParser;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataFlowResponse;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Support Data Plane Signaling upcoming spec.
+ */
+public class DataPlaneSignalingFlowController implements DataFlowController {
+    private final DataPlaneSelectorService dataPlaneSelectorService;
+    private final TransferTypeParser transferTypeParser;
+
+    public DataPlaneSignalingFlowController(DataPlaneSelectorService dataPlaneSelectorService,
+                                            TransferTypeParser transferTypeParser) {
+        this.dataPlaneSelectorService = dataPlaneSelectorService;
+        this.transferTypeParser = transferTypeParser;
+    }
+
+    @Override
+    public boolean canHandle(TransferProcess transferProcess) {
+        return transferTypeParser.parse(transferProcess.getTransferType()).succeeded();
+    }
+
+    @Override
+    public StatusResult<DataFlowResponse> prepare(TransferProcess transferProcess, Policy policy) {
+        return null;
+    }
+
+    @Override
+    public @NotNull StatusResult<DataFlowResponse> start(TransferProcess transferProcess, Policy policy) {
+        return StatusResult.success(DataFlowResponse.Builder.newInstance().build());
+    }
+
+    @Override
+    public StatusResult<Void> suspend(TransferProcess transferProcess) {
+        return null;
+    }
+
+    @Override
+    public StatusResult<Void> terminate(TransferProcess transferProcess) {
+        return null;
+    }
+
+    @Override
+    public Set<String> transferTypesFor(Asset asset) {
+        return dataPlaneSelectorService.getAll()
+                .map(dataPlaneInstances -> dataPlaneInstances.stream()
+                        .map(DataPlaneInstance::getAllowedTransferTypes)
+                        .flatMap(Collection::stream)
+                        .collect(Collectors.toSet()))
+                .orElse(f -> Set.of());
+    }
+}

--- a/data-protocols/data-plane-signaling/src/test/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowControllerTest.java
+++ b/data-protocols/data-plane-signaling/src/test/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowControllerTest.java
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.signaling.logic;
+
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.transfer.spi.flow.TransferTypeParser;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.transfer.FlowType;
+import org.eclipse.edc.spi.types.domain.transfer.TransferType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class DataPlaneSignalingFlowControllerTest {
+
+    private final DataPlaneSelectorService dataPlaneSelectorService = Mockito.mock();
+    private final TransferTypeParser transferTypeParser = Mockito.mock();
+    private final DataPlaneSignalingFlowController controller = new DataPlaneSignalingFlowController(
+            dataPlaneSelectorService, transferTypeParser);
+
+    @Nested
+    class CanHandle {
+        @Test
+        void shouldReturnTrue_whenFlowTypeIsValid() {
+            when(transferTypeParser.parse(any())).thenReturn(Result.success(new TransferType("Valid", FlowType.PUSH)));
+            var transferProcess = TransferProcess.Builder.newInstance()
+                    .transferType("Valid-PUSH")
+                    .dataDestination(DataAddress.Builder.newInstance().type("Custom").build())
+                    .build();
+
+            var result = controller.canHandle(transferProcess);
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void shouldReturnFalse_whenFlowTypeIsNotValid() {
+            when(transferTypeParser.parse(any())).thenReturn(Result.failure("cannot parse"));
+            var transferProcess = TransferProcess.Builder.newInstance()
+                    .transferType("Invalid-ANY")
+                    .dataDestination(DataAddress.Builder.newInstance().type("Custom").build())
+                    .build();
+
+            var result = controller.canHandle(transferProcess);
+
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    class TransferTypes {
+
+        @Test
+        void shouldReturnSupportedTransferTypes() {
+            var assetNoResponse = Asset.Builder.newInstance().dataAddress(DataAddress.Builder.newInstance().type("TargetSrc").build()).build();
+            when(transferTypeParser.parse(any()))
+                    .thenReturn(Result.success(new TransferType("any", FlowType.PUSH)))
+                    .thenReturn(Result.success(new TransferType("any", FlowType.PULL)));
+
+            when(dataPlaneSelectorService.getAll()).thenReturn(ServiceResult.success(List.of(
+                    dataPlaneInstanceBuilder().allowedTransferType("Custom-PUSH").build(),
+                    dataPlaneInstanceBuilder().allowedTransferType("Custom-PULL").build()
+            )));
+
+            var transferTypes = controller.transferTypesFor(assetNoResponse);
+
+            assertThat(transferTypes).containsExactly("Custom-PUSH", "Custom-PULL");
+        }
+
+        @Test
+        void shouldReturnEmptyList_whenCannotGetDataplaneInstances() {
+            when(dataPlaneSelectorService.getAll()).thenReturn(ServiceResult.unexpected("error"));
+            var asset = Asset.Builder.newInstance().dataAddress(DataAddress.Builder.newInstance().type("TargetSrc").build()).build();
+
+            var transferTypes = controller.transferTypesFor(asset);
+
+            assertThat(transferTypes).isEmpty();
+        }
+    }
+
+    @NotNull
+    private DataPlaneInstance.Builder dataPlaneInstanceBuilder() {
+        return DataPlaneInstance.Builder.newInstance().url("http://any");
+    }
+}

--- a/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
+++ b/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
@@ -1,8 +1,8 @@
 [
   {
-    "version": "2.1.0",
+    "version": "2.1.1",
     "urlPath": "/v1",
-    "lastUpdated": "2025-10-02T12:00:01Z",
+    "lastUpdated": "2025-12-12T12:00:01Z",
     "maturity": "stable"
   }
 ]

--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -8,7 +8,7 @@
   {
     "version": "4.0.0-beta",
     "urlPath": "/v4beta",
-    "lastUpdated": "2025-11-12T17:43:01Z",
+    "lastUpdated": "2025-12-12T17:43:01Z",
     "maturity": "beta"
   }
 ]

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/assetindex/SqlAssetIndex.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/assetindex/SqlAssetIndex.java
@@ -36,6 +36,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -185,14 +186,16 @@ public class SqlAssetIndex extends AbstractSqlStore implements AssetIndex {
     }
 
     private Asset mapAsset(ResultSet resultSet) throws SQLException {
+        Map<String, Object> dataAddressProperties = fromJson(resultSet.getString(assetStatements.getDataAddressColumn()), getTypeRef());
+        var dataAddress = Optional.ofNullable(dataAddressProperties)
+                .map(it -> DataAddress.Builder.newInstance().properties(dataAddressProperties).build())
+                .orElse(null);
         return Asset.Builder.newInstance()
                 .id(resultSet.getString(assetStatements.getAssetIdColumn()))
                 .createdAt(resultSet.getLong(assetStatements.getCreatedAtColumn()))
                 .properties(fromJson(resultSet.getString(assetStatements.getPropertiesColumn()), getTypeRef()))
                 .privateProperties(fromJson(resultSet.getString(assetStatements.getPrivatePropertiesColumn()), getTypeRef()))
-                .dataAddress(DataAddress.Builder.newInstance()
-                        .properties(fromJson(resultSet.getString(assetStatements.getDataAddressColumn()), getTypeRef()))
-                        .build())
+                .dataAddress(dataAddress)
                 .participantContextId(resultSet.getString(assetStatements.getParticipantContextIdColumn()))
                 .dataplaneMetadata(fromJson(resultSet.getString(assetStatements.getDataplaneMetadataColumn()), DataplaneMetadata.class))
                 .build();

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/TransferDataPlaneSignalingExtension.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/TransferDataPlaneSignalingExtension.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.connector.controlplane.transfer.dataplane;
 
-import org.eclipse.edc.connector.controlplane.transfer.dataplane.flow.DataPlaneSignalingFlowController;
+import org.eclipse.edc.connector.controlplane.transfer.dataplane.flow.LegacyDataPlaneSignalingFlowController;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowManager;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowPropertiesProvider;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.TransferTypeParser;
@@ -62,7 +62,7 @@ public class TransferDataPlaneSignalingExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var controller = new DataPlaneSignalingFlowController(callbackUrl, selectorService, getPropertiesProvider(),
+        var controller = new LegacyDataPlaneSignalingFlowController(callbackUrl, selectorService, getPropertiesProvider(),
                 clientFactory, selectionStrategy, transferTypeParser);
         dataFlowManager.register(controller);
     }

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/LegacyDataPlaneSignalingFlowController.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/LegacyDataPlaneSignalingFlowController.java
@@ -48,11 +48,12 @@ import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
  * <p>
  * It handles all the transfer process where the transferType met the criteria defined in the format mapping of the
  * signaling spec
+ * This implementation will soon be replaced by the one supporting the upcoming Data Plane Signaling spec.
  *
  * @see <a href="https://github.com/eclipse-edc/Connector/blob/main/docs/developer/data-plane-signaling/data-plane-signaling.md">Data plane signaling</a>
  * @see <a href="https://github.com/eclipse-edc/Connector/blob/main/docs/developer/data-plane-signaling/data-plane-signaling-mapping.md">Data plane signaling transfer type mapping</a>
  */
-public class DataPlaneSignalingFlowController implements DataFlowController {
+public class LegacyDataPlaneSignalingFlowController implements DataFlowController {
 
     private final ControlApiUrl callbackUrl;
     private final DataPlaneSelectorService selectorClient;
@@ -61,9 +62,9 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
     private final String selectionStrategy;
     private final TransferTypeParser transferTypeParser;
 
-    public DataPlaneSignalingFlowController(ControlApiUrl callbackUrl, DataPlaneSelectorService selectorClient,
-                                            DataFlowPropertiesProvider propertiesProvider, DataPlaneClientFactory clientFactory,
-                                            String selectionStrategy, TransferTypeParser transferTypeParser) {
+    public LegacyDataPlaneSignalingFlowController(ControlApiUrl callbackUrl, DataPlaneSelectorService selectorClient,
+                                                  DataFlowPropertiesProvider propertiesProvider, DataPlaneClientFactory clientFactory,
+                                                  String selectionStrategy, TransferTypeParser transferTypeParser) {
         this.callbackUrl = callbackUrl;
         this.selectorClient = selectorClient;
         this.propertiesProvider = propertiesProvider;
@@ -186,6 +187,12 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
         }
 
         var assetDataAddress = asset.getDataAddress();
+        if (assetDataAddress == null) {
+            return allDataPlanes.getContent().stream()
+                    .flatMap(dataPlane -> dataPlane.getAllowedTransferTypes().stream())
+                    .collect(toSet());
+        }
+
         var expectedResponseChannelType = Optional.ofNullable(assetDataAddress.getResponseChannel())
                 .map(DataAddress::getType)
                 .orElse(null);

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/TransferDataPlaneSignalingExtensionTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/TransferDataPlaneSignalingExtensionTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.connector.controlplane.transfer.dataplane;
 
-import org.eclipse.edc.connector.controlplane.transfer.dataplane.flow.DataPlaneSignalingFlowController;
+import org.eclipse.edc.connector.controlplane.transfer.dataplane.flow.LegacyDataPlaneSignalingFlowController;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowManager;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -39,6 +39,6 @@ class TransferDataPlaneSignalingExtensionTest {
     @Test
     void initialize(ServiceExtensionContext context, TransferDataPlaneSignalingExtension extension) {
         extension.initialize(context);
-        verify(dataFlowManager).register(isA(DataPlaneSignalingFlowController.class));
+        verify(dataFlowManager).register(isA(LegacyDataPlaneSignalingFlowController.class));
     }
 }

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/LegacyDataPlaneSignalingFlowControllerTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/LegacyDataPlaneSignalingFlowControllerTest.java
@@ -55,7 +55,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-public class DataPlaneSignalingFlowControllerTest {
+public class LegacyDataPlaneSignalingFlowControllerTest {
 
     private static final String HTTP_DATA_PULL = "HttpData-PULL";
     private final DataPlaneClient dataPlaneClient = mock();
@@ -64,7 +64,7 @@ public class DataPlaneSignalingFlowControllerTest {
     private final DataFlowPropertiesProvider propertiesProvider = mock();
     private final TransferTypeParser transferTypeParser = mock();
 
-    private final DataPlaneSignalingFlowController flowController = new DataPlaneSignalingFlowController(
+    private final LegacyDataPlaneSignalingFlowController flowController = new LegacyDataPlaneSignalingFlowController(
             () -> URI.create("http://localhost"), selectorService, propertiesProvider, dataPlaneClientFactory,
             "random", transferTypeParser);
 

--- a/spi/common/core-spi/build.gradle.kts
+++ b/spi/common/core-spi/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
     api(libs.failsafe.core)
     api(project(":spi:common:boot-spi"))
     api(project(":spi:common:policy-model"))
-    implementation(libs.opentelemetry.api)
 
     testImplementation(project(":tests:junit-base"))
     testImplementation(project(":core:common:lib:json-lib"))

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowStartMessage.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/types/domain/transfer/DataFlowStartMessage.java
@@ -271,7 +271,6 @@ public class DataFlowStartMessage implements Polymorphic, TraceCarrier {
                 request.traceContext = new HashMap<>();
             }
             Objects.requireNonNull(request.processId, "processId");
-            Objects.requireNonNull(request.sourceDataAddress, "sourceDataAddress");
             if (request.transferType == null) {
                 request.transferType = new TransferType(this.transferTypeDestination, this.flowType);
             }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
@@ -300,7 +300,7 @@ public class TransferProcess extends StatefulEntity<TransferProcess> implements 
     }
 
     public void transitionStarting() {
-        transition(STARTING, PROVISIONED, STARTING, SUSPENDED, STARTUP_REQUESTED);
+        transition(STARTING, PROVISIONED, INITIAL, STARTING, SUSPENDED, STARTUP_REQUESTED);
     }
 
     public boolean canBeStartedConsumer() {

--- a/system-tests/e2e-transfer-test/signaling-data-plane/src/main/java/org/eclipse/edc/test/runtime/signaling/SignalingDataPlaneExtension.java
+++ b/system-tests/e2e-transfer-test/signaling-data-plane/src/main/java/org/eclipse/edc/test/runtime/signaling/SignalingDataPlaneExtension.java
@@ -21,7 +21,7 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebService;
 
-public class DataPlaneSignalingExtension implements ServiceExtension {
+public class SignalingDataPlaneExtension implements ServiceExtension {
 
     @Setting(key = "signaling.dataplane.controlplane.endpoint")
     private String controlplaneEndpoint;

--- a/system-tests/e2e-transfer-test/signaling-data-plane/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/system-tests/e2e-transfer-test/signaling-data-plane/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,1 +1,1 @@
-org.eclipse.edc.test.runtime.signaling.DataPlaneSignalingExtension
+org.eclipse.edc.test.runtime.signaling.SignalingDataPlaneExtension


### PR DESCRIPTION
## What this PR changes/adds

Introduce new `DataPlaneSignalingFlowController` with minimal implementation to permit correct flow controller selection. Proper implementation will come in subsequent PRs.

## Why it does that

support new data plane signaling spec

## Further notes
- current `DataPlaneSignalingFlowController` has been renamed to `LegacyDataPlaneSignalingFlowController`, so it can be distinguished
- now transfer processes can be requested also without data destination, in this case, the provisioning phase will be avoided (as it's supposed to be managed by the data plane)


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #5323 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
