### PR TITLE
docs: remove dataDestination from management transfer v4 api

### DIFF
--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -8,7 +8,7 @@
   {
     "version": "4.0.0-beta",
     "urlPath": "/v4beta",
-    "lastUpdated": "2026-02-05T17:43:01Z",
+    "lastUpdated": "2026-02-16T08:43:01Z",
     "maturity": "beta"
   }
 ]

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/asset-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/asset-schema.json
@@ -30,9 +30,6 @@
           "type": "object",
           "example": { "privateKey": "privateValue" }
         },
-        "dataAddress": {
-          "$ref": "https://w3id.org/edc/connector/management/schema/v4/data-address-schema.json"
-        },
         "dataplaneMetadata": {
           "$ref": "https://w3id.org/edc/connector/management/schema/v4/dataplane-metadata-schema.json"
         }

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/transfer-process-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/transfer-process-schema.json
@@ -56,9 +56,6 @@
         "errorDetail": {
           "type": "string"
         },
-        "dataDestination": {
-          "$ref": "https://w3id.org/edc/connector/management/schema/v4/data-address-schema.json"
-        },
         "dataplaneMetadata": {
           "$ref": "https://w3id.org/edc/connector/management/schema/v4/dataplane-metadata-schema.json"
         }

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/transfer-request-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/transfer-request-schema.json
@@ -37,9 +37,6 @@
         "privateProperties": {
           "type": "object"
         },
-        "dataDestination": {
-          "$ref": "https://w3id.org/edc/connector/management/schema/v4/data-address-schema.json"
-        },
         "callbackAddresses": {
           "type": "array",
           "items": {

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferRequest.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferRequest.java
@@ -32,6 +32,7 @@ public class TransferRequest {
     public static final String TRANSFER_REQUEST_TYPE = EDC_NAMESPACE + TRANSFER_REQUEST_TYPE_TERM;
     public static final String TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS = EDC_NAMESPACE + "counterPartyAddress";
     public static final String TRANSFER_REQUEST_CONTRACT_ID = EDC_NAMESPACE + "contractId";
+    @Deprecated(since = "management-api:v3")
     public static final String TRANSFER_REQUEST_DATA_DESTINATION = EDC_NAMESPACE + "dataDestination";
     public static final String TRANSFER_REQUEST_TRANSFER_TYPE = EDC_NAMESPACE + "transferType";
     public static final String TRANSFER_REQUEST_PRIVATE_PROPERTIES = EDC_NAMESPACE + "privateProperties";
@@ -63,6 +64,7 @@ public class TransferRequest {
         return contractId;
     }
 
+    @Deprecated(since = "management-api:v3")
     public DataAddress getDataDestination() {
         return dataDestination;
     }
@@ -118,6 +120,7 @@ public class TransferRequest {
             return this;
         }
 
+        @Deprecated(since = "management-api:v3")
         public Builder dataDestination(DataAddress dataDestination) {
             request.dataDestination = dataDestination;
             return this;


### PR DESCRIPTION
## What this PR changes/adds

Remove `dataDestination` from management transfer API v4.
Deprecate the field on the related object as well.
Remove also `dataAddress` from `Asset`

## Why it does that

cleanup

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #5323 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
