### PR TITLE
refactor: permit no consumer dataplane on legacy signaling flow

### DIFF
--- a/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
@@ -201,14 +201,7 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
                     update(process);
                 })
                 .onFailure((t, throwable) -> transitionToInitial(t))
-                .onFinalFailure((t, throwable) -> {
-                    // with the upcoming data-plane signaling, the data-plane will be mandatory also on consumer side
-                    // so in this case the transfer will retry
-                    monitor.warning("Data Flow preparation failed, please note that this phase will become mandatory in " +
-                            "the upcoming versions so please ensure that there's a data-plane able to manage the transfer-type " +
-                            "%s. Error: %s".formatted(t.getTransferType(), throwable.getMessage()));
-                    transitionToRequesting(t);
-                })
+                .onFinalFailure(this::transitionToTerminated)
                 .execute();
     }
 

--- a/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
+++ b/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
@@ -560,7 +560,7 @@ class TransferProcessManagerImplTest {
         }
 
         @Test
-        void shouldTransitionToRequesting_whenProvisionThroughDataplaneFails() {
+        void shouldTransitionToTerminated_whenProvisionThroughDataplaneFails() {
             var transferProcess = createTransferProcess(INITIAL);
             when(transferProcessStore.nextNotLeased(anyInt(), consumerStateIs(INITIAL.code())))
                     .thenReturn(List.of(transferProcess))
@@ -574,7 +574,7 @@ class TransferProcessManagerImplTest {
                 var captor = ArgumentCaptor.forClass(TransferProcess.class);
                 verify(transferProcessStore).save(captor.capture());
                 var storedTransferProcess = captor.getValue();
-                assertThat(storedTransferProcess.getState()).isEqualTo(REQUESTING.code());
+                assertThat(storedTransferProcess.getState()).isEqualTo(TERMINATED.code());
                 assertThat(storedTransferProcess.getDataPlaneId()).isEqualTo(null);
             });
         }

--- a/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
+++ b/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "2.1.4",
     "urlPath": "/v1",
-    "lastUpdated": "2026-01-28T12:00:01Z",
+    "lastUpdated": "2026-02-13T12:00:01Z",
     "maturity": "stable"
   }
 ]

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/TransferDataPlaneSignalingExtension.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/TransferDataPlaneSignalingExtension.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.web.spi.configuration.context.ControlApiUrl;
@@ -58,11 +59,13 @@ public class TransferDataPlaneSignalingExtension implements ServiceExtension {
     private AssetIndex assetIndex;
     @Inject
     private DataAddressStore dataAddressStore;
+    @Inject
+    private Monitor monitor;
 
     @Provider
     public DataFlowController dataFlowController() {
         return new LegacyDataPlaneSignalingFlowController(callbackUrl, selectorService, getPropertiesProvider(),
-                clientFactory, selectionStrategy, transferTypeParser, assetIndex, dataAddressStore);
+                clientFactory, selectionStrategy, transferTypeParser, assetIndex, dataAddressStore, monitor);
     }
 
     private DataFlowPropertiesProvider getPropertiesProvider() {


### PR DESCRIPTION
## What this PR changes/adds

Minor refactoring: move the passthrough for no dataplanes to the legacy flow controller, as currently a consumer data-plane is not mandatory for the transfer process, but it will become with the new signaling spec.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #5323 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
