### PR TITLE
feat: implement data-plane signaling client availability check

### DIFF
--- a/core/common/lib/http-lib/src/main/java/org/eclipse/edc/http/client/ControlApiHttpClientImpl.java
+++ b/core/common/lib/http-lib/src/main/java/org/eclipse/edc/http/client/ControlApiHttpClientImpl.java
@@ -50,11 +50,10 @@ public class ControlApiHttpClientImpl implements ControlApiHttpClient {
                 var response = httpClient.execute(requestBuilder.build(), List.of(retryWhenStatusIsNotIn(200, 204)));
                 var responseBody = response.body();
         ) {
-            var bodyAsString = responseBody == null ? null : responseBody.string();
             if (response.isSuccessful()) {
-                return ServiceResult.success(bodyAsString);
+                return ServiceResult.success(responseBody.string());
             } else {
-                return mapToFailure(response.code(), bodyAsString);
+                return mapToFailure(response.code(), responseBody.string());
             }
         } catch (IOException exception) {
             return ServiceResult.unexpected("Unexpected IOException. " + exception.getMessage());

--- a/data-protocols/data-plane-signaling/build.gradle.kts
+++ b/data-protocols/data-plane-signaling/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 
 dependencies {
     api(project(":spi:common:core-spi"))
+    api(project(":spi:common:http-spi"))
     api(project(":spi:common:web-spi"))
     api(project(":spi:control-plane:contract-spi"))
     api(project(":spi:control-plane:transfer-spi"))

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingClientExtension.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingClientExtension.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.signaling;
+
+import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClientFactory;
+import org.eclipse.edc.http.spi.ControlApiHttpClient;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.signaling.port.DataPlaneSignalingClient;
+import org.eclipse.edc.spi.system.ServiceExtension;
+
+import static org.eclipse.edc.signaling.DataPlaneSignalingClientExtension.NAME;
+
+@Extension(NAME)
+public class DataPlaneSignalingClientExtension implements ServiceExtension {
+
+    public static final String NAME = "Data Plane Signaling client";
+
+    @Inject
+    private ControlApiHttpClient httpClient;
+
+    @Provider
+    public DataPlaneClientFactory dataPlaneClientFactory() {
+        return dataPlane -> new DataPlaneSignalingClient(dataPlane, httpClient);
+    }
+}

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/port/DataPlaneSignalingClient.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/port/DataPlaneSignalingClient.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.signaling.port;
+
+import okhttp3.Request;
+import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClient;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.http.spi.ControlApiHttpClient;
+import org.eclipse.edc.spi.response.ResponseStatus;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowProvisionMessage;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowResponseMessage;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowStartMessage;
+
+import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
+
+/**
+ * Client that implements the Data Plane Signaling spec
+ */
+public class DataPlaneSignalingClient implements DataPlaneClient {
+
+    private final DataPlaneInstance dataPlane;
+    private final ControlApiHttpClient httpClient;
+
+    public DataPlaneSignalingClient(DataPlaneInstance dataPlane, ControlApiHttpClient httpClient) {
+        this.dataPlane = dataPlane;
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public StatusResult<DataFlowResponseMessage> prepare(DataFlowProvisionMessage request) {
+        return StatusResult.failure(ResponseStatus.FATAL_ERROR, "not implemented");
+    }
+
+    @Override
+    public StatusResult<DataFlowResponseMessage> start(DataFlowStartMessage request) {
+        return StatusResult.failure(ResponseStatus.FATAL_ERROR, "not implemented");
+    }
+
+    @Override
+    public StatusResult<Void> suspend(String transferProcessId) {
+        return StatusResult.failure(ResponseStatus.FATAL_ERROR, "not implemented");
+    }
+
+    @Override
+    public StatusResult<Void> terminate(String transferProcessId) {
+        return StatusResult.failure(ResponseStatus.FATAL_ERROR, "not implemented");
+    }
+
+    @Override
+    public StatusResult<Void> checkAvailability() {
+        var requestBuilder = new Request.Builder().get().url(dataPlane.getUrl() + "/");
+        return httpClient.request(requestBuilder)
+                .flatMap(result -> result.map(it -> StatusResult.success()).orElse(failure ->
+                        StatusResult.failure(FATAL_ERROR, "Communication with data-plane %s failed: %s".formatted(dataPlane.getId(), failure.getFailureDetail()))));
+    }
+
+}

--- a/data-protocols/data-plane-signaling/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/data-plane-signaling/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,1 +1,2 @@
 org.eclipse.edc.signaling.DataPlaneSignalingExtension
+org.eclipse.edc.signaling.DataPlaneSignalingClientExtension

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientExtension.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientExtension.java
@@ -77,7 +77,7 @@ public class DataPlaneSignalingClientExtension implements ServiceExtension {
         context.getMonitor().debug(() -> "Using remote Data Plane client.");
         Objects.requireNonNull(httpClient, "To use remote Data Plane client, a ControlApiHttpClient instance must be registered");
         var signalingApiTypeTransformerRegistry = transformerRegistry.forContext("signaling-api");
-        return instance -> new DataPlaneSignalingClient(httpClient, signalingApiTypeTransformerRegistry, jsonLd, CONTROL_CLIENT_SCOPE, typeManager, JSON_LD,
+        return instance -> new LegacyDataPlaneSignalingClient(httpClient, signalingApiTypeTransformerRegistry, jsonLd, CONTROL_CLIENT_SCOPE, typeManager, JSON_LD,
                 instance);
     }
 }

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/LegacyDataPlaneSignalingClient.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/main/java/org/eclipse/edc/connector/dataplane/client/LegacyDataPlaneSignalingClient.java
@@ -47,7 +47,7 @@ import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
  * Implementation of a {@link DataPlaneClient} that uses a remote {@link DataPlaneManager} accessible from a REST API using
  * the data plane signaling protocol.
  */
-public class DataPlaneSignalingClient implements DataPlaneClient {
+public class LegacyDataPlaneSignalingClient implements DataPlaneClient {
     public static final MediaType TYPE_JSON = MediaType.parse("application/json");
     private final ControlApiHttpClient httpClient;
     private final String typeContext;
@@ -58,8 +58,8 @@ public class DataPlaneSignalingClient implements DataPlaneClient {
     private final String jsonLdScope;
     private final TypeManager typeManager;
 
-    public DataPlaneSignalingClient(ControlApiHttpClient httpClient, TypeTransformerRegistry transformerRegistry, JsonLd jsonLd, String jsonLdScope,
-                                    TypeManager typeManager, String typeContext, DataPlaneInstance dataPlane) {
+    public LegacyDataPlaneSignalingClient(ControlApiHttpClient httpClient, TypeTransformerRegistry transformerRegistry, JsonLd jsonLd, String jsonLdScope,
+                                          TypeManager typeManager, String typeContext, DataPlaneInstance dataPlane) {
         this.httpClient = httpClient;
         this.transformerRegistry = transformerRegistry;
         this.jsonLd = jsonLd;

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientExtensionTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientExtensionTest.java
@@ -46,7 +46,7 @@ class DataPlaneSignalingClientExtensionTest {
 
         var client = extension.dataPlaneClientFactory(context).createClient(createDataPlaneInstance());
 
-        assertThat(client).isInstanceOf(DataPlaneSignalingClient.class);
+        assertThat(client).isInstanceOf(LegacyDataPlaneSignalingClient.class);
         verify(jsonLd).registerNamespace(ODRL_PREFIX, ODRL_SCHEMA, CONTROL_CLIENT_SCOPE);
         verify(jsonLd).registerNamespace(DSPACE_PREFIX, DSPACE_SCHEMA, CONTROL_CLIENT_SCOPE);
         verify(jsonLd).registerNamespace(VOCAB, EDC_NAMESPACE, CONTROL_CLIENT_SCOPE);

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientTest.java
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-client/src/test/java/org/eclipse/edc/connector/dataplane/client/DataPlaneSignalingClientTest.java
@@ -102,7 +102,7 @@ class DataPlaneSignalingClientTest {
     private final DataPlaneInstance instance = DataPlaneInstance.Builder.newInstance().url(DATA_PLANE_API_URI).build();
     private final ControlApiHttpClient httpClient = new ControlApiHttpClientImpl(testHttpClient(), mock());
 
-    private final DataPlaneClient dataPlaneClient = new DataPlaneSignalingClient(httpClient, TRANSFORMER_REGISTRY,
+    private final DataPlaneClient dataPlaneClient = new LegacyDataPlaneSignalingClient(httpClient, TRANSFORMER_REGISTRY,
             JSON_LD, CONTROL_CLIENT_SCOPE, TYPE_MANAGER, "test", instance);
 
     @BeforeAll
@@ -181,7 +181,7 @@ class DataPlaneSignalingClientTest {
         void verifyReturnFatalErrorIfTransformFails() {
             var flowRequest = createDataFlowRequest();
             TypeTransformerRegistry registry = mock();
-            var dataPlaneClient = new DataPlaneSignalingClient(httpClient, registry, JSON_LD, CONTROL_CLIENT_SCOPE, TYPE_MANAGER, "test", instance);
+            var dataPlaneClient = new LegacyDataPlaneSignalingClient(httpClient, registry, JSON_LD, CONTROL_CLIENT_SCOPE, TYPE_MANAGER, "test", instance);
 
             when(registry.transform(any(), any())).thenReturn(Result.failure("Transform Failure"));
 
@@ -331,7 +331,7 @@ class DataPlaneSignalingClientTest {
         void verifyReturnFatalErrorIfTransformFails() {
             var request = createProvisionRequest();
             TypeTransformerRegistry registry = mock();
-            var dataPlaneClient = new DataPlaneSignalingClient(httpClient, registry, JSON_LD, CONTROL_CLIENT_SCOPE, TYPE_MANAGER, "test", instance);
+            var dataPlaneClient = new LegacyDataPlaneSignalingClient(httpClient, registry, JSON_LD, CONTROL_CLIENT_SCOPE, TYPE_MANAGER, "test", instance);
 
             when(registry.transform(any(), any())).thenReturn(Result.failure("Transform Failure"));
 
@@ -457,7 +457,7 @@ class DataPlaneSignalingClientTest {
         @Test
         void verifyReturnFatalErrorIfTransformFails() {
             TypeTransformerRegistry registry = mock();
-            var dataPlaneClient = new DataPlaneSignalingClient(httpClient, registry, JSON_LD, CONTROL_CLIENT_SCOPE, TYPE_MANAGER, "test", instance);
+            var dataPlaneClient = new LegacyDataPlaneSignalingClient(httpClient, registry, JSON_LD, CONTROL_CLIENT_SCOPE, TYPE_MANAGER, "test", instance);
 
             when(registry.transform(any(), any())).thenReturn(Result.failure("Transform Failure"));
 
@@ -500,7 +500,7 @@ class DataPlaneSignalingClientTest {
         @Test
         void verifyReturnFatalErrorIfTransformFails() {
             TypeTransformerRegistry registry = mock();
-            var dataPlaneClient = new DataPlaneSignalingClient(httpClient, registry, JSON_LD, CONTROL_CLIENT_SCOPE, TYPE_MANAGER, "test", instance);
+            var dataPlaneClient = new LegacyDataPlaneSignalingClient(httpClient, registry, JSON_LD, CONTROL_CLIENT_SCOPE, TYPE_MANAGER, "test", instance);
 
             when(registry.transform(any(), any())).thenReturn(Result.failure("Transform Failure"));
 

--- a/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/control-plane/build.gradle.kts
@@ -17,15 +17,9 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":dist:bom:controlplane-base-bom"))
-    implementation(project(":core:common:edr-store-core"))
-    implementation(project(":core:common:token-core"))
-    implementation(project(":core:control-plane:control-plane-core"))
-    implementation(project(":data-protocols:dsp"))
-    implementation(project(":data-protocols:dsp:dsp-2025"))
-    implementation(project(":extensions:common:http"))
-    implementation(project(":extensions:common:api:control-api-configuration"))
-    implementation(project(":extensions:common:api:management-api-configuration"))
+    implementation(project(":dist:bom:controlplane-base-bom")) {
+        exclude(group = "org.eclipse.edc", module = "transfer-data-plane-signaling")
+    }
     implementation(project(":extensions:common:iam:iam-mock"))
 }
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Runtimes.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Runtimes.java
@@ -32,7 +32,8 @@ public interface Runtimes {
 
         String[] MODULES = new String[]{
                 ":system-tests:e2e-transfer-test:control-plane",
-                ":extensions:data-plane:data-plane-signaling:data-plane-signaling-client"
+                ":extensions:data-plane:data-plane-signaling:data-plane-signaling-client",
+                ":extensions:control-plane:transfer:transfer-data-plane-signaling"
         };
 
         String[] SIGNALING_MODULES = new String[]{
@@ -42,7 +43,8 @@ public interface Runtimes {
 
         String[] EMBEDDED_DP_MODULES = new String[]{
                 ":system-tests:e2e-transfer-test:control-plane",
-                ":system-tests:e2e-transfer-test:data-plane"
+                ":system-tests:e2e-transfer-test:data-plane",
+                ":extensions:control-plane:transfer:transfer-data-plane-signaling"
         };
 
         String[] SQL_MODULES = new String[]{
@@ -53,7 +55,6 @@ public interface Runtimes {
                 .endpoint("management", () -> URI.create("http://localhost:" + getFreePort() + "/management"))
                 .endpoint("control", () -> URI.create("http://localhost:" + getFreePort() + "/control"))
                 .endpoint("protocol", () -> URI.create("http://localhost:" + getFreePort() + "/protocol"));
-
 
         static Config config(String participantId) {
             return ConfigFactory.fromMap(new HashMap<>() {

--- a/system-tests/e2e-transfer-test/signaling-data-plane/src/main/java/org/eclipse/edc/test/runtime/signaling/SignalingDataPlaneRuntimeExtension.java
+++ b/system-tests/e2e-transfer-test/signaling-data-plane/src/main/java/org/eclipse/edc/test/runtime/signaling/SignalingDataPlaneRuntimeExtension.java
@@ -21,7 +21,7 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebService;
 
-public class SignalingDataPlaneExtension implements ServiceExtension {
+public class SignalingDataPlaneRuntimeExtension implements ServiceExtension {
 
     @Setting(key = "signaling.dataplane.controlplane.endpoint")
     private String controlplaneEndpoint;

--- a/system-tests/e2e-transfer-test/signaling-data-plane/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/system-tests/e2e-transfer-test/signaling-data-plane/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,1 +1,1 @@
-org.eclipse.edc.test.runtime.signaling.SignalingDataPlaneExtension
+org.eclipse.edc.test.runtime.signaling.SignalingDataPlaneRuntimeExtension


### PR DESCRIPTION
## What this PR changes/adds

Implements data-plane availability check through the provisioning of the new `DataPlaneClientFactory` and relative `DataPlaneSignalingClient` implementation.

the current client has been renamed with a leading `Legacy` term

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #5323 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
