### PR TITLE
refactor: make participant agent id non-null

### DIFF
--- a/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/agent/ParticipantAgentServiceImplTest.java
+++ b/core/common/connector-core/src/test/java/org/eclipse/edc/connector/core/agent/ParticipantAgentServiceImplTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.participant.spi.ParticipantAgent.PARTICIPANT_IDENTITY;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -35,7 +34,7 @@ class ParticipantAgentServiceImplTest {
 
     @Test
     void verifyRegisteredExtensionIsInvoked() {
-        ParticipantAgentServiceExtension extension = mock(ParticipantAgentServiceExtension.class);
+        var extension = mock(ParticipantAgentServiceExtension.class);
         when(extension.attributesFor(isA(ClaimToken.class))).thenReturn(Map.of("foo", "bar"));
 
         var participantAgentService = new ParticipantAgentServiceImpl();
@@ -64,7 +63,6 @@ class ParticipantAgentServiceImplTest {
         var givenParticipantId = "test-participant";
 
         var extension = mock(ParticipantAgentServiceExtension.class);
-        when(extension.attributesFor(isA(ClaimToken.class))).thenReturn(Map.of(PARTICIPANT_IDENTITY, extensionParticipantId));
         participantAgentService.register(extension);
 
         var agent = participantAgentService.createFor(ClaimToken.Builder.newInstance().build(), givenParticipantId);

--- a/core/common/lib/policy-engine-lib/src/test/java/org/eclipse/edc/policy/engine/PolicyEngineImplScenariosTest.java
+++ b/core/common/lib/policy-engine-lib/src/test/java/org/eclipse/edc/policy/engine/PolicyEngineImplScenariosTest.java
@@ -106,11 +106,11 @@ public class PolicyEngineImplScenariosTest {
         var usePermission = Permission.Builder.newInstance().action(USE_ACTION).constraint(spatialConstraint).build();
         var policy = Policy.Builder.newInstance().permission(usePermission).build();
 
-        var euContext = new TestAgentContext(new ParticipantAgent(Map.of("region", "eu"), emptyMap()));
+        var euContext = new TestAgentContext(new ParticipantAgent("identity", Map.of("region", "eu"), emptyMap()));
         var euResult = policyEngine.evaluate(policy, euContext);
         assertThat(euResult).isSucceeded();
 
-        var noRegionContext = new TestAgentContext(new ParticipantAgent(emptyMap(), emptyMap()));
+        var noRegionContext = new TestAgentContext(new ParticipantAgent("identity", emptyMap(), emptyMap()));
         var noRegionResult = policyEngine.evaluate(policy, noRegionContext);
         assertThat(noRegionResult).isFailed();
     }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogProtocolServiceImplTest.java
@@ -69,7 +69,7 @@ class CatalogProtocolServiceImplTest {
             dataServiceRegistry, protocolTokenValidator, identityResolver, transactionContext);
 
     private ParticipantAgent createParticipantAgent() {
-        return new ParticipantAgent(emptyMap(), emptyMap());
+        return new ParticipantAgent("identity", emptyMap(), emptyMap());
     }
 
     private Dataset createDataset() {

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -61,7 +61,6 @@ import org.mockito.ArgumentCaptor;
 
 import java.time.Instant;
 import java.util.Collections;
-import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -80,7 +79,6 @@ import static org.eclipse.edc.connector.controlplane.services.contractnegotiatio
 import static org.eclipse.edc.connector.controlplane.services.contractnegotiation.ContractNegotiationProtocolServiceImplTest.TestFunctions.createContractDefinition;
 import static org.eclipse.edc.connector.controlplane.services.contractnegotiation.ContractNegotiationProtocolServiceImplTest.TestFunctions.createPolicy;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
-import static org.eclipse.edc.participant.spi.ParticipantAgent.PARTICIPANT_IDENTITY;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.BAD_REQUEST;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.CONFLICT;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
@@ -435,7 +433,7 @@ class ContractNegotiationProtocolServiceImplTest {
 
 
     private ParticipantAgent participantAgent() {
-        return new ParticipantAgent(Collections.emptyMap(), Map.of(PARTICIPANT_IDENTITY, "counterPartyId"));
+        return new ParticipantAgent("counterPartyId", Collections.emptyMap(), Collections.emptyMap());
     }
 
     private ContractNegotiation createContractNegotiationRequested() {

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -413,7 +413,7 @@ class TransferProcessProtocolServiceImplTest {
     }
 
     private ParticipantAgent participantAgent() {
-        return new ParticipantAgent(emptyMap(), emptyMap());
+        return new ParticipantAgent("identity", emptyMap(), emptyMap());
     }
 
     private TokenRepresentation tokenRepresentation() {

--- a/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/ContractDefinitionResolverImplTest.java
+++ b/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/ContractDefinitionResolverImplTest.java
@@ -63,7 +63,7 @@ class ContractDefinitionResolverImplTest {
 
     @Test
     void shouldReturnDefinition_whenAccessPolicySatisfied() {
-        var agent = new ParticipantAgent(emptyMap(), emptyMap());
+        var agent = new ParticipantAgent("identity", emptyMap(), emptyMap());
         var def = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
         when(policyStore.findById(any())).thenReturn(def);
         when(policyEngine.evaluate(any(), isA(PolicyContext.class))).thenReturn(Result.success());
@@ -84,7 +84,7 @@ class ContractDefinitionResolverImplTest {
 
     @Test
     void shouldNotReturnDefinition_whenAccessPolicyNotSatisfied() {
-        var agent = new ParticipantAgent(emptyMap(), emptyMap());
+        var agent = new ParticipantAgent("identity", emptyMap(), emptyMap());
         var definition = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).id("access").build();
         when(policyStore.findById(any())).thenReturn(definition);
         var contractDefinition = createContractDefinition();
@@ -100,7 +100,7 @@ class ContractDefinitionResolverImplTest {
 
     @Test
     void shouldNotReturnDefinition_whenAccessPolicyDoesNotExist() {
-        var agent = new ParticipantAgent(emptyMap(), emptyMap());
+        var agent = new ParticipantAgent("identity", emptyMap(), emptyMap());
         when(policyStore.findById(any())).thenReturn(null);
         when(policyEngine.evaluate(any(), isA(PolicyContext.class))).thenReturn(Result.success());
         when(definitionStore.findAll(QuerySpec.max())).thenReturn(Stream.of(createContractDefinition()));
@@ -122,7 +122,7 @@ class ContractDefinitionResolverImplTest {
         when(policyEngine.evaluate(any(), isA(PolicyContext.class))).thenReturn(Result.success());
         when(definitionStore.findAll(any())).thenReturn(Stream.of(contractDefinition1, contractDefinition2));
 
-        var result = resolver.resolveFor(participantContext, new ParticipantAgent(emptyMap(), emptyMap()));
+        var result = resolver.resolveFor(participantContext, new ParticipantAgent("identity", emptyMap(), emptyMap()));
 
         assertThat(result.contractDefinitions()).hasSize(2);
         assertThat(result.policies()).hasSize(1).containsOnly(entry("accessPolicyId", policy));

--- a/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplIntegrationTest.java
+++ b/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplIntegrationTest.java
@@ -171,7 +171,7 @@ class DatasetResolverImplIntegrationTest {
 
     @NotNull
     private ParticipantAgent createAgent() {
-        return new ParticipantAgent(emptyMap(), emptyMap());
+        return new ParticipantAgent("identity", emptyMap(), emptyMap());
     }
 
     private ParticipantContext createParticipantContext() {

--- a/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplTest.java
+++ b/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplTest.java
@@ -94,7 +94,7 @@ class DatasetResolverImplTest {
     }
 
     private ParticipantAgent createParticipantAgent() {
-        return new ParticipantAgent(emptyMap(), emptyMap());
+        return new ParticipantAgent("identity", emptyMap(), emptyMap());
     }
 
     private ParticipantContext createParticipantContext() {

--- a/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ContractNegotiationIntegrationTest.java
+++ b/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ContractNegotiationIntegrationTest.java
@@ -131,7 +131,7 @@ class ContractNegotiationIntegrationTest {
             .participantContextId("participantContextId")
             .identity("identifier")
             .build();
-    protected ParticipantAgent participantAgent = new ParticipantAgent(Collections.emptyMap(), Collections.emptyMap());
+    protected ParticipantAgent participantAgent = new ParticipantAgent("identity", Collections.emptyMap(), Collections.emptyMap());
     protected TokenRepresentation tokenRepresentation = TokenRepresentation.Builder.newInstance().build();
     private String consumerNegotiationId;
     private ProviderContractNegotiationManagerImpl providerManager;

--- a/spi/common/participant-spi/src/main/java/org/eclipse/edc/participant/spi/ParticipantAgent.java
+++ b/spi/common/participant-spi/src/main/java/org/eclipse/edc/participant/spi/ParticipantAgent.java
@@ -15,9 +15,9 @@
 package org.eclipse.edc.participant.spi;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents a system running on behalf of a dataspace participant.
@@ -28,17 +28,15 @@ import java.util.Map;
  * <p>
  * Claims are verifiable claims presented to the current runtime by the ParticipantAgent system, typically as part of a security token or credential store. Attributes are
  * additional values added by the current system based on.
- * <p>
- * Participant agents must have an {@link #PARTICIPANT_IDENTITY} attribute set. The value of the attribute is determined using a dataspace-specific mechanism, but it must be from
- * a trusted source since the value is used to authorize operations such as contract negotiations and data transfers. For example, the identity value may be based on a claim token
- * or a check against a trusted service. The default behavior is to set the identity using the <code>client_id</code> claim, if present. This behavior can be overridden by using a
- * {@link ParticipantAgentServiceExtension}.
  */
 public class ParticipantAgent {
 
     /**
      * The dataspace participant identity attribute key.
+     *
+     * @deprecated replaced by {@link #id}.
      */
+    @Deprecated(since = "0.14.0")
     public static final String PARTICIPANT_IDENTITY = "edc:identity";
 
     private final String id;
@@ -46,7 +44,7 @@ public class ParticipantAgent {
     private final Map<String, String> attributes;
     
     public ParticipantAgent(String id, Map<String, Object> claims, Map<String, String> attributes) {
-        this.id = id;
+        this.id = Objects.requireNonNull(id, "identity cannot be null");
         this.claims = Map.copyOf(claims);
         this.attributes = Map.copyOf(attributes);
     }
@@ -73,9 +71,9 @@ public class ParticipantAgent {
     }
 
     /**
-     * Returns the verified identity of the participant or null if one is not available.
+     * Returns the identity of the participant.
      */
-    @Nullable
+    @NotNull
     public String getIdentity() {
         return id;
     }


### PR DESCRIPTION
## What this PR changes/adds

Anticipate `ParticipantAgent` id non-null validation on the very moment the `ParticipantAgent` is instantiated, so no need to check for its nullability after that.

## Why it does that

_Briefly state why the change was necessary._

## Further notes
- switching all the deprecated `ParticipantAgent` constructor call to the non-deprecated one.


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #5323 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
