### PR TITLE
feat: validate transferType on transfer request on provider side

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -62,6 +62,7 @@ import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.Trans
 import org.eclipse.edc.connector.controlplane.services.transferprocess.TransferProcessProtocolServiceImpl;
 import org.eclipse.edc.connector.controlplane.services.transferprocess.TransferProcessServiceImpl;
 import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessManager;
+import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowManager;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.TransferTypeParser;
 import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
@@ -106,88 +107,64 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
 
     @Inject
     private Clock clock;
-
     @Inject
     private Monitor monitor;
-
     @Inject
     private EventRouter eventRouter;
-
     @Inject
     private RemoteMessageDispatcherRegistry dispatcher;
-
     @Inject
     private AssetIndex assetIndex;
     @Inject
     private Vault vault;
     @Inject
     private ContractDefinitionStore contractDefinitionStore;
-
     @Inject
     private ContractNegotiationStore contractNegotiationStore;
-
     @Inject
     private ConsumerContractNegotiationManager consumerContractNegotiationManager;
-
     @Inject
     private PolicyDefinitionStore policyDefinitionStore;
-
     @Inject
     private TransferProcessStore transferProcessStore;
-
     @Inject
     private TransferProcessManager transferProcessManager;
-
     @Inject
     private TransactionContext transactionContext;
-
     @Inject
     private ContractValidationService contractValidationService;
-
     @Inject
     private ConsumerOfferResolver consumerOfferResolver;
-
     @Inject
     private ContractNegotiationObservable contractNegotiationObservable;
-
     @Inject
     private TransferProcessObservable transferProcessObservable;
-
     @Inject
     private Telemetry telemetry;
-
     @Inject
     private ParticipantAgentService participantAgentService;
-
     @Inject
     private DataServiceRegistry dataServiceRegistry;
-
     @Inject
     private DatasetResolver datasetResolver;
-
     @Inject
     private CommandHandlerRegistry commandHandlerRegistry;
-
     @Inject
     private DataAddressValidatorRegistry dataAddressValidator;
-
     @Inject
     private IdentityService identityService;
-
     @Inject
     private PolicyEngine policyEngine;
-
     @Inject(required = false)
     private ProtocolTokenValidator protocolTokenValidator;
-
     @Inject
     private DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
-
     @Inject
     private TransferTypeParser transferTypeParser;
-
     @Inject
     private ParticipantIdentityResolver identityResolver;
+    @Inject
+    private DataFlowManager dataFlowManager;
 
     @Override
     public String name() {
@@ -271,7 +248,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     public TransferProcessProtocolService transferProcessProtocolService() {
         return new TransferProcessProtocolServiceImpl(transferProcessStore, transactionContext, contractNegotiationStore,
                 contractValidationService, protocolTokenValidator(), dataAddressValidator, transferProcessObservable, clock,
-                monitor, telemetry, vault);
+                monitor, telemetry, vault, dataFlowManager);
     }
 
     @Provider

--- a/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DefaultDistributionResolverTest.java
+++ b/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DefaultDistributionResolverTest.java
@@ -41,7 +41,7 @@ class DefaultDistributionResolverTest {
     @Test
     void shouldReturnDistributionsForEveryTransferType() {
         when(dataServiceRegistry.getDataServices(any(), any())).thenReturn(List.of(dataService));
-        when(dataFlowManager.transferTypesFor(any())).thenReturn(Set.of("type1", "type2"));
+        when(dataFlowManager.transferTypesFor(any(Asset.class))).thenReturn(Set.of("type1", "type2"));
 
         var dataAddress = DataAddress.Builder.newInstance().type("any").build();
         var asset = Asset.Builder.newInstance().dataAddress(dataAddress).build();
@@ -62,7 +62,7 @@ class DefaultDistributionResolverTest {
     @Test
     void shouldReturnDistribution_whenAssetIsCatalog() {
         when(dataServiceRegistry.getDataServices(any(), any())).thenReturn(List.of(dataService));
-        when(dataFlowManager.transferTypesFor(any())).thenReturn(Set.of("type1", "type2"));
+        when(dataFlowManager.transferTypesFor(any(Asset.class))).thenReturn(Set.of("type1", "type2"));
 
         var dataAddress = DataAddress.Builder.newInstance()
                 .type("HttpData")

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferProcessDefaultServicesExtension.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferProcessDefaultServicesExtension.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.controlplane.transfer;
 
+import org.eclipse.edc.connector.controlplane.asset.spi.index.AssetIndex;
 import org.eclipse.edc.connector.controlplane.transfer.flow.DataFlowManagerImpl;
 import org.eclipse.edc.connector.controlplane.transfer.flow.TransferTypeParserImpl;
 import org.eclipse.edc.connector.controlplane.transfer.observe.TransferProcessObservableImpl;
@@ -42,6 +43,8 @@ public class TransferProcessDefaultServicesExtension implements ServiceExtension
 
     @Inject
     private PolicyEngine policyEngine;
+    @Inject
+    private AssetIndex assetIndex;
 
     @Override
     public String name() {
@@ -55,7 +58,7 @@ public class TransferProcessDefaultServicesExtension implements ServiceExtension
 
     @Provider
     public DataFlowManager dataFlowManager(ServiceExtensionContext context) {
-        return new DataFlowManagerImpl(context.getMonitor());
+        return new DataFlowManagerImpl(context.getMonitor(), assetIndex);
     }
 
     @Provider

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowManager.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowManager.java
@@ -87,7 +87,15 @@ public interface DataFlowManager {
      * Returns the transfer types available for a specific asset.
      *
      * @param asset the asset.
-     * @return tranfer types list.
+     * @return transfer types list.
      */
     Set<String> transferTypesFor(Asset asset);
+
+    /**
+     * Returns the transfer types available for a specific asset given its id.
+     *
+     * @param assetId the asset id.
+     * @return transfer types list.
+     */
+    Set<String> transferTypesFor(String assetId);
 }

--- a/system-tests/e2e-transfer-test/signaling-data-plane/src/main/java/org/eclipse/edc/test/runtime/signaling/SignalingDataPlaneExtension.java
+++ b/system-tests/e2e-transfer-test/signaling-data-plane/src/main/java/org/eclipse/edc/test/runtime/signaling/SignalingDataPlaneExtension.java
@@ -31,6 +31,7 @@ public class SignalingDataPlaneExtension implements ServiceExtension {
 
     private Dataplane dataplane = Dataplane.newInstance()
             .endpoint("http://localhost")
+            .transferType("Finite-PUSH")
             .build();
 
     @Override


### PR DESCRIPTION
## What this PR changes/adds

Validates transferType on provider side on transfer process request

## Why it does that

Fail fast in case a received transferType is not supported

## Further notes
- did some cleanup in the transfer process protocol service class. I was in doubt about moving the transfer request validations in a collaborator, but eventually let's do in the future, as the improvements brought by an eventual refactor weren't enough to justify it


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4745
_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
