### PR TITLE
refactor: cleanup 0.14.0 generic deprecations

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -187,7 +187,6 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
                             .participantContextId(participantContext.getParticipantContextId())
                             .build();
 
-                    observable.invokeForEach(l -> l.preCreated(process));
                     process.protocolMessageReceived(message.getId());
                     update(process);
                     observable.invokeForEach(l -> l.initiated(process));
@@ -224,7 +223,6 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     @NotNull
     private ServiceResult<TransferProcess> startedAction(TransferStartMessage message, TransferProcess transferProcess) {
         if (transferProcess.getType() == CONSUMER && transferProcess.canBeStartedConsumer()) {
-            observable.invokeForEach(l -> l.preStarted(transferProcess));
             transferProcess.protocolMessageReceived(message.getId());
             transferProcess.transitionStarted();
             update(transferProcess);
@@ -246,7 +244,6 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     @NotNull
     private ServiceResult<TransferProcess> completedAction(TransferCompletionMessage message, TransferProcess transferProcess) {
         if (transferProcess.canBeCompleted()) {
-            observable.invokeForEach(l -> l.preCompleted(transferProcess));
             transferProcess.protocolMessageReceived(message.getId());
             transferProcess.transitionCompletingRequested();
             update(transferProcess);

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -159,7 +159,6 @@ class TransferProcessProtocolServiceImplTest {
                 assertThat(tp.getCounterPartyAddress()).isEqualTo("http://any");
                 assertThat(tp.getAssetId()).isEqualTo("assetId");
             });
-            verify(listener).preCreated(any());
             verify(store).save(argThat(t -> t.getState() == INITIAL.code()));
             verify(listener).initiated(any());
             verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
@@ -463,7 +462,6 @@ class TransferProcessProtocolServiceImplTest {
             var result = service.notifyCompleted(participantContext, message, tokenRepresentation);
 
             assertThat(result).isSucceeded();
-            verify(listener).preCompleted(any());
             verify(store).save(argThat(t -> t.getState() == COMPLETING_REQUESTED.code()));
             verify(listener).completed(any());
             verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
@@ -652,7 +650,6 @@ class TransferProcessProtocolServiceImplTest {
             var startedDataCaptor = ArgumentCaptor.forClass(TransferProcessStartedData.class);
             var transferProcessCaptor = ArgumentCaptor.forClass(TransferProcess.class);
             assertThat(result).isSucceeded();
-            verify(listener).preStarted(any());
             verify(store).save(transferProcessCaptor.capture());
             verify(store).save(argThat(t -> t.getState() == STARTED.code()));
             verify(listener).started(any(), startedDataCaptor.capture());

--- a/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
@@ -162,7 +162,6 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
                 .dataplaneMetadata(transferRequest.getDataplaneMetadata())
                 .build();
 
-        observable.invokeForEach(l -> l.preCreated(process));
         update(process);
         observable.invokeForEach(l -> l.initiated(process));
 
@@ -390,7 +389,6 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
 
                     } else {
                         process.transitionStarted();
-                        observable.invokeForEach(l -> l.preStarted(t));
                         update(t);
                         observable.invokeForEach(l -> l.started(t, TransferProcessStartedData.Builder.newInstance().build()));
                     }
@@ -537,8 +535,6 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
      */
     @WithSpan
     private boolean processDeprovisioning(TransferProcess process) {
-        observable.invokeForEach(l -> l.preDeprovisioning(process)); // TODO: this is called here since it's not callable from the command handler
-
         var policy = policyArchive.findPolicyForContract(process.getContractId());
 
         var resourcesToDeprovision = process.getResourcesToDeprovision();
@@ -630,20 +626,17 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
 
     private void transitionToProvisioning(TransferProcess process) {
         process.transitionProvisioning(process.getResourceManifest());
-        observable.invokeForEach(l -> l.preProvisioning(process));
         update(process);
     }
 
     private void transitionToRequesting(TransferProcess process) {
         process.transitionRequesting();
-        observable.invokeForEach(l -> l.preRequesting(process));
         update(process);
     }
 
     private void transitionToRequested(TransferProcess transferProcess, TransferProcessAck ack) {
         transferProcess.transitionRequested();
         transferProcess.setCorrelationId(ack.getProviderPid());
-        observable.invokeForEach(l -> l.preRequested(transferProcess));
         update(transferProcess);
         observable.invokeForEach(l -> l.requested(transferProcess));
     }
@@ -670,7 +663,6 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
 
     private void transitionToCompleted(TransferProcess transferProcess) {
         transferProcess.transitionCompleted();
-        observable.invokeForEach(l -> l.preCompleted(transferProcess));
         update(transferProcess);
         observable.invokeForEach(l -> l.completed(transferProcess));
     }
@@ -716,7 +708,6 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
 
     private void transitionToTerminated(TransferProcess process) {
         process.transitionTerminated();
-        observable.invokeForEach(l -> l.preTerminated(process));
         update(process);
         observable.invokeForEach(l -> l.terminated(process));
     }
@@ -729,7 +720,6 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
     private void transitionToDeprovisioningError(TransferProcess transferProcess, String message) {
         monitor.severe(message);
         transferProcess.transitionDeprovisioned(message);
-        observable.invokeForEach(l -> l.preDeprovisioned(transferProcess));
         update(transferProcess);
         observable.invokeForEach(l -> l.deprovisioned(transferProcess));
     }

--- a/core/control-plane/lib/control-plane-transfer-provision-lib/src/main/java/org/eclipse/edc/connector/controlplane/transfer/provision/DeprovisionResponsesHandler.java
+++ b/core/control-plane/lib/control-plane-transfer-provision-lib/src/main/java/org/eclipse/edc/connector/controlplane/transfer/provision/DeprovisionResponsesHandler.java
@@ -98,7 +98,6 @@ public class DeprovisionResponsesHandler implements ResponsesHandler<StatusResul
 
         if (transferProcess.deprovisionComplete()) {
             transferProcess.transitionDeprovisioned();
-            observable.invokeForEach(l -> l.preDeprovisioned(transferProcess));
         } else if (results.stream().anyMatch(DeprovisionedResource::isInProcess)) {
             transferProcess.transitionDeprovisioningRequested();
         }
@@ -116,6 +115,5 @@ public class DeprovisionResponsesHandler implements ResponsesHandler<StatusResul
     private void transitionToDeprovisioningError(TransferProcess transferProcess, String message) {
         monitor.severe(message);
         transferProcess.transitionDeprovisioned(message);
-        observable.invokeForEach(l -> l.preDeprovisioned(transferProcess));
     }
 }

--- a/core/control-plane/lib/control-plane-transfer-provision-lib/src/main/java/org/eclipse/edc/connector/controlplane/transfer/provision/ProvisionResponsesHandler.java
+++ b/core/control-plane/lib/control-plane-transfer-provision-lib/src/main/java/org/eclipse/edc/connector/controlplane/transfer/provision/ProvisionResponsesHandler.java
@@ -133,7 +133,6 @@ public class ProvisionResponsesHandler implements ResponsesHandler<StatusResult<
 
         if (transferProcess.provisioningComplete()) {
             transferProcess.transitionProvisioned();
-            observable.invokeForEach(l -> l.preProvisioned(transferProcess));
         } else if (responses.stream().anyMatch(ProvisionResponse::isInProcess)) {
             transferProcess.transitionProvisioningRequested();
         }

--- a/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-http-api-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/NegotiationApiPaths.java
+++ b/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-http-api-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/NegotiationApiPaths.java
@@ -21,12 +21,8 @@ public interface NegotiationApiPaths {
 
     String BASE_PATH = "/negotiations/";
     String INITIAL_CONTRACT_REQUEST = "request";
-    @Deprecated(since = "0.13.0")
-    String INITIAL_CONTRACT_OFFER = "offer";
     String INITIAL_CONTRACT_OFFERS = "offers";
     String CONTRACT_REQUEST = "/" + INITIAL_CONTRACT_REQUEST;
-    @Deprecated(since = "0.14.0")
-    String CONTRACT_OFFER = "/" + INITIAL_CONTRACT_OFFER;
     String CONTRACT_OFFERS = "/" + INITIAL_CONTRACT_OFFERS;
     String EVENT = "/events";
     String AGREEMENT = "/agreement";

--- a/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-http-api-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/BaseDspNegotiationApiController.java
+++ b/data-protocols/dsp/dsp-lib/dsp-negotiation-lib/dsp-negotiation-http-api-lib/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/BaseDspNegotiationApiController.java
@@ -40,11 +40,9 @@ import org.eclipse.edc.protocol.dsp.http.spi.message.PostDspRequest;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.AGREEMENT;
-import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.CONTRACT_OFFER;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.CONTRACT_OFFERS;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.CONTRACT_REQUEST;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.EVENT;
-import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.INITIAL_CONTRACT_OFFER;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.INITIAL_CONTRACT_OFFERS;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.INITIAL_CONTRACT_REQUEST;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.TERMINATION;
@@ -142,31 +140,6 @@ public abstract class BaseDspNegotiationApiController {
     @POST
     @Path(INITIAL_CONTRACT_OFFERS)
     public Response initialContractOffer(JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
-        var request = PostDspRequest.Builder.newInstance(ContractOfferMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
-                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM))
-                .message(jsonObject)
-                .token(token)
-                .serviceCall(protocolService::notifyOffered)
-                .errorProvider(ContractNegotiationError.Builder::newInstance)
-                .protocol(protocol)
-                .participantContextProvider(participantContextSupplier)
-                .build();
-
-        return dspRequestHandler.createResource(request);
-    }
-
-    /**
-     * Consumer-specific endpoint.
-     *
-     * @param jsonObject dspace:ContractOfferMessage sent by a consumer.
-     * @param token      identity token.
-     * @return the created contract negotiation or an error.
-     * @deprecated use {@link #initialContractOffer(JsonObject, String)}
-     */
-    @Deprecated(since = "0.14.0")
-    @POST
-    @Path(INITIAL_CONTRACT_OFFER)
-    public Response deprecatedInitialContractOffer(JsonObject jsonObject, @HeaderParam(AUTHORIZATION) String token) {
         var request = PostDspRequest.Builder.newInstance(ContractOfferMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
                 .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM))
                 .message(jsonObject)
@@ -302,35 +275,6 @@ public abstract class BaseDspNegotiationApiController {
     @POST
     @Path("{id}" + CONTRACT_OFFERS)
     public Response providerOffer(@PathParam("id") String id,
-                                  JsonObject body,
-                                  @HeaderParam(AUTHORIZATION) String token) {
-        var request = PostDspRequest.Builder.newInstance(ContractOfferMessage.class, ContractNegotiation.class, ContractNegotiationError.class)
-                .expectedMessageType(namespace.toIri(DSPACE_TYPE_CONTRACT_OFFER_MESSAGE_TERM))
-                .processId(id)
-                .message(body)
-                .token(token)
-                .serviceCall(protocolService::notifyOffered)
-                .errorProvider(ContractNegotiationError.Builder::newInstance)
-                .protocol(protocol)
-                .participantContextProvider(participantContextSupplier)
-                .build();
-
-        return dspRequestHandler.updateResource(request);
-    }
-
-    /**
-     * Consumer-specific endpoint.
-     *
-     * @param id    of contract negotiation.
-     * @param body  dspace:ContractOfferMessage sent by a provider.
-     * @param token identity token.
-     * @return empty response or error.
-     * @deprecated use {@link #providerOffer(String, JsonObject, String)}
-     */
-    @Deprecated(since = "0.14.0")
-    @POST
-    @Path("{id}" + CONTRACT_OFFER)
-    public Response deprecatedProviderOffer(@PathParam("id") String id,
                                   JsonObject body,
                                   @HeaderParam(AUTHORIZATION) String token) {
         var request = PostDspRequest.Builder.newInstance(ContractOfferMessage.class, ContractNegotiation.class, ContractNegotiationError.class)

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.jsonld.spi;
 
 import static org.eclipse.edc.jsonld.spi.Namespaces.DCAT_SCHEMA;
 import static org.eclipse.edc.jsonld.spi.Namespaces.DCT_SCHEMA;
-import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_SCHEMA;
 import static org.eclipse.edc.policy.model.OdrlNamespace.ODRL_SCHEMA;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 
@@ -75,6 +74,4 @@ public interface PropertyAndTypeNames {
     String ODRL_USE_ACTION_ATTRIBUTE = ODRL_SCHEMA + "use";
     String ODRL_PROFILE_ATTRIBUTE = ODRL_SCHEMA + "profile";
     String DSPACE_PROPERTY_PARTICIPANT_ID_TERM = "participantId";
-    @Deprecated(since = "0.14.0")
-    String DSPACE_PROPERTY_PARTICIPANT_ID_IRI = DSPACE_SCHEMA + DSPACE_PROPERTY_PARTICIPANT_ID_TERM;
 }

--- a/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/revocation/bitstringstatuslist/BitstringStatusListCredential.java
+++ b/spi/common/verifiable-credentials-spi/src/main/java/org/eclipse/edc/iam/verifiablecredentials/spi/model/revocation/bitstringstatuslist/BitstringStatusListCredential.java
@@ -51,7 +51,7 @@ public class BitstringStatusListCredential extends VerifiableCredential {
      * @see <a href="https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatuslistcredential">W3C BitStringStatusListCredential</a>
      * @deprecated the "ttl" field is in conflict with the {@link BitstringStatusListCredential#validUntil()} field and may get removed in the future.
      */
-    @Deprecated(since = "0.14.0")
+    @Deprecated(since = "0.16.0")
     public Duration ttl() {
         var ttl = ofNullable(credentialSubject.get(0).getClaim(BITSTRING_STATUS_LIST_PREFIX, BITSTRING_TTL_LITERAL))
                 .map(String::valueOf)

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/observe/TransferProcessListener.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/observe/TransferProcessListener.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.controlplane.transfer.spi.observe;
 
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.spi.observe.Observable;
 
 /**
@@ -27,115 +26,6 @@ import org.eclipse.edc.spi.observe.Observable;
  * is guaranteed to be called at least once.
  */
 public interface TransferProcessListener {
-    /**
-     * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#INITIAL INITIAL}, but before the change is persisted.
-     *
-     * @param process the transfer process whose state has changed.
-     * @deprecated will be removed soon.
-     */
-    @Deprecated(since = "0.14.0")
-    default void preCreated(TransferProcess process) {
-    }
-
-    /**
-     * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#PROVISIONING PROVISIONING}, but before the change is persisted.
-     *
-     * @param process the transfer process whose state has changed.
-     * @deprecated will be removed soon.
-     */
-    @Deprecated(since = "0.14.0")
-    default void preProvisioning(TransferProcess process) {
-    }
-
-    /**
-     * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#PROVISIONED PROVISIONED}, but before the change is persisted.
-     *
-     * @param process the transfer process whose state has changed.
-     * @deprecated will be removed soon.
-     */
-    @Deprecated(since = "0.14.0")
-    default void preProvisioned(TransferProcess process) {
-    }
-
-    /**
-     * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#REQUESTING REQUESTING}, but before the change is persisted.
-     *
-     * @param process the transfer process whose state has changed.
-     * @deprecated will be removed soon.
-     */
-    @Deprecated(since = "0.14.0")
-    default void preRequesting(TransferProcess process) {
-    }
-
-    /**
-     * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#REQUESTED REQUESTED}, but before the change is persisted.
-     *
-     * @param process the transfer process whose state has changed.
-     * @deprecated will be removed soon.
-     */
-    @Deprecated(since = "0.14.0")
-    default void preRequested(TransferProcess process) {
-    }
-
-    /**
-     * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#STARTED}, but before the change is persisted.
-     *
-     * @param process the transfer process whose state has changed.
-     * @deprecated will be removed soon.
-     */
-    @Deprecated(since = "0.14.0")
-    default void preStarted(TransferProcess process) {
-    }
-
-    /**
-     * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#COMPLETED COMPLETED}, but before the change is persisted.
-     *
-     * @param process the transfer process whose state has changed.
-     * @deprecated will be removed soon.
-     */
-    @Deprecated(since = "0.14.0")
-    default void preCompleted(TransferProcess process) {
-    }
-
-    /**
-     * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#DEPROVISIONING DEPROVISIONING}, but before the change is persisted.
-     *
-     * @param process the transfer process whose state has changed.
-     * @deprecated will be removed soon.
-     */
-    @Deprecated(since = "0.14.0")
-    default void preDeprovisioning(TransferProcess process) {
-    }
-
-    /**
-     * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#DEPROVISIONED DEPROVISIONED}, but before the change is persisted.
-     *
-     * @param process the transfer process whose state has changed.
-     * @deprecated will be removed soon.
-     */
-    @Deprecated(since = "0.14.0")
-    default void preDeprovisioned(TransferProcess process) {
-    }
-
-    /**
-     * Called after a {@link TransferProcess} has moved to state
-     * {@link TransferProcessStates#TERMINATED}, but before the change is persisted.
-     *
-     * @param process the transfer process whose state has changed.
-     * @deprecated will be removed soon.
-     */
-    @Deprecated(since = "0.14.0")
-    default void preTerminated(TransferProcess process) {
-    }
 
     /**
      * Called after a {@link TransferProcess} was initiated.


### PR DESCRIPTION
## What this PR changes/adds

Cleanup generic deprecations introduced in 0.14.x.
Further PRs will come for DSP versions and control-plane provisioning.

## Why it does that

cleanup

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
