### PR TITLE
chore: add missing contract negotiation fields

### DIFF
--- a/extensions/common/json-ld/src/main/resources/document/management-context-v2.jsonld
+++ b/extensions/common/json-ld/src/main/resources/document/management-context-v2.jsonld
@@ -175,7 +175,9 @@
         "state": "edc:state",
         "errorDetail": "edc:errorDetail",
         "contractAgreementId": "edc:contractAgreementId",
-        "createdAt": "edc:createdAt"
+        "createdAt": "edc:createdAt",
+        "assetId": "edc:assetId",
+        "correlationId": "edc:correlationId"
       }
     },
     "CallbackAddress": {

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/SerdeEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/SerdeEndToEndTest.java
@@ -201,6 +201,8 @@ public class SerdeEndToEndTest {
                 assertThat(events).containsAll(firstCallback.getEvents());
             });
             assertThat(compactResult.getJsonNumber("createdAt").longValue()).isEqualTo(1234);
+            assertThat(compactResult.getString("assetId")).isEqualTo(negotiation.getLastContractOffer().getAssetId());
+            assertThat(compactResult.getString("correlationId")).isEqualTo(negotiation.getCorrelationId());
 
         }
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
@@ -20,6 +20,7 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.edr.spi.types.EndpointDataReferenceEntry;
 import org.eclipse.edc.policy.engine.spi.PolicyValidatorRule;
@@ -46,6 +47,7 @@ import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
@@ -328,6 +330,11 @@ public class TestFunctions {
                 .contractAgreement(createContractAgreement("test-agreement"))
                 .state(REQUESTED.code())
                 .type(ContractNegotiation.Type.PROVIDER)
+                .contractOffer(ContractOffer.Builder.newInstance()
+                        .id(UUID.randomUUID().toString())
+                        .assetId("assetId")
+                        .policy(Policy.Builder.newInstance().build())
+                        .build())
                 .callbackAddresses(List.of(
                         CallbackAddress.Builder.newInstance()
                                 .uri("local://test")


### PR DESCRIPTION
## What this PR changes/adds

add missing contract negotiation fields in the management v2 JSON-LD context 

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
