### PR TITLE
fix: policy evaluation NPE

### DIFF
--- a/core/common/lib/policy-evaluator-lib/src/main/java/org/eclipse/edc/policy/evaluator/PolicyEvaluator.java
+++ b/core/common/lib/policy-evaluator-lib/src/main/java/org/eclipse/edc/policy/evaluator/PolicyEvaluator.java
@@ -156,27 +156,35 @@ public class PolicyEvaluator implements Policy.Visitor<Boolean>, Rule.Visitor<Bo
 
     @Override
     public Boolean visitAtomicConstraint(AtomicConstraint constraint) {
-        var rightValue = constraint.getRightExpression().accept(this);
         var leftRawValue = constraint.getLeftExpression().accept(this);
-        if (leftRawValue instanceof String) {
-            AtomicConstraintFunction<Object, Rule, Boolean> function;
-            if (ruleContext instanceof Permission) {
-                function = getEvaluationFunction((String) leftRawValue, permissionFunctions, dynamicPermissionFunctions);
-            } else if (ruleContext instanceof Prohibition) {
-                function = getEvaluationFunction((String) leftRawValue, prohibitionFunctions, dynamicProhibitionFunctions);
-            } else {
-                function = getEvaluationFunction((String) leftRawValue, dutyFunctions, dynamicDutyFunctions);
-            }
-            if (function != null) {
-                return function.evaluate(constraint.getOperator(), rightValue, ruleContext);
-            }
+        if (!(leftRawValue instanceof String)) {
+            ruleProblems.add(RuleProblem.Builder.newInstance()
+                    .rule(ruleContext)
+                    .description(ruleContext.toString())
+                    .constraintProblem(new ConstraintProblem("Left operand value is not a String", constraint))
+                    .build());
+            return false;
+        }
+
+        AtomicConstraintFunction<Object, Rule, Boolean> function;
+        if (ruleContext instanceof Permission) {
+            function = getEvaluationFunction((String) leftRawValue, permissionFunctions, dynamicPermissionFunctions);
+        } else if (ruleContext instanceof Prohibition) {
+            function = getEvaluationFunction((String) leftRawValue, prohibitionFunctions, dynamicProhibitionFunctions);
+        } else {
+            function = getEvaluationFunction((String) leftRawValue, dutyFunctions, dynamicDutyFunctions);
+        }
+        if (function == null) {
             ruleProblems.add(RuleProblem.Builder.newInstance()
                     .rule(ruleContext)
                     .description(ruleContext.toString())
                     .constraintProblem(new ConstraintProblem("No evaluation function found", constraint))
                     .build());
+            return false;
         }
-        return false;
+
+        var rightValue = constraint.getRightExpression().accept(this);
+        return function.evaluate(constraint.getOperator(), rightValue, ruleContext);
     }
 
     @Override

--- a/core/common/lib/policy-evaluator-lib/src/test/java/org/eclipse/edc/policy/evaluator/PolicyEvaluatorTest.java
+++ b/core/common/lib/policy-evaluator-lib/src/test/java/org/eclipse/edc/policy/evaluator/PolicyEvaluatorTest.java
@@ -48,11 +48,23 @@ import static org.mockito.Mockito.when;
 class PolicyEvaluatorTest {
 
     @Test
+    void verifyEvaluationFails_whenLeftOperandIsNotString() {
+        var constraint = AtomicConstraint.Builder.newInstance()
+                .leftExpression(new LiteralExpression(new Object()))
+                .operator(Operator.EQ)
+                .rightExpression(new LiteralExpression("foo"))
+                .build();
         var permission = Permission.Builder.newInstance().constraint(constraint).build();
         var policy = Policy.Builder.newInstance().permission(permission).build();
 
         var evaluator = PolicyEvaluator.Builder.newInstance().build();
+        var result = evaluator.evaluate(policy);
 
+        assertThat(result.valid()).isFalse();
+        assertThat(result.getProblems())
+                .flatExtracting(RuleProblem::getConstraintProblem)
+                .extracting(ConstraintProblem::getDescription)
+                .contains("Left operand value is not a String");
     }
 
     @ParameterizedTest(name = "{displayName} {0}")


### PR DESCRIPTION
## What this PR changes/adds

Adjusts the `PolicyEvaluator` to remove policy literal evaluations and to return `false` if an evaluation function was not found.

## Why it does that

Avoid possible NPE.

## Further notes

If no evaluation function was found an entry is added to the `ruleProblems`. Note that this doesn't mean that the error is logged. The caller function will have access to all "problems" and may handle it as needed.

## Who will sponsor this feature?

@ndr-brt 

## Linked Issue(s)

Closes #5426
