### PR TITLE
feat: support for JWT status list credential

### DIFF
--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpCoreExtension.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpCoreExtension.java
@@ -186,8 +186,8 @@ public class DcpCoreExtension implements ServiceExtension {
 
         // register revocation services
         var acceptedContentTypes = parseAcceptedContentTypes(contentTypes);
-        revocationServiceRegistry.addService(StatusList2021Status.TYPE, new StatusList2021RevocationService(typeManager.getMapper(), revocationCacheValidity, acceptedContentTypes, httpClient));
-        revocationServiceRegistry.addService(BitstringStatusListStatus.TYPE, new BitstringStatusListRevocationService(typeManager.getMapper(), revocationCacheValidity, acceptedContentTypes, httpClient));
+        revocationServiceRegistry.addService(StatusList2021Status.TYPE, new StatusList2021RevocationService(typeManager.getMapper(), revocationCacheValidity, acceptedContentTypes, httpClient, tokenValidationService, didPublicKeyResolver));
+        revocationServiceRegistry.addService(BitstringStatusListStatus.TYPE, new BitstringStatusListRevocationService(typeManager.getMapper(), revocationCacheValidity, acceptedContentTypes, httpClient, tokenValidationService, didPublicKeyResolver));
     }
 
     @Override

--- a/extensions/common/iam/verifiable-credentials/build.gradle.kts
+++ b/extensions/common/iam/verifiable-credentials/build.gradle.kts
@@ -21,7 +21,10 @@ dependencies {
     api(project(":spi:common:verifiable-credentials-spi"))
     api(project(":spi:common:http-spi"))
     implementation(project(":core:common:lib:util-lib"))
+    implementation(project(":spi:common:token-spi"))
+    implementation(project(":spi:common:identity-did-spi"))
     implementation(libs.jsonschema)
+    implementation(libs.jakarta.rsApi)
 
     testImplementation(libs.wiremock)
     testImplementation(testFixtures(project(":spi:common:verifiable-credentials-spi")))

--- a/extensions/common/iam/verifiable-credentials/src/main/java/org/eclipse/edc/iam/verifiablecredentials/revocation/bitstring/BitstringStatusListRevocationService.java
+++ b/extensions/common/iam/verifiable-credentials/src/main/java/org/eclipse/edc/iam/verifiablecredentials/revocation/bitstring/BitstringStatusListRevocationService.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.iam.verifiablecredentials.revocation.bitstring;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.edc.iam.verifiablecredentials.revocation.BaseRevocationListService;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialStatus;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.BitString;
@@ -23,6 +24,7 @@ import org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.bitstrings
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.bitstringstatuslist.BitstringStatusListStatus;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.bitstringstatuslist.StatusMessage;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.token.spi.TokenValidationService;
 
 import java.util.Collection;
 
@@ -34,8 +36,10 @@ import static org.eclipse.edc.spi.result.Result.success;
  */
 public class BitstringStatusListRevocationService extends BaseRevocationListService<BitstringStatusListCredential, BitstringStatusListStatus> {
 
-    public BitstringStatusListRevocationService(ObjectMapper mapper, long cacheValidity, Collection<String> acceptedContentTypes, EdcHttpClient httpClient) {
-        super(mapper, cacheValidity, acceptedContentTypes, httpClient, BitstringStatusListCredential.class);
+    public BitstringStatusListRevocationService(ObjectMapper mapper, long cacheValidity, Collection<String> acceptedContentTypes,
+                                                EdcHttpClient httpClient, TokenValidationService tokenValidationService,
+                                                DidPublicKeyResolver didPublicKeyResolver) {
+        super(mapper, cacheValidity, acceptedContentTypes, httpClient, tokenValidationService, didPublicKeyResolver, BitstringStatusListCredential.class);
     }
 
     @Override

--- a/extensions/common/iam/verifiable-credentials/src/main/java/org/eclipse/edc/iam/verifiablecredentials/revocation/statuslist2021/StatusList2021RevocationService.java
+++ b/extensions/common/iam/verifiable-credentials/src/main/java/org/eclipse/edc/iam/verifiablecredentials/revocation/statuslist2021/StatusList2021RevocationService.java
@@ -16,12 +16,14 @@ package org.eclipse.edc.iam.verifiablecredentials.revocation.statuslist2021;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.edc.iam.verifiablecredentials.revocation.BaseRevocationListService;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialStatus;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.BitString;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.statuslist2021.StatusList2021Credential;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.statuslist2021.StatusList2021Status;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.token.spi.TokenValidationService;
 
 import java.util.Collection;
 
@@ -34,8 +36,10 @@ import static org.eclipse.edc.spi.result.Result.success;
  */
 public class StatusList2021RevocationService extends BaseRevocationListService<StatusList2021Credential, StatusList2021Status> {
 
-    public StatusList2021RevocationService(ObjectMapper objectMapper, long cacheValidity, Collection<String> acceptedContentTypes, EdcHttpClient httpClient) {
-        super(objectMapper, cacheValidity, acceptedContentTypes, httpClient, StatusList2021Credential.class);
+    public StatusList2021RevocationService(ObjectMapper objectMapper, long cacheValidity, Collection<String> acceptedContentTypes,
+                                           EdcHttpClient httpClient, TokenValidationService tokenValidationService,
+                                           DidPublicKeyResolver didPublicKeyResolver) {
+        super(objectMapper, cacheValidity, acceptedContentTypes, httpClient, tokenValidationService, didPublicKeyResolver, StatusList2021Credential.class);
     }
 
     @Override


### PR DESCRIPTION
## What this PR changes/adds

Adds support for requesting and parsing the status list credential as JWT in the `BaseRevocationListService`.

## Why it does that

specification support, alignment with identity hub's default behaviour


## Who will sponsor this feature?

me


## Linked Issue(s)

Closes #5398

