### PR TITLE
fix: make dataDestination accessible for TP that relies on legacy data plane specs

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessEventDispatchTest.java
@@ -115,6 +115,7 @@ public class TransferProcessEventDispatchTest {
         when(dataFlowController.prepare(any(), any())).thenReturn(StatusResult.success(DataFlowResponse.Builder.newInstance().build()));
         when(dataFlowController.started(any())).thenReturn(StatusResult.success());
         when(dataAddressStore.resolve(any())).thenReturn(StoreResult.notFound("any"));
+        when(dataAddressStore.store(any(), any())).thenReturn(StoreResult.success());
         when(dataAddressStore.remove(any())).thenReturn(StoreResult.success());
     }
 

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferProcessDefaultServicesExtension.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferProcessDefaultServicesExtension.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessPendin
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.TransferTypeParser;
 import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataAddressStore;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataPlaneProtocolInUse;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -40,6 +41,8 @@ public class TransferProcessDefaultServicesExtension implements ServiceExtension
     private TypeTransformerRegistry typeTransformerRegistry;
     @Inject
     private JsonLd jsonLd;
+
+    private final DataPlaneProtocolInUse dataPlaneProtocolInUse = new DataPlaneProtocolInUse();
 
     @Override
     public String name() {
@@ -63,7 +66,11 @@ public class TransferProcessDefaultServicesExtension implements ServiceExtension
 
     @Provider
     public DataAddressStore dataAddressStore() {
-        return new VaultDataAddressStore(vault, typeTransformerRegistry, jsonLd);
+        return new VaultDataAddressStore(vault, typeTransformerRegistry, jsonLd, dataPlaneProtocolInUse);
     }
 
+    @Provider
+    public DataPlaneProtocolInUse dataPlaneProtocolInUse() {
+        return dataPlaneProtocolInUse;
+    }
 }

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataaddress/VaultDataAddressStore.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataaddress/VaultDataAddressStore.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.controlplane.transfer.dataaddress;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataAddressStore;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataPlaneProtocolInUse;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.spi.result.Result;
@@ -36,11 +37,14 @@ public class VaultDataAddressStore implements DataAddressStore {
     private final Vault vault;
     private final TypeTransformerRegistry typeTransformerRegistry;
     private final JsonLd jsonLd;
+    private final DataPlaneProtocolInUse dataPlaneProtocolInUse;
 
-    public VaultDataAddressStore(Vault vault, TypeTransformerRegistry typeTransformerRegistry, JsonLd jsonLd) {
+    public VaultDataAddressStore(Vault vault, TypeTransformerRegistry typeTransformerRegistry, JsonLd jsonLd,
+                                 DataPlaneProtocolInUse dataPlaneProtocolInUse) {
         this.vault = vault;
         this.typeTransformerRegistry = typeTransformerRegistry;
         this.jsonLd = jsonLd;
+        this.dataPlaneProtocolInUse = dataPlaneProtocolInUse;
     }
 
     @Override
@@ -53,7 +57,11 @@ public class VaultDataAddressStore implements DataAddressStore {
                 .flatMap(this::toStoreResult)
                 .onSuccess(o -> {
                     transferProcess.setDataAddressAlias(alias);
-                    transferProcess.updateDestination(null);
+                    if (dataPlaneProtocolInUse.isLegacy()) {
+                        transferProcess.updateDestination(dataAddress);
+                    } else {
+                        transferProcess.updateDestination(null);
+                    }
                 });
     }
 

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/TransferDataPlaneSignalingExtension.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/TransferDataPlaneSignalingExtension.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowControll
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowPropertiesProvider;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.TransferTypeParser;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataAddressStore;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataPlaneProtocolInUse;
 import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
 import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClientFactory;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -63,9 +64,12 @@ public class TransferDataPlaneSignalingExtension implements ServiceExtension {
     private DataAddressStore dataAddressStore;
     @Inject
     private Monitor monitor;
+    @Inject
+    private DataPlaneProtocolInUse dataPlaneProtocolInUse;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
+        dataPlaneProtocolInUse.setLegacy(true);
         monitor.warning("The EDC Data Plane has been deprecated, the related modules will be removed in future releases, " +
                 "please look into Data Plane Signaling specification and implement your own Data Planes. The EDC control-plane " +
                 "is already supporting that specification, by adding the `data-plane-signaling` module to your runtime and " +

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/DataPlaneProtocolInUse.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/DataPlaneProtocolInUse.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.transfer.spi.types;
+
+/**
+ * This service is needed to avoid breaking changes in the TransferProcess behavior during the introduction of the new
+ * Data Plane Signaling protocol.
+ *
+ * @deprecated will be removed together with the Legacy Data Plane signaling protocol.
+ */
+@Deprecated(since = "0.16.0")
+public class DataPlaneProtocolInUse {
+    private boolean isLegacy = false;
+
+    public void setLegacy(boolean legacy) {
+        isLegacy = legacy;
+    }
+
+    public boolean isLegacy() {
+        return isLegacy;
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Adds missing storage of `DataAddress` on Transfer initialization on consumer side.
Avoid deleting `dataDestination` from TransferProcess when the data plane protocol used is the legacy one: this will avoid breaking the management contract for which the data destination is readable from the management API.
With the new data plane signaling specs the data destination/data address will be totally managed by the data-plane so it could be eventually requested there, but the control-plane will just store it securely to being able to pass it to the counter party but nothing more..

To permit this I introduced a `DataPlaneProtocolInUse` service class that permits the `VaultDataAddress` to understand when the DataAddress needs to be stored in the vault (new protocol) or in the vault and the database (legacy protocol).
It's already deprecated so it will be deleted together with the legacy protocol.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5516 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
