### PR TITLE
fix: copy privateEntries on toBuilder()

### DIFF
--- a/spi/common/participant-context-config-spi/src/main/java/org/eclipse/edc/participantcontext/spi/config/model/ParticipantContextConfiguration.java
+++ b/spi/common/participant-context-config-spi/src/main/java/org/eclipse/edc/participantcontext/spi/config/model/ParticipantContextConfiguration.java
@@ -68,6 +68,7 @@ public class ParticipantContextConfiguration implements ParticipantResource {
                 .clock(clock)
                 .createdAt(createdAt)
                 .lastModified(lastModified)
+                .privateEntries(privateEntries)
                 .entries(entries);
     }
 


### PR DESCRIPTION
copies the privateProperties on `toBuilder()`

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
