### PR TITLE
feat: add missing counterPartyId validation

### DIFF
--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/validation/CatalogRequestValidator.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/validation/CatalogRequestValidator.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.validator.jsonobject.validators.model.QuerySpecValidator;
 import org.eclipse.edc.validator.spi.Validator;
 
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_COUNTER_PARTY_ADDRESS;
+import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_COUNTER_PARTY_ID;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_PROTOCOL;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_QUERY_SPEC;
 
@@ -29,6 +30,7 @@ public class CatalogRequestValidator {
 
     public static Validator<JsonObject> instance(CriterionOperatorRegistry criterionOperatorRegistry) {
         return JsonObjectValidator.newValidator()
+                .verify(CATALOG_REQUEST_COUNTER_PARTY_ID, MandatoryValue::new)
                 .verify(CATALOG_REQUEST_COUNTER_PARTY_ADDRESS, MandatoryValue::new)
                 .verify(CATALOG_REQUEST_PROTOCOL, MandatoryValue::new)
                 .verifyObject(CATALOG_REQUEST_QUERY_SPEC, path -> QuerySpecValidator.instance(path, criterionOperatorRegistry))

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/validation/DatasetRequestValidator.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/validation/DatasetRequestValidator.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.validator.jsonobject.validators.MandatoryValue;
 import org.eclipse.edc.validator.spi.Validator;
 
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_COUNTER_PARTY_ADDRESS;
+import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_COUNTER_PARTY_ID;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_PROTOCOL;
 
 public class DatasetRequestValidator {
@@ -29,6 +30,7 @@ public class DatasetRequestValidator {
         return JsonObjectValidator.newValidator()
                 .verifyId(MandatoryIdNotBlank::new)
                 .verify(DATASET_REQUEST_PROTOCOL, MandatoryValue::new)
+                .verify(DATASET_REQUEST_COUNTER_PARTY_ID, MandatoryValue::new)
                 .verify(DATASET_REQUEST_COUNTER_PARTY_ADDRESS, MandatoryValue::new)
                 .build();
     }

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/validation/CatalogRequestValidatorTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/validation/CatalogRequestValidatorTest.java
@@ -27,6 +27,7 @@ import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_COUNTER_PARTY_ADDRESS;
+import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_COUNTER_PARTY_ID;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_PROTOCOL;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_QUERY_SPEC;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
@@ -41,6 +42,7 @@ class CatalogRequestValidatorTest {
     @Test
     void shouldSucceed_whenInputIsValid() {
         var input = Json.createObjectBuilder()
+                .add(CATALOG_REQUEST_COUNTER_PARTY_ID, value("anId"))
                 .add(CATALOG_REQUEST_COUNTER_PARTY_ADDRESS, value("http://any"))
                 .add(CATALOG_REQUEST_PROTOCOL, value("protocol"))
                 .build();
@@ -57,7 +59,8 @@ class CatalogRequestValidatorTest {
         var result = validator.validate(input);
 
         assertThat(result).isFailed().extracting(ValidationFailure::getViolations).asInstanceOf(list(Violation.class))
-                .hasSize(2)
+                .hasSize(3)
+                .anySatisfy(v -> assertThat(v.path()).isEqualTo(CATALOG_REQUEST_COUNTER_PARTY_ID))
                 .anySatisfy(v -> assertThat(v.path()).isEqualTo(CATALOG_REQUEST_COUNTER_PARTY_ADDRESS))
                 .anySatisfy(v -> assertThat(v.path()).isEqualTo(CATALOG_REQUEST_PROTOCOL));
     }
@@ -65,6 +68,7 @@ class CatalogRequestValidatorTest {
     @Test
     void shouldFail_whenOptionalQuerySpecIsInvalid() {
         var input = Json.createObjectBuilder()
+                .add(CATALOG_REQUEST_COUNTER_PARTY_ID, value("anId"))
                 .add(CATALOG_REQUEST_COUNTER_PARTY_ADDRESS, value("http://any"))
                 .add(CATALOG_REQUEST_PROTOCOL, value("protocol"))
                 .add(CATALOG_REQUEST_QUERY_SPEC, createArrayBuilder().add(createObjectBuilder()

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/validation/DatasetRequestValidatorTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/validation/DatasetRequestValidatorTest.java
@@ -27,6 +27,7 @@ import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_COUNTER_PARTY_ADDRESS;
+import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_COUNTER_PARTY_ID;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_PROTOCOL;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
@@ -40,6 +41,7 @@ class DatasetRequestValidatorTest {
     void shouldSucceed_whenInputIsValid() {
         var input = Json.createObjectBuilder()
                 .add(ID, "id")
+                .add(DATASET_REQUEST_COUNTER_PARTY_ID, value("anId"))
                 .add(DATASET_REQUEST_COUNTER_PARTY_ADDRESS, value("http://any"))
                 .add(DATASET_REQUEST_PROTOCOL, value("protocol"))
                 .build();
@@ -56,8 +58,9 @@ class DatasetRequestValidatorTest {
         var result = validator.validate(input);
 
         assertThat(result).isFailed().extracting(ValidationFailure::getViolations).asInstanceOf(list(Violation.class))
-                .hasSize(3)
+                .hasSize(4)
                 .anySatisfy(v -> assertThat(v.path()).isEqualTo(ID))
+                .anySatisfy(v -> assertThat(v.path()).isEqualTo(DATASET_REQUEST_COUNTER_PARTY_ID))
                 .anySatisfy(v -> assertThat(v.path()).isEqualTo(DATASET_REQUEST_COUNTER_PARTY_ADDRESS))
                 .anySatisfy(v -> assertThat(v.path()).isEqualTo(DATASET_REQUEST_PROTOCOL));
     }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/CatalogApiEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/CatalogApiEndToEndTest.java
@@ -64,6 +64,7 @@ public class CatalogApiEndToEndTest {
             var requestBody = createObjectBuilder()
                     .add(CONTEXT, createObjectBuilder().add(EDC_PREFIX, EDC_NAMESPACE))
                     .add(TYPE, "CatalogRequest")
+                    .add("counterPartyId", "id")
                     .add("counterPartyAddress", context.providerDsp2025url())
                     .add("protocol", DATASPACE_PROTOCOL_HTTP_V_2025_1)
                     .build();
@@ -106,6 +107,7 @@ public class CatalogApiEndToEndTest {
             var requestBody = createObjectBuilder()
                     .add(CONTEXT, createObjectBuilder().add(EDC_PREFIX, EDC_NAMESPACE))
                     .add(TYPE, "CatalogRequest")
+                    .add("counterPartyId", "id")
                     .add("counterPartyAddress", context.providerDsp2025url())
                     .add("protocol", DATASPACE_PROTOCOL_HTTP_V_2025_1)
                     .add("querySpec", querySpec)
@@ -148,6 +150,7 @@ public class CatalogApiEndToEndTest {
             var requestBody = createObjectBuilder()
                     .add(CONTEXT, createObjectBuilder().add(EDC_PREFIX, EDC_NAMESPACE))
                     .add(TYPE, "CatalogRequest")
+                    .add("counterPartyId", "id")
                     .add("counterPartyAddress", context.providerDsp2025url())
                     .add("protocol", DATASPACE_PROTOCOL_HTTP_V_2025_1)
                     .build();
@@ -185,6 +188,7 @@ public class CatalogApiEndToEndTest {
                     .add(CONTEXT, createObjectBuilder().add(EDC_PREFIX, EDC_NAMESPACE))
                     .add(TYPE, "DatasetRequest")
                     .add(ID, "asset-id")
+                    .add("counterPartyId", "id")
                     .add("counterPartyAddress", context.providerDsp2025url())
                     .add("protocol", DATASPACE_PROTOCOL_HTTP_V_2025_1)
                     .build();
@@ -228,6 +232,7 @@ public class CatalogApiEndToEndTest {
                     .add(CONTEXT, createObjectBuilder().add(EDC_PREFIX, EDC_NAMESPACE))
                     .add(TYPE, "DatasetRequest")
                     .add(ID, "asset-response")
+                    .add("counterPartyId", "id")
                     .add("counterPartyAddress", context.providerDsp2025url())
                     .add("protocol", DATASPACE_PROTOCOL_HTTP_V_2025_1)
                     .build();

--- a/system-tests/telemetry/telemetry-test-runner/src/test/java/org/eclipse/edc/test/e2e/tracing/MicrometerEndToEndTest.java
+++ b/system-tests/telemetry/telemetry-test-runner/src/test/java/org/eclipse/edc/test/e2e/tracing/MicrometerEndToEndTest.java
@@ -35,6 +35,7 @@ public class MicrometerEndToEndTest extends BaseTelemetryEndToEndTest {
         // will request the catalog to itself, just to trigger okhttp metrics
         var requestBody = Json.createObjectBuilder()
                 .add(TYPE, CATALOG_REQUEST_TYPE)
+                .add(EDC_NAMESPACE + "counterPartyId", "counterPartyId")
                 .add(EDC_NAMESPACE + "counterPartyAddress", "http://localhost:" + PROTOCOL_PORT + "/protocol/2025-1")
                 .add(EDC_NAMESPACE + "protocol", "dataspace-protocol-http:2025-1")
                 .build();


### PR DESCRIPTION
## What this PR changes/adds

Adds missing `counterPartyId` validation on `CatalogRequest` and `DatasetRequest`

## Why it does that

`counterPartyId` is technically mandatory because it's used to set up the token audience. If not provided the system will provide a not really understandable error. With the validation, the request will be refused straight away with a meaningful message.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4746 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
