### PR TITLE
docs: add examples on json schemas

### DIFF
--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -8,7 +8,7 @@
   {
     "version": "4.0.0-beta",
     "urlPath": "/v4beta",
-    "lastUpdated": "2026-01-12T17:43:01Z",
+    "lastUpdated": "2026-02-05T17:43:01Z",
     "maturity": "beta"
   }
 ]

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/asset-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/asset-schema.json
@@ -23,10 +23,12 @@
           "type": "string"
         },
         "properties": {
-          "type": "object"
+          "type": "object",
+          "example": { "key": "value" }
         },
         "privateProperties": {
-          "type": "object"
+          "type": "object",
+          "example": { "privateKey": "privateValue" }
         },
         "dataAddress": {
           "$ref": "https://w3id.org/edc/connector/management/schema/v4/data-address-schema.json"

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/data-address-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/data-address-schema.json
@@ -18,7 +18,8 @@
         },
         "type": {
           "type": "string"
-        }
+        },
+        "example": { "type": "type" }
       },
       "required": [
         "@type",

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/dataplane-metadata-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/dataplane-metadata-schema.json
@@ -23,7 +23,8 @@
           }
         },
         "properties": {
-          "type": "object"
+          "type": "object",
+          "example": { "key": "value" }
         }
       }
     }

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/policy-definition-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/policy-definition-schema.json
@@ -26,7 +26,8 @@
           "$ref": "https://w3id.org/edc/connector/management/schema/v4/policy-definition-schema.json#/definitions/PolicyClass"
         },
         "privateProperties": {
-          "type": "object"
+          "type": "object",
+          "example": { "privateKey": "privateValue" }
         }
       },
       "required": [

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -130,6 +130,6 @@ dsp-core = { module = "org.eclipse.dataspacetck.dsp:core", version.ref = "dcp-tc
 jackson = ["jackson-annotations", "jackson-databind"]
 
 [plugins]
-edc-build = { id = "org.eclipse.edc.edc-build", version = "1.1.5" }
+edc-build = { id = "org.eclipse.edc.edc-build", version = "1.1.6" }
 shadow = { id = "com.gradleup.shadow", version = "9.3.1" }
 swagger = { id = "io.swagger.core.v3.swagger-gradle-plugin", version.ref = "swagger" }


### PR DESCRIPTION
## What this PR changes/adds

Adds examples in the json-schemas

## Why it does that

Avoid "{}" object examples in documentation ([see](https://eclipse-edc.github.io/Connector/openapi/management-api/management-api.yaml))

## Further notes

- bump edc-build


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
