### PR TITLE
docs: deprecate Data Plane Framework

### DIFF
--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneFrameworkExtension.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneFrameworkExtension.java
@@ -47,9 +47,12 @@ import static org.eclipse.edc.connector.dataplane.spi.manager.DataPlaneManager.D
 
 /**
  * Provides core services for the Data Plane Framework.
+ *
+ * @deprecated please look into Data Plane Signaling.
  */
 @Provides({ DataPlaneManager.class, TransferServiceRegistry.class })
 @Extension(value = DataPlaneFrameworkExtension.NAME)
+@Deprecated(since = "0.16.0")
 public class DataPlaneFrameworkExtension implements ServiceExtension {
 
     public static final String NAME = "Data Plane Framework";
@@ -98,6 +101,11 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var monitor = context.getMonitor();
+
+        monitor.warning("The EDC Data Plane has been deprecated, the related modules will be removed in future releases, " +
+                "please look into Data Plane Signaling specification and implement your own Data Planes. The EDC control-plane " +
+                "is already supporting that specification, by adding the `data-plane-signaling` module to your runtime and " +
+                "removing the legacy `transfer-data-plane-signaling` one.");
 
         var transferServiceRegistry = new TransferServiceRegistryImpl();
         transferServiceRegistry.registerTransferService(pipelineService);

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/TransferDataPlaneSignalingExtension.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/TransferDataPlaneSignalingExtension.java
@@ -29,6 +29,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.configuration.context.ControlApiUrl;
 
 import java.util.Map;
@@ -36,9 +37,10 @@ import java.util.Map;
 import static org.eclipse.edc.connector.controlplane.transfer.dataplane.TransferDataPlaneSignalingExtension.NAME;
 
 @Extension(NAME)
+@Deprecated(since = "0.16.0")
 public class TransferDataPlaneSignalingExtension implements ServiceExtension {
 
-    protected static final String NAME = "Legacy Data Plane Signaling Extension";
+    protected static final String NAME = "DEPRECATED: Legacy Data Plane Signaling Extension";
 
     private static final String DEFAULT_DATAPLANE_SELECTOR_STRATEGY = "random";
 
@@ -61,6 +63,14 @@ public class TransferDataPlaneSignalingExtension implements ServiceExtension {
     private DataAddressStore dataAddressStore;
     @Inject
     private Monitor monitor;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        monitor.warning("The EDC Data Plane has been deprecated, the related modules will be removed in future releases, " +
+                "please look into Data Plane Signaling specification and implement your own Data Planes. The EDC control-plane " +
+                "is already supporting that specification, by adding the `data-plane-signaling` module to your runtime and " +
+                "removing the legacy `transfer-data-plane-signaling` one.");
+    }
 
     @Provider
     public DataFlowController dataFlowController() {


### PR DESCRIPTION
## What this PR changes/adds

Deprecates Data-Plane Framework extension and the related control-plane extension.

## Why it does that

Notify users

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
