### PR TITLE
fix: participant context when using memory

### DIFF
--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/BaseAssetApiController.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/BaseAssetApiController.java
@@ -55,23 +55,23 @@ public abstract class BaseAssetApiController {
     public JsonObject createAsset(JsonObject assetJson) {
         validator.validate(EDC_ASSET_TYPE, assetJson).orElseThrow(ValidationFailureException::new);
         var participantContext = participantContextSupplier.get()
-                                         .orElseThrow(exceptionMapper(Asset.class));
+                .orElseThrow(exceptionMapper(Asset.class));
 
         var asset = transformerRegistry.transform(assetJson, Asset.class)
-                            .orElseThrow(InvalidRequestException::new)
-                            .toBuilder()
-                            .participantContextId(participantContext.getParticipantContextId())
-                            .build();
+                .orElseThrow(InvalidRequestException::new)
+                .toBuilder()
+                .participantContextId(participantContext.getParticipantContextId())
+                .build();
 
         var idResponse = service.create(asset)
-                                 .map(a -> IdResponse.Builder.newInstance()
-                                                   .id(a.getId())
-                                                   .createdAt(a.getCreatedAt())
-                                                   .build())
-                                 .orElseThrow(exceptionMapper(Asset.class, asset.getId()));
+                .map(a -> IdResponse.Builder.newInstance()
+                        .id(a.getId())
+                        .createdAt(a.getCreatedAt())
+                        .build())
+                .orElseThrow(exceptionMapper(Asset.class, asset.getId()));
 
         return transformerRegistry.transform(idResponse, JsonObject.class)
-                       .orElseThrow(f -> new EdcException(f.getFailureDetail()));
+                .orElseThrow(f -> new EdcException(f.getFailureDetail()));
     }
 
     public JsonArray requestAssets(JsonObject querySpecJson) {
@@ -82,24 +82,24 @@ public abstract class BaseAssetApiController {
             validator.validate(EDC_QUERY_SPEC_TYPE, querySpecJson).orElseThrow(ValidationFailureException::new);
 
             querySpec = transformerRegistry.transform(querySpecJson, QuerySpec.class)
-                                .orElseThrow(InvalidRequestException::new);
+                    .orElseThrow(InvalidRequestException::new);
         }
 
         return service.search(querySpec).orElseThrow(exceptionMapper(QuerySpec.class, null)).stream()
-                       .map(it -> transformerRegistry.transform(it, JsonObject.class))
-                       .peek(r -> r.onFailure(f -> monitor.warning(f.getFailureDetail())))
-                       .filter(Result::succeeded)
-                       .map(Result::getContent)
-                       .collect(toJsonArray());
+                .map(it -> transformerRegistry.transform(it, JsonObject.class))
+                .peek(r -> r.onFailure(f -> monitor.warning(f.getFailureDetail())))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .collect(toJsonArray());
     }
 
     public JsonObject getAsset(String id) {
         var asset = of(id)
-                            .map(it -> service.findById(id))
-                            .orElseThrow(() -> new ObjectNotFoundException(Asset.class, id));
+                .map(it -> service.findById(id))
+                .orElseThrow(() -> new ObjectNotFoundException(Asset.class, id));
 
         return transformerRegistry.transform(asset, JsonObject.class)
-                       .orElseThrow(f -> new EdcException(f.getFailureDetail()));
+                .orElseThrow(f -> new EdcException(f.getFailureDetail()));
 
     }
 
@@ -109,9 +109,14 @@ public abstract class BaseAssetApiController {
 
     public void updateAsset(JsonObject assetJson) {
         validator.validate(EDC_ASSET_TYPE, assetJson).orElseThrow(ValidationFailureException::new);
+        var participantContext = participantContextSupplier.get()
+                .orElseThrow(exceptionMapper(Asset.class));
 
         var assetResult = transformerRegistry.transform(assetJson, Asset.class)
-                                  .orElseThrow(InvalidRequestException::new);
+                .orElseThrow(InvalidRequestException::new)
+                .toBuilder()
+                .participantContextId(participantContext.getParticipantContextId())
+                .build();
 
         service.update(assetResult)
                 .orElseThrow(exceptionMapper(Asset.class, assetResult.getId()));

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/BaseAssetApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/BaseAssetApiControllerTest.java
@@ -56,6 +56,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -350,7 +351,9 @@ public abstract class BaseAssetApiControllerTest extends RestControllerTestBase 
 
     @Test
     void updateAsset_whenExists() {
-        var asset = Asset.Builder.newInstance().property("key1", "value1").build();
+        var asset = Asset.Builder.newInstance().property("key1", "value1")
+                .participantContextId(participantContext.getParticipantContextId())
+                .build();
         when(transformerRegistry.transform(isA(JsonObject.class), eq(Asset.class))).thenReturn(Result.success(asset));
         when(service.update(any(Asset.class))).thenReturn(ServiceResult.success());
         when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
@@ -361,7 +364,7 @@ public abstract class BaseAssetApiControllerTest extends RestControllerTestBase 
                 .put("/assets")
                 .then()
                 .statusCode(204);
-        verify(service).update(eq(asset));
+        verify(service).update(refEq(asset));
     }
 
     @Test

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/BaseContractDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/BaseContractDefinitionApiController.java
@@ -112,8 +112,14 @@ public abstract class BaseContractDefinitionApiController {
         validatorRegistry.validate(CONTRACT_DEFINITION_TYPE, updateObject)
                 .orElseThrow(ValidationFailureException::new);
 
+        var participantContext = participantContextSupplier.get()
+                .orElseThrow(exceptionMapper(ContractDefinition.class));
+
         var contractDefinition = transformerRegistry.transform(updateObject, ContractDefinition.class)
-                .orElseThrow(InvalidRequestException::new);
+                .orElseThrow(InvalidRequestException::new)
+                .toBuilder()
+                .participantContextId(participantContext.getParticipantContextId())
+                .build();
 
         service.update(contractDefinition).orElseThrow(exceptionMapper(ContractDefinition.class));
     }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/BasePolicyDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/BasePolicyDefinitionApiController.java
@@ -121,8 +121,14 @@ public abstract class BasePolicyDefinitionApiController {
     public void updatePolicyDefinition(String id, JsonObject input) {
         validatorRegistry.validate(EDC_POLICY_DEFINITION_TYPE, input).orElseThrow(ValidationFailureException::new);
 
+        var participantContext = participantContextSupplier.get()
+                .orElseThrow(exceptionMapper(PolicyDefinition.class));
+
         var policyDefinition = transformerRegistry.transform(input, PolicyDefinition.class)
-                .orElseThrow(InvalidRequestException::new);
+                .orElseThrow(InvalidRequestException::new)
+                .toBuilder()
+                .participantContextId(participantContext.getParticipantContextId())
+                .build();
 
         service.update(policyDefinition)
                 .onSuccess(d -> monitor.debug(format("Policy Definition updated %s", d.getId())))

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/AssetApiEndToEndTest.java
@@ -409,6 +409,8 @@ public class AssetApiEndToEndTest {
             assertThat(dbAsset.getDataAddress().getProperty(EDC_NAMESPACE + "complex"))
                     .asInstanceOf(MAP)
                     .containsEntry(EDC_NAMESPACE + "nested", List.of(Map.of(VALUE, "value")));
+
+            assertThat(dbAsset.getParticipantContextId()).isNotNull();
         }
 
         private DataAddress.Builder createDataAddress() {

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractDefinitionApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/ContractDefinitionApiEndToEndTest.java
@@ -174,6 +174,7 @@ public class ContractDefinitionApiEndToEndTest {
             var actual = store.findById(id);
 
             assertThat(actual.getId()).matches(id);
+            assertThat(actual.getParticipantContextId()).isNotNull();
         }
 
         @Test
@@ -212,6 +213,7 @@ public class ContractDefinitionApiEndToEndTest {
             var actual = store.findById(id);
 
             assertThat(actual.getAccessPolicyId()).isEqualTo("new-policy");
+            assertThat(actual.getParticipantContextId()).isNotNull();
         }
 
         @Test

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/PolicyDefinitionApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/PolicyDefinitionApiEndToEndTest.java
@@ -122,6 +122,9 @@ public class PolicyDefinitionApiEndToEndTest {
             assertThat(result).isNotNull()
                     .extracting(PolicyDefinition::getPrivateProperties).isEqualTo(privateProp);
 
+            assertThat(result.getParticipantContextId()).isNotNull();
+
+
             context.baseRequest()
                     .get("/v3/policydefinitions/" + id)
                     .then()
@@ -219,10 +222,13 @@ public class PolicyDefinitionApiEndToEndTest {
                     .then()
                     .statusCode(204);
 
-            assertThat(store.findById(id))
+            var policyDef = store.findById(id);
+            assertThat(policyDef)
                     .extracting(PolicyDefinition::getPrivateProperties)
                     .asInstanceOf(MAP)
                     .isNotEmpty();
+
+            assertThat(policyDef.getParticipantContextId()).isNotNull();
         }
 
         @Test

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
@@ -136,6 +136,8 @@ public class AssetApiV4EndToEndTest {
                     .asInstanceOf(MAP)
                     .containsEntry(EDC_NAMESPACE + "simple", List.of(Map.of(VALUE, "value")))
                     .containsEntry(EDC_NAMESPACE + "nested", List.of(Map.of(EDC_NAMESPACE + "innerValue", List.of(Map.of(VALUE, "value")))));
+
+            assertThat(asset.getParticipantContextId()).isNotNull();
         }
 
         @Test
@@ -425,6 +427,8 @@ public class AssetApiV4EndToEndTest {
             assertThat(dbAsset.getDataAddress().getProperty(EDC_NAMESPACE + "complex"))
                     .asInstanceOf(MAP)
                     .containsEntry(EDC_NAMESPACE + "nested", List.of(Map.of(VALUE, "value")));
+
+            assertThat(dbAsset.getParticipantContextId()).isNotNull();
         }
 
         private DataAddress.Builder createDataAddress() {

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractDefinitionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/ContractDefinitionApiV4EndToEndTest.java
@@ -175,6 +175,8 @@ public class ContractDefinitionApiV4EndToEndTest {
             var actual = store.findById(id);
 
             assertThat(actual.getId()).matches(id);
+            assertThat(actual.getParticipantContextId()).isNotNull();
+
         }
 
         @Test

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/PolicyDefinitionApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/PolicyDefinitionApiV4EndToEndTest.java
@@ -116,7 +116,7 @@ public class PolicyDefinitionApiV4EndToEndTest {
             privateProp.put("https://w3id.org/edc/v0.0.1/ns/newKey", "newValue");
             assertThat(result).isNotNull()
                     .extracting(PolicyDefinition::getPrivateProperties).isEqualTo(privateProp);
-
+            assertThat(result.getParticipantContextId()).isNotNull();
             context.baseRequest()
                     .get("/v4beta/policydefinitions/" + id)
                     .then()
@@ -209,10 +209,13 @@ public class PolicyDefinitionApiV4EndToEndTest {
                     .then()
                     .statusCode(204);
 
-            assertThat(store.findById(id))
+            var policyDef = store.findById(id);
+            assertThat(policyDef)
                     .extracting(PolicyDefinition::getPrivateProperties)
                     .asInstanceOf(MAP)
                     .isNotEmpty();
+
+            assertThat(policyDef.getParticipantContextId()).isNotNull();
         }
 
         @Test


### PR DESCRIPTION
## What this PR changes/adds

When using memory the `participantContextId` gets override to `null` 

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
