### PR TITLE
feat: data plane signaling discovery by labels

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -60,6 +60,7 @@ import org.eclipse.edc.connector.controlplane.services.spi.protocol.VersionProto
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessProtocolService;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.controlplane.services.transferprocess.TransferProcessProtocolServiceImpl;
+import org.eclipse.edc.connector.controlplane.services.transferprocess.TransferProcessProviderFactory;
 import org.eclipse.edc.connector.controlplane.services.transferprocess.TransferProcessServiceImpl;
 import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessManager;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowController;
@@ -249,9 +250,10 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
 
     @Provider
     public TransferProcessProtocolService transferProcessProtocolService() {
+        var factory = new TransferProcessProviderFactory(clock, telemetry, assetIndex);
         return new TransferProcessProtocolServiceImpl(transferProcessStore, transactionContext, contractNegotiationStore,
-                contractValidationService, protocolTokenValidator(), dataAddressValidator, transferProcessObservable, clock,
-                monitor, telemetry, dataFlowController, dataAddressStore);
+                contractValidationService, protocolTokenValidator(), dataAddressValidator, transferProcessObservable,
+                monitor, dataFlowController, dataAddressStore, factory);
     }
 
     @Provider

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProviderFactory.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProviderFactory.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.services.transferprocess;
+
+import org.eclipse.edc.connector.controlplane.asset.spi.index.AssetIndex;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferRequestMessage;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.telemetry.Telemetry;
+
+import java.time.Clock;
+
+import static java.util.UUID.randomUUID;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.Type.PROVIDER;
+
+/**
+ * A factory class for creating {@link TransferProcess} instances for providers.
+ * This class encapsulates the dependencies required to construct and initialize a transfer process.
+ */
+public class TransferProcessProviderFactory {
+
+    private final Clock clock;
+    private final Telemetry telemetry;
+    private final AssetIndex assetIndex;
+
+    public TransferProcessProviderFactory(Clock clock, Telemetry telemetry, AssetIndex assetIndex) {
+        this.clock = clock;
+        this.telemetry = telemetry;
+        this.assetIndex = assetIndex;
+    }
+
+    /**
+     * Creates a new instance of {@link TransferProcess} for a provider based on the given inputs.
+     * This method validates the asset associated with the provided {@link ContractAgreement}
+     * and constructs a transfer process, encapsulating all required information.
+     *
+     * @param participantContext the context of the participant initiating the transfer process
+     * @param message the transfer request message containing details of the request
+     * @param contractAgreement the contract agreement associated with the transfer process
+     * @return a {@link ServiceResult} containing the successfully created {@link TransferProcess},
+     *         or an error message if the asset could not be found
+     */
+    public ServiceResult<TransferProcess> create(ParticipantContext participantContext, TransferRequestMessage message, ContractAgreement contractAgreement) {
+        var asset = assetIndex.findById(contractAgreement.getAssetId());
+        if (asset == null) {
+            return ServiceResult.badRequest("Asset " + contractAgreement.getAssetId() + " not found");
+        }
+
+        var process = TransferProcess.Builder.newInstance()
+                .id(randomUUID().toString())
+                .protocol(message.getProtocol())
+                .correlationId(message.getConsumerPid())
+                .counterPartyAddress(message.getCallbackAddress())
+                .assetId(contractAgreement.getAssetId())
+                .contractId(contractAgreement.getId())
+                .transferType(message.getTransferType())
+                .type(PROVIDER)
+                .clock(clock)
+                .traceContext(telemetry.getCurrentTraceContext())
+                .participantContextId(participantContext.getParticipantContextId())
+                .dataplaneMetadata(asset.getDataplaneMetadata())
+                .build();
+
+        return ServiceResult.success(process);
+    }
+}

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProviderFactoryTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProviderFactoryTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.services.transferprocess;
+
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata;
+import org.eclipse.edc.connector.controlplane.asset.spi.index.AssetIndex;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferRequestMessage;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.result.ServiceFailure;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.BAD_REQUEST;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TransferProcessProviderFactoryTest {
+
+    private final AssetIndex assetIndex = mock();
+    private final TransferProcessProviderFactory factory = new TransferProcessProviderFactory(mock(), mock(), assetIndex);
+
+    @Test
+    void shouldCreateProviderTransferProcess() {
+        var dataplaneMetadata = DataplaneMetadata.Builder.newInstance().build();
+        when(assetIndex.findById("assetId")).thenReturn(Asset.Builder.newInstance().id("assetId").dataplaneMetadata(dataplaneMetadata).build());
+        var contractAgreement = createAgreementBuilder().assetId("assetId").build();
+
+        var result = factory.create(createParticipantContext("participantContextId"), createMessage(), contractAgreement);
+
+        assertThat(result).isSucceeded().satisfies(transferProcess -> {
+            assertThat(transferProcess.getId()).isNotBlank();
+            assertThat(transferProcess.getParticipantContextId()).isEqualTo("participantContextId");
+            assertThat(transferProcess.getDataplaneMetadata()).isSameAs(dataplaneMetadata);
+        });
+        verify(assetIndex).findById("assetId");
+    }
+
+    @Test
+    void shouldReturnError_whenAssetNotFound() {
+        when(assetIndex.findById(any())).thenReturn(null);
+        var contractAgreement = createAgreementBuilder().assetId("assetId").build();
+
+        var result = factory.create(createParticipantContext("participantContextId"), createMessage(), contractAgreement);
+
+        assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(BAD_REQUEST);
+    }
+
+    private ContractAgreement.Builder createAgreementBuilder() {
+        return ContractAgreement.Builder.newInstance().providerId("providerId").consumerId("consumerId")
+                .policy(Policy.Builder.newInstance().build());
+    }
+
+    private TransferRequestMessage createMessage() {
+        return TransferRequestMessage.Builder.newInstance().callbackAddress("http://any").build();
+    }
+
+    private ParticipantContext createParticipantContext(String participantContextId) {
+        return ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity("any").build();
+    }
+}

--- a/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorExtension.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorExtension.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.strategy.SelectionStrate
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -30,6 +31,14 @@ import static org.eclipse.edc.connector.dataplane.selector.DataPlaneSelectorExte
 public class DataPlaneSelectorExtension implements ServiceExtension {
 
     public static final String NAME = "Data Plane Selector core";
+    private static final String DEFAULT_DATAPLANE_SELECTOR_STRATEGY = "random";
+
+    @Setting(
+            description = "Defines strategy for Data Plane instance selection in case Data Plane is not embedded in current runtime",
+            defaultValue = DEFAULT_DATAPLANE_SELECTOR_STRATEGY,
+            key = "edc.dataplane.client.selector.strategy"
+    )
+    private String selectionStrategy;
 
     @Inject
     private DataPlaneInstanceStore instanceStore;
@@ -45,7 +54,7 @@ public class DataPlaneSelectorExtension implements ServiceExtension {
 
     @Provider(isDefault = true)
     public DataPlaneSelectorService dataPlaneSelectorService() {
-        return new EmbeddedDataPlaneSelectorService(instanceStore, selectionStrategyRegistry, transactionContext);
+        return new EmbeddedDataPlaneSelectorService(instanceStore, selectionStrategyRegistry, transactionContext, selectionStrategy);
     }
 
 }

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingFlowControllerExtension.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingFlowControllerExtension.java
@@ -20,7 +20,6 @@ import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
-import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.signaling.logic.DataPlaneSignalingFlowController;
 import org.eclipse.edc.signaling.port.ClientFactory;
 import org.eclipse.edc.signaling.port.transformer.DataAddressToDspDataAddressTransformer;
@@ -37,14 +36,6 @@ import static org.eclipse.edc.signaling.DataPlaneSignalingFlowControllerExtensio
 public class DataPlaneSignalingFlowControllerExtension implements ServiceExtension {
 
     public static final String NAME = "Data Plane Signaling Api";
-    private static final String DEFAULT_DATAPLANE_SELECTOR_STRATEGY = "random";
-
-    @Setting(
-            description = "Defines strategy for Data Plane instance selection in case Data Plane is not embedded in current runtime",
-            defaultValue = DEFAULT_DATAPLANE_SELECTOR_STRATEGY,
-            key = "edc.dataplane.client.selector.strategy"
-    )
-    private String selectionStrategy;
 
     @Inject
     private TypeTransformerRegistry transformerRegistry;
@@ -68,7 +59,7 @@ public class DataPlaneSignalingFlowControllerExtension implements ServiceExtensi
         typeTransformerRegistry.register(new DataAddressToDspDataAddressTransformer());
         typeTransformerRegistry.register(new DataFlowResponseMessageToDataFlowResponseTransformer());
         typeTransformerRegistry.register(new DspDataAddressToDataAddressTransformer());
-        return new DataPlaneSignalingFlowController(controlApiUrl, dataPlaneSelectorService, selectionStrategy,
+        return new DataPlaneSignalingFlowController(controlApiUrl, dataPlaneSelectorService,
                 typeTransformerRegistry, clientFactory, dataAddressStore);
     }
 }

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowController.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowController.java
@@ -49,17 +49,15 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
 
     private final ControlApiUrl callbackUrl;
     private final DataPlaneSelectorService selectorClient;
-    private final String selectionStrategy;
     private final TypeTransformerRegistry typeTransformerRegistry;
     private final ClientFactory clientFactory;
     private final DataAddressStore dataAddressStore;
 
-    public DataPlaneSignalingFlowController(ControlApiUrl callbackUrl, DataPlaneSelectorService selectorClient, String selectionStrategy,
+    public DataPlaneSignalingFlowController(ControlApiUrl callbackUrl, DataPlaneSelectorService selectorClient,
                                             TypeTransformerRegistry typeTransformerRegistry, ClientFactory clientFactory,
                                             DataAddressStore dataAddressStore) {
         this.callbackUrl = callbackUrl;
         this.selectorClient = selectorClient;
-        this.selectionStrategy = selectionStrategy;
         this.typeTransformerRegistry = typeTransformerRegistry;
         this.clientFactory = clientFactory;
         this.dataAddressStore = dataAddressStore;
@@ -72,7 +70,7 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
 
     @Override
     public StatusResult<DataFlowResponse> prepare(TransferProcess transferProcess, Policy policy) {
-        var selection = selectorClient.select(selectionStrategy, dataPlane -> dataPlane.getAllowedTransferTypes().contains(transferProcess.getTransferType()));
+        var selection = selectorClient.selectFor(transferProcess);
         if (!selection.succeeded()) {
             return StatusResult.failure(FATAL_ERROR, selection.getFailureDetail());
         }
@@ -104,7 +102,7 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
 
     @Override
     public @NotNull StatusResult<DataFlowResponse> start(TransferProcess transferProcess, Policy policy) {
-        var selection = selectorClient.select(selectionStrategy, dataPlane -> dataPlane.getAllowedTransferTypes().contains(transferProcess.getTransferType()));
+        var selection = selectorClient.selectFor(transferProcess);
         if (!selection.succeeded()) {
             return StatusResult.failure(FATAL_ERROR, selection.getFailureDetail());
         }

--- a/data-protocols/data-plane-signaling/src/test/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowControllerTest.java
+++ b/data-protocols/data-plane-signaling/src/test/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowControllerTest.java
@@ -64,7 +64,7 @@ public class DataPlaneSignalingFlowControllerTest {
 
     private final DataPlaneSignalingFlowController flowController = new DataPlaneSignalingFlowController(
             () -> URI.create("http://localhost"), selectorService,
-            "random", typeTransformerRegistry, clientFactory, dataAddressStore);
+            typeTransformerRegistry, clientFactory, dataAddressStore);
 
     @Nested
     class Prepare {
@@ -73,7 +73,7 @@ public class DataPlaneSignalingFlowControllerTest {
         void shouldCallPrepareOnDataPlane() {
             var dataPlaneInstance = createDataPlaneInstance();
             var transferProcess = transferProcessBuilder().build();
-            when(selectorService.select(any(), any())).thenReturn(ServiceResult.success(dataPlaneInstance));
+            when(selectorService.selectFor(any())).thenReturn(ServiceResult.success(dataPlaneInstance));
             when(clientFactory.createClient(any())).thenReturn(dataPlaneClient);
             var flowResponseMessage = DataFlowResponseMessage.Builder.newInstance()
                     .dataAddress(createDspDataAddress())
@@ -92,7 +92,7 @@ public class DataPlaneSignalingFlowControllerTest {
         @Test
         void shouldReturnFailure_whenNoDataPlaneIsFound() {
             var transferProcess = transferProcessBuilder().build();
-            when(selectorService.select(any(), any())).thenReturn(ServiceResult.notFound("no data plane can provision this"));
+            when(selectorService.selectFor(any())).thenReturn(ServiceResult.notFound("no data plane can provision this"));
 
             var result = flowController.prepare(transferProcess, policyBuilder().build());
 
@@ -112,7 +112,7 @@ public class DataPlaneSignalingFlowControllerTest {
                     .contentDataAddress(testDataAddress())
                     .build();
             var dataPlaneInstance = createDataPlaneInstance();
-            when(selectorService.select(any(), any())).thenReturn(ServiceResult.success(dataPlaneInstance));
+            when(selectorService.selectFor(any())).thenReturn(ServiceResult.success(dataPlaneInstance));
             when(clientFactory.createClient(any())).thenReturn(dataPlaneClient);
             when(typeTransformerRegistry.transform(isA(DataAddress.class), any())).thenReturn(Result.success(createDspDataAddress()));
             var response = DataFlowResponse.Builder.newInstance().dataPlaneId("dataPlaneId").dataAddress(testDataAddress()).build();
@@ -134,7 +134,7 @@ public class DataPlaneSignalingFlowControllerTest {
                     .transferType(HTTP_DATA_PULL)
                     .build();
 
-            when(selectorService.select(any(), any())).thenReturn(ServiceResult.notFound("no dataplane found"));
+            when(selectorService.selectFor(any())).thenReturn(ServiceResult.notFound("no dataplane found"));
 
             var result = flowController.start(transferProcess, Policy.Builder.newInstance().build());
 
@@ -151,7 +151,7 @@ public class DataPlaneSignalingFlowControllerTest {
 
             when(dataPlaneClient.start(any())).thenReturn(StatusResult.failure(ResponseStatus.FATAL_ERROR, errorMsg));
             var dataPlaneInstance = createDataPlaneInstance();
-            when(selectorService.select(any(), any())).thenReturn(ServiceResult.success(dataPlaneInstance));
+            when(selectorService.selectFor(any())).thenReturn(ServiceResult.success(dataPlaneInstance));
             when(clientFactory.createClient(any())).thenReturn(dataPlaneClient);
             when(typeTransformerRegistry.transform(isA(DataAddress.class), any())).thenReturn(Result.success(createDspDataAddress()));
             when(dataAddressStore.resolve(any())).thenReturn(StoreResult.success(DataAddress.Builder.newInstance().type("test").build()));

--- a/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorApiExtensionTest.java
+++ b/extensions/data-plane-selector/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/DataPlaneSelectorApiExtensionTest.java
@@ -17,8 +17,6 @@ package org.eclipse.edc.connector.dataplane.selector;
 import org.eclipse.edc.boot.system.DefaultServiceExtensionContext;
 import org.eclipse.edc.boot.system.injection.ObjectFactory;
 import org.eclipse.edc.connector.dataplane.selector.api.v3.DataplaneSelectorApiV3Controller;
-import org.eclipse.edc.connector.dataplane.selector.service.EmbeddedDataPlaneSelectorService;
-import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
 import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -26,7 +24,6 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.transform.transformer.edc.from.JsonObjectFromDataPlaneInstanceTransformer;
 import org.eclipse.edc.web.spi.WebService;
@@ -57,8 +54,6 @@ class DataPlaneSelectorApiExtensionTest {
     void setUp(ServiceExtensionContext context, ObjectFactory factory) {
         context.registerService(TypeManager.class, new JacksonTypeManager());
         context.registerService(WebService.class, webService);
-        context.registerService(DataPlaneSelectorService.class, new EmbeddedDataPlaneSelectorService(mock(), mock(),
-                new NoopTransactionContext()));
 
         TypeTransformerRegistry parentTransformerRegistry = mock();
         when(parentTransformerRegistry.forContext("management-api")).thenReturn(managementApiTransformerRegistry);

--- a/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorService.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorService.java
@@ -22,6 +22,7 @@ import jakarta.json.JsonValue;
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.http.spi.ControlApiHttpClient;
@@ -78,6 +79,11 @@ public class RemoteDataPlaneSelectorService implements DataPlaneSelectorService 
 
     @Override
     public ServiceResult<DataPlaneInstance> select(@Nullable String selectionStrategy, Predicate<DataPlaneInstance> filter) {
+        return ServiceResult.unexpected("DataPlaneSelectorService.select can only be called as embedded in the control-plane");
+    }
+
+    @Override
+    public ServiceResult<DataPlaneInstance> selectFor(TransferProcess transferProcess) {
         return ServiceResult.unexpected("DataPlaneSelectorService.select can only be called as embedded in the control-plane");
     }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferProcess.java
@@ -577,6 +577,10 @@ public class TransferProcess extends StatefulEntity<TransferProcess> implements 
                 entity.callbackAddresses = new ArrayList<>();
             }
 
+            if (entity.dataplaneMetadata == null) {
+                entity.dataplaneMetadata = DataplaneMetadata.Builder.newInstance().build();
+            }
+
             return entity;
         }
     }

--- a/spi/data-plane-selector/data-plane-selector-spi/build.gradle.kts
+++ b/spi/data-plane-selector/data-plane-selector-spi/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
 dependencies {
     api(project(":spi:common:core-spi"))
     api(project(":spi:common:connector-participant-context-spi"))
+    api(project(":spi:control-plane:transfer-spi"))
     api(project(":spi:data-plane:data-plane-spi"))
     implementation(project(":core:common:lib:util-lib"))
 

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.dataplane.selector.spi;
 
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstanceStates;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
@@ -42,8 +43,18 @@ public interface DataPlaneSelectorService {
      * @param selectionStrategy the selection strategy.
      * @param filter the predicate.
      * @return the data plane, empty otherwise
+     * @deprecated use {@link #selectFor(TransferProcess)} instead
      */
+    @Deprecated(since = "0.16.0")
     ServiceResult<DataPlaneInstance> select(@Nullable String selectionStrategy, Predicate<DataPlaneInstance> filter);
+
+    /**
+     * Select the {@link DataPlaneInstance} that to be used for the given {@link TransferProcess}.
+     *
+     * @param transferProcess the transfer process.
+     * @return success with the selected instance, failure otherwise.
+     */
+    ServiceResult<DataPlaneInstance> selectFor(TransferProcess transferProcess);
 
     /**
      * Register a data plane instance

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/instance/DataPlaneInstance.java
@@ -68,6 +68,7 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> impleme
     private long lastActive = Instant.now().toEpochMilli();
     private URL url;
     private String participantContextId;
+    private final Set<String> labels = new HashSet<>();
 
     private DataPlaneInstance() {
     }
@@ -87,7 +88,8 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> impleme
                 .allowedTransferType(allowedTransferTypes)
                 .properties(properties)
                 .destinationProvisionTypes(destinationProvisionTypes)
-                .participantContextId(participantContextId);
+                .participantContextId(participantContextId)
+                .labels(labels);
 
         return copy(builder);
     }
@@ -104,7 +106,9 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> impleme
      * @param sourceAddress the sourceAddress
      * @param transferType  the transferType
      * @return true if it can handle, false otherwise.
+     * @deprecated will be determined by the DataPlaneSelectorService directly
      */
+    @Deprecated(since = "0.16.0")
     public boolean canHandle(DataAddress sourceAddress, @Nullable String transferType) {
         Objects.requireNonNull(transferType, "transferType cannot be null!");
         if (sourceAddress != null) {
@@ -146,6 +150,10 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> impleme
 
     public Set<String> getDestinationProvisionTypes() {
         return destinationProvisionTypes;
+    }
+
+    public Set<String> getLabels() {
+        return labels;
     }
 
     @Override
@@ -255,6 +263,18 @@ public class DataPlaneInstance extends StatefulEntity<DataPlaneInstance> impleme
 
         public Builder participantContextId(String participantContextId) {
             entity.participantContextId = participantContextId;
+            return this;
+        }
+
+        public Builder labels(Set<String> labels) {
+            if (labels != null) {
+                entity.labels.addAll(labels);
+            }
+            return this;
+        }
+
+        public Builder label(String label) {
+            entity.labels.add(label);
             return this;
         }
 

--- a/spi/data-plane-selector/data-plane-selector-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/selector/spi/testfixtures/store/DataPlaneInstanceStoreTestBase.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/testFixtures/java/org/eclipse/edc/connector/dataplane/selector/spi/testfixtures/store/DataPlaneInstanceStoreTestBase.java
@@ -115,6 +115,7 @@ public abstract class DataPlaneInstanceStoreTestBase {
             var entry = createInstanceBuilder(UUID.randomUUID().toString())
                     .allowedTransferType("transfer-type")
                     .allowedSourceType("source-type")
+                    .label("label")
                     .build();
             getStore().save(entry);
 


### PR DESCRIPTION
## What this PR changes/adds

Implement data plane discovery by labels.
Specifically, the new discovery mechanism has been implemented in a new `selectFor` method in `DataPlaneSelectorService`, that takes a `TransferProcess` and uses it to select the data plane.

Selection is made this way:
- get all the data plane instances
- filter out the `UNREGISTERED` data planes
- filter out data planes that cannot manage the transfer type
- eventually filter out data planes that cannot manage the labels attached to the transfer process

## Why it does that

data plane signaling

## Further notes
- extracted a `TransferProcessProviderFactory` that takes care to create the transfer process


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #5323

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
