### PR TITLE
feat: support dataplane signaling non-finite push type

### DIFF
--- a/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
@@ -435,7 +435,7 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
                 .doProcess(futureResult("Dispatch TransferCompletionMessage to " + process.getCounterPartyAddress(),
                         (t, dataFlowResponse) -> {
                             if (t.completionWasRequestedByCounterParty()) {
-                                var result = dataFlowManager.terminate(t);
+                                var result = dataFlowManager.completed(t);
                                 return completedFuture(result.mapEmpty());
                             } else {
                                 return dispatch(builder, t, Object.class);

--- a/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
+++ b/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
@@ -534,7 +534,7 @@ class TransferProcessManagerImplTest {
         }
 
         @Test
-        void shouldTerminateDataFlow_whenTransferCompletedByCounterPart() {
+        void shouldNotifyDataFlowCompletion_whenTransferCompletedByCounterPart() {
             var process = createTransferProcessBuilder(COMPLETING_REQUESTED).type(CONSUMER).correlationId("correlationId").build();
             when(transferProcessStore.nextNotLeased(anyInt(), stateIs(COMPLETING_REQUESTED.code()))).thenReturn(List.of(process)).thenReturn(emptyList());
             when(transferProcessStore.findById(process.getId())).thenReturn(process, process.toBuilder().state(COMPLETING_REQUESTED.code()).build());
@@ -543,7 +543,7 @@ class TransferProcessManagerImplTest {
             manager.start();
 
             await().untilAsserted(() -> {
-                verify(dataFlowManager).terminate(process);
+                verify(dataFlowManager).completed(process);
             });
         }
     }

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/flow/DataFlowManagerImpl.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/flow/DataFlowManagerImpl.java
@@ -104,6 +104,13 @@ public class DataFlowManagerImpl implements DataFlowManager {
     }
 
     @Override
+    public @NotNull StatusResult<Void> completed(TransferProcess transferProcess) {
+        return chooseController(transferProcess)
+                .map(controller -> controller.completed(transferProcess))
+                .orElseGet(() -> StatusResult.failure(FATAL_ERROR, controllerNotFound(transferProcess.getId())));
+    }
+
+    @Override
     public Set<String> transferTypesFor(Asset asset) {
         return controllers.stream()
                 .map(it -> it.controller)

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowController.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowController.java
@@ -140,7 +140,15 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
 
     @Override
     public StatusResult<Void> suspend(TransferProcess transferProcess) {
-        return StatusResult.failure(FATAL_ERROR, "not implemented");
+        var dataPlaneId = transferProcess.getDataPlaneId();
+        if (dataPlaneId == null) {
+            return StatusResult.fatalError("DataPlane id is null");
+        }
+
+        return selectorClient.findById(transferProcess.getDataPlaneId())
+                .flatMap(this::toStatusResult)
+                .map(clientFactory::createClient)
+                .compose(client -> client.suspend(transferProcess.getId()));
     }
 
     @Override
@@ -154,6 +162,19 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
                 .flatMap(this::toStatusResult)
                 .map(clientFactory::createClient)
                 .compose(client -> client.terminate(transferProcess.getId()));
+    }
+
+    @Override
+    public StatusResult<Void> completed(TransferProcess transferProcess) {
+        var dataPlaneId = transferProcess.getDataPlaneId();
+        if (dataPlaneId == null) {
+            return StatusResult.fatalError("DataPlane id is null");
+        }
+
+        return selectorClient.findById(transferProcess.getDataPlaneId())
+                .flatMap(this::toStatusResult)
+                .map(clientFactory::createClient)
+                .compose(client -> client.completed(transferProcess.getId()));
     }
 
     @Override

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/port/DataPlaneSignalingClient.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/port/DataPlaneSignalingClient.java
@@ -24,10 +24,10 @@ import org.eclipse.edc.http.spi.ControlApiHttpClient;
 import org.eclipse.edc.signaling.domain.DataFlowPrepareMessage;
 import org.eclipse.edc.signaling.domain.DataFlowResponseMessage;
 import org.eclipse.edc.signaling.domain.DataFlowStartMessage;
-import org.eclipse.edc.spi.response.ResponseStatus;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceFailure;
+import org.eclipse.edc.spi.types.domain.transfer.DataFlowSuspendMessage;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -71,11 +71,30 @@ public class DataPlaneSignalingClient {
     }
 
     public StatusResult<Void> suspend(String transferProcessId) {
-        return StatusResult.failure(ResponseStatus.FATAL_ERROR, "not implemented");
+        var url = "%s/%s/suspend".formatted(dataPlane.getUrl(), transferProcessId);
+        var message = DataFlowSuspendMessage.Builder.newInstance().build();
+        return createRequestBuilder(message, url)
+                .compose(builder -> httpClient.request(builder)
+                        .flatMap(result -> result.map(it -> StatusResult.success())
+                                .orElse(this::failedResult)));
     }
 
     public StatusResult<Void> terminate(String transferProcessId) {
-        return StatusResult.success();
+        var url = "%s/%s/terminate".formatted(dataPlane.getUrl(), transferProcessId);
+        var message = DataFlowSuspendMessage.Builder.newInstance().build();
+        return createRequestBuilder(message, url)
+                .compose(builder -> httpClient.request(builder)
+                        .flatMap(result -> result.map(it -> StatusResult.success())
+                                .orElse(this::failedResult)));
+    }
+
+    public StatusResult<Void> completed(String flowId) {
+        var url = "%s/%s/completed".formatted(dataPlane.getUrl(), flowId);
+        var message = DataFlowSuspendMessage.Builder.newInstance().build();
+        return createRequestBuilder(message, url)
+                .compose(builder -> httpClient.request(builder)
+                        .flatMap(result -> result.map(it -> StatusResult.success())
+                                .orElse(this::failedResult)));
     }
 
     public StatusResult<Void> checkAvailability() {
@@ -123,5 +142,4 @@ public class DataPlaneSignalingClient {
             return Result.failure(e.getMessage());
         }
     }
-
 }

--- a/data-protocols/data-plane-signaling/src/test/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowControllerTest.java
+++ b/data-protocols/data-plane-signaling/src/test/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowControllerTest.java
@@ -213,6 +213,112 @@ public class DataPlaneSignalingFlowControllerTest {
     }
 
     @Nested
+    class Completed {
+
+        @Test
+        void shouldCallComplete() {
+            var transferProcess = TransferProcess.Builder.newInstance()
+                    .id("transferProcessId")
+                    .contentDataAddress(testDataAddress())
+                    .dataPlaneId("dataPlaneId")
+                    .build();
+            when(dataPlaneClient.completed(any())).thenReturn(StatusResult.success());
+            var dataPlaneInstance = dataPlaneInstanceBuilder().id("dataPlaneId").build();
+            when(clientFactory.createClient(any())).thenReturn(dataPlaneClient);
+            when(selectorService.findById(any())).thenReturn(ServiceResult.success(dataPlaneInstance));
+
+            var result = flowController.completed(transferProcess);
+
+            assertThat(result).isSucceeded();
+            verify(dataPlaneClient).completed("transferProcessId");
+            verify(clientFactory).createClient(dataPlaneInstance);
+        }
+
+        @Test
+        void shouldFail_whenDataPlaneDoesNotExist() {
+            var transferProcess = TransferProcess.Builder.newInstance()
+                    .id("transferProcessId")
+                    .contentDataAddress(testDataAddress())
+                    .dataPlaneId("invalid")
+                    .build();
+            when(selectorService.findById(any())).thenReturn(ServiceResult.notFound("not found"));
+
+            var result = flowController.completed(transferProcess);
+
+            assertThat(result).isFailed();
+            verifyNoInteractions(dataPlaneClient, clientFactory);
+        }
+
+        @Test
+        void shouldFail_whenDataPlaneIdIsNull() {
+            var transferProcess = TransferProcess.Builder.newInstance()
+                    .id("transferProcessId")
+                    .contentDataAddress(testDataAddress())
+                    .dataPlaneId(null)
+                    .build();
+
+            var result = flowController.completed(transferProcess);
+
+            assertThat(result).isFailed();
+            verifyNoInteractions(dataPlaneClient, clientFactory, selectorService);
+        }
+
+    }
+
+    @Nested
+    class Suspend {
+
+        @Test
+        void shouldCallSuspend() {
+            var transferProcess = TransferProcess.Builder.newInstance()
+                    .id("transferProcessId")
+                    .contentDataAddress(testDataAddress())
+                    .dataPlaneId("dataPlaneId")
+                    .build();
+            when(dataPlaneClient.suspend(any())).thenReturn(StatusResult.success());
+            var dataPlaneInstance = dataPlaneInstanceBuilder().id("dataPlaneId").build();
+            when(clientFactory.createClient(any())).thenReturn(dataPlaneClient);
+            when(selectorService.findById(any())).thenReturn(ServiceResult.success(dataPlaneInstance));
+
+            var result = flowController.suspend(transferProcess);
+
+            assertThat(result).isSucceeded();
+            verify(dataPlaneClient).suspend("transferProcessId");
+            verify(clientFactory).createClient(dataPlaneInstance);
+        }
+
+        @Test
+        void shouldFail_whenDataPlaneDoesNotExist() {
+            var transferProcess = TransferProcess.Builder.newInstance()
+                    .id("transferProcessId")
+                    .contentDataAddress(testDataAddress())
+                    .dataPlaneId("invalid")
+                    .build();
+            when(selectorService.findById(any())).thenReturn(ServiceResult.notFound("not found"));
+
+            var result = flowController.suspend(transferProcess);
+
+            assertThat(result).isFailed();
+            verifyNoInteractions(dataPlaneClient, clientFactory);
+        }
+
+        @Test
+        void shouldFail_whenDataPlaneIdIsNull() {
+            var transferProcess = TransferProcess.Builder.newInstance()
+                    .id("transferProcessId")
+                    .contentDataAddress(testDataAddress())
+                    .dataPlaneId(null)
+                    .build();
+
+            var result = flowController.suspend(transferProcess);
+
+            assertThat(result).isFailed();
+            verifyNoInteractions(dataPlaneClient, clientFactory, selectorService);
+        }
+
+    }
+
+    @Nested
     class TransferTypes {
 
         @Test

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
@@ -477,6 +477,12 @@ public class Participant {
                 .extract().body().jsonPath().getString("state");
     }
 
+    public String getTransferProcessIdGivenCounterPartyOne(String consumerTransferProcessId) {
+        return getTransferProcesses().stream()
+                .filter(filter -> filter.asJsonObject().getString("correlationId").equals(consumerTransferProcessId))
+                .map(id -> id.asJsonObject().getString("@id")).findFirst().orElseThrow();
+    }
+
     /**
      * Suspend the transfer process
      *

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/LegacyDataPlaneSignalingFlowController.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/LegacyDataPlaneSignalingFlowController.java
@@ -180,6 +180,11 @@ public class LegacyDataPlaneSignalingFlowController implements DataFlowControlle
     }
 
     @Override
+    public StatusResult<Void> completed(TransferProcess transferProcess) {
+        return terminate(transferProcess);
+    }
+
+    @Override
     public Set<String> transferTypesFor(Asset asset) {
         var allDataPlanes = selectorClient.getAll();
         if (allDataPlanes.failed()) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ atomikos = "6.0.0"
 awaitility = "4.2.2"
 bouncyCastle-jdk18on = "1.83"
 cloudEvents = "4.0.1"
+dataplane-sdk = "0.0.2-SNAPSHOT"
 edc = "0.16.0-SNAPSHOT"
 failsafe = "3.3.2"
 h2 = "2.4.240"
@@ -50,6 +51,7 @@ assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
 bouncyCastle-bcpkixJdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncyCastle-jdk18on" }
 bouncyCastle-bcprovJdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncyCastle-jdk18on" }
+dataplane-sdk = { module = "org.eclipse.dataplane-core:dataplane-sdk", version.ref = "dataplane-sdk" }
 dnsOverHttps = { module = "com.squareup.okhttp3:okhttp-dnsoverhttps", version.ref = "okhttp" }
 edc-runtime-metamodel = { module = "org.eclipse.edc:runtime-metamodel", version.ref = "edc" }
 failsafe-core = { module = "dev.failsafe:failsafe", version.ref = "failsafe" }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/response/StatusResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/response/StatusResult.java
@@ -52,6 +52,10 @@ public class StatusResult<T> extends AbstractResult<T, ResponseFailure, StatusRe
         return new StatusResult<>(null, new ResponseFailure(status, List.of(error)));
     }
 
+    public static StatusResult<Void> fatalError(String error) {
+        return failure(FATAL_ERROR, error);
+    }
+
     public boolean fatalError() {
         return failed() && getFailure().status() == FATAL_ERROR;
     }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowController.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowController.java
@@ -75,6 +75,14 @@ public interface DataFlowController {
     StatusResult<Void> terminate(TransferProcess transferProcess);
 
     /**
+     * Notify data flow completion.
+     *
+     * @param transferProcess the transfer process.
+     * @return success if the notification has been delivered correctly, failure otherwise;
+     */
+    StatusResult<Void> completed(TransferProcess transferProcess);
+
+    /**
      * Returns transfer types that the controller can handle for the specified Asset.
      *
      * @return transfer type set.

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowManager.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/DataFlowManager.java
@@ -84,6 +84,15 @@ public interface DataFlowManager {
     StatusResult<Void> suspend(TransferProcess transferProcess);
 
     /**
+     * Notify data flow completion.
+     *
+     * @param transferProcess the transfer process.
+     * @return success if the flow completion notification has been delivered correctly, failed otherwise.
+     */
+    @NotNull
+    StatusResult<Void> completed(TransferProcess transferProcess);
+
+    /**
      * Returns the transfer types available for a specific asset.
      *
      * @param asset the asset.

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
@@ -208,9 +208,7 @@ class TransferPullEndToEndTest {
 
             var edrEntry = assertConsumerCanAccessData(consumer, consumerTransferProcessId);
 
-            var providerTransferProcessId = provider.getTransferProcesses().stream()
-                    .filter(filter -> filter.asJsonObject().getString("correlationId").equals(consumerTransferProcessId))
-                    .map(id -> id.asJsonObject().getString("@id")).findFirst().orElseThrow();
+            var providerTransferProcessId = provider.getTransferProcessIdGivenCounterPartyOne(consumerTransferProcessId);
 
             provider.suspendTransfer(providerTransferProcessId, "supension");
 
@@ -270,9 +268,7 @@ class TransferPullEndToEndTest {
 
             var edrEntry = assertConsumerCanAccessData(consumer, consumerTransferProcessId);
 
-            var providerTransferProcessId = provider.getTransferProcesses().stream()
-                    .filter(filter -> filter.asJsonObject().getString("correlationId").equals(consumerTransferProcessId))
-                    .map(id -> id.asJsonObject().getString("@id")).findFirst().orElseThrow();
+            var providerTransferProcessId = provider.getTransferProcessIdGivenCounterPartyOne(consumerTransferProcessId);
 
             provider.terminateTransfer(providerTransferProcessId);
 
@@ -296,9 +292,7 @@ class TransferPullEndToEndTest {
 
             var edrEntry = assertConsumerCanAccessData(consumer, consumerTransferProcessId);
 
-            var providerTransferProcessId = provider.getTransferProcesses().stream()
-                    .filter(filter -> filter.asJsonObject().getString("correlationId").equals(consumerTransferProcessId))
-                    .map(id -> id.asJsonObject().getString("@id")).findFirst().orElseThrow();
+            var providerTransferProcessId = provider.getTransferProcessIdGivenCounterPartyOne(consumerTransferProcessId);
 
             consumer.terminateTransfer(consumerTransferProcessId);
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/dataplane/DataPlaneSignalingClient.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/dataplane/DataPlaneSignalingClient.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.dataplane;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.eclipse.edc.junit.extensions.ComponentRuntimeContext;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class DataPlaneSignalingClient {
+    private final ComponentRuntimeContext context;
+
+    public DataPlaneSignalingClient(ComponentRuntimeContext context) {
+        this.context = context;
+    }
+
+    public void awaitFlowToBe(String flowId, String status) {
+        await().untilAsserted(() -> {
+            var uri = context.getEndpoint("default").get();
+            RestAssured.given()
+                    .baseUri(uri.toString())
+                    .get("/v1/dataflows/{flowId}/status", flowId)
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .contentType(ContentType.JSON)
+                    .body("state", equalTo(status));
+        });
+    }
+}

--- a/system-tests/e2e-transfer-test/signaling-data-plane/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/signaling-data-plane/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
 dependencies {
     implementation(project(":core:common:runtime-core"))
     implementation(project(":extensions:common:http"))
-    implementation("org.eclipse.dataplane-core:dataplane-sdk:0.0.1-SNAPSHOT") // TODO: put in version catalog
+    implementation(libs.dataplane.sdk)
 }
 
 edcBuild {


### PR DESCRIPTION
## What this PR changes/adds

Supports dataplane signaling non-finite push type

## Why it does that

dataplane signaling

## Further notes
- added the `completed` signal on the flow controller


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #5323 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
