### PR TITLE
refactor: move revocation registries registration from IdentityHub

### DIFF
--- a/extensions/common/iam/verifiable-credentials/src/main/java/org/eclipse/edc/iam/verifiablecredentials/RevocationServiceRegistryExtension.java
+++ b/extensions/common/iam/verifiable-credentials/src/main/java/org/eclipse/edc/iam/verifiablecredentials/RevocationServiceRegistryExtension.java
@@ -14,18 +14,53 @@
 
 package org.eclipse.edc.iam.verifiablecredentials;
 
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.edc.iam.verifiablecredentials.revocation.RevocationServiceRegistryImpl;
+import org.eclipse.edc.iam.verifiablecredentials.revocation.bitstring.BitstringStatusListRevocationService;
+import org.eclipse.edc.iam.verifiablecredentials.revocation.statuslist2021.StatusList2021RevocationService;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.RevocationServiceRegistry;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.bitstringstatuslist.BitstringStatusListStatus;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.statuslist2021.StatusList2021Status;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.token.spi.TokenValidationService;
+
+import java.util.List;
 
 import static org.eclipse.edc.iam.verifiablecredentials.RevocationServiceRegistryExtension.NAME;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.validation.TrustedIssuerRegistry.WILDCARD;
 
 @Extension(value = NAME)
 public class RevocationServiceRegistryExtension implements ServiceExtension {
-    public static final String NAME = "Revocation Service Extension";
+
+    public static final String NAME = "Revocation Service Registry";
+    public static final long DEFAULT_REVOCATION_CACHE_VALIDITY_MILLIS = 15 * 60 * 1000L;
+
+    @Setting(
+            key = "edc.iam.credential.revocation.cache.validity",
+            description = "Validity period of cached StatusList2021 credential entries in milliseconds.",
+            defaultValue = DEFAULT_REVOCATION_CACHE_VALIDITY_MILLIS + "")
+    private long revocationCacheValidity;
+    @Setting(
+            key = "edc.iam.credential.revocation.mimetype",
+            description = "A comma-separated list of accepted content types of the revocation list credential.",
+            defaultValue = WILDCARD)
+    private String contentTypes;
+
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private EdcHttpClient httpClient;
+    @Inject
+    private TokenValidationService tokenValidationService;
+    @Inject
+    private DidPublicKeyResolver didPublicKeyResolver;
 
     @Override
     public String name() {
@@ -34,6 +69,12 @@ public class RevocationServiceRegistryExtension implements ServiceExtension {
 
     @Provider
     public RevocationServiceRegistry createRevocationListService(ServiceExtensionContext context) {
-        return new RevocationServiceRegistryImpl(context.getMonitor());
+        var revocationServiceRegistry = new RevocationServiceRegistryImpl(context.getMonitor());
+        var acceptedContentTypes = List.of(contentTypes.split(","));
+        revocationServiceRegistry.addService(StatusList2021Status.TYPE, new StatusList2021RevocationService(typeManager.getMapper(),
+                revocationCacheValidity, acceptedContentTypes, httpClient, tokenValidationService, didPublicKeyResolver));
+        revocationServiceRegistry.addService(BitstringStatusListStatus.TYPE, new BitstringStatusListRevocationService(typeManager.getMapper(),
+                revocationCacheValidity, acceptedContentTypes, httpClient, tokenValidationService, didPublicKeyResolver));
+        return revocationServiceRegistry;
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Move revocation list services registration from IdentityHub

## Why it does that

untangle dependencies

## Further notes

- a good pattern would be to have 2 different extensions for the 2 different status list type. I'll leave that PR for someone else (that could be a future me :) )


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Related to https://github.com/eclipse-edc/IdentityHub/issues/916

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
