### PR TITLE
fix: serialize policy profiles

### DIFF
--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
@@ -64,6 +64,7 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PERMISSION_AT
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_AGREEMENT;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_SET;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROFILE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROHIBITION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_REFINEMENT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_REMEDY_ATTRIBUTE;
@@ -177,6 +178,12 @@ public class JsonObjectFromPolicyTransformer extends AbstractJsonLdTransformer<P
                             ODRL_TARGET_ATTRIBUTE,
                             jsonFactory.createArrayBuilder().add(jsonFactory.createObjectBuilder().add(ID, target)))
                     );
+
+            if (!policy.getProfiles().isEmpty()) {
+                var profiles = jsonFactory.createArrayBuilder();
+                policy.getProfiles().stream().map(profile -> jsonFactory.createObjectBuilder().add(ID, profile)).forEach(profiles::add);
+                builder.add(ODRL_PROFILE_ATTRIBUTE, profiles);
+            }
 
             return builder.build();
         }

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformerTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -66,6 +67,7 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PERMISSION_AT
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_AGREEMENT;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_SET;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROFILE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROHIBITION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_REFINEMENT_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_REMEDY_ATTRIBUTE;
@@ -110,6 +112,7 @@ class JsonObjectFromPolicyTransformerTest {
                 .permission(permission)
                 .prohibition(prohibition)
                 .duty(duty)
+                .profiles(List.of("profile"))
                 .build();
 
         var result = transformer.transform(policy, context);
@@ -152,6 +155,10 @@ class JsonObjectFromPolicyTransformerTest {
         var dutyJson = result.get(ODRL_OBLIGATION_ATTRIBUTE).asJsonArray().get(0).asJsonObject();
         assertThat(dutyJson.getJsonObject(ODRL_ACTION_ATTRIBUTE)).isNotNull();
         assertThat(dutyJson.getJsonObject(ODRL_CONSTRAINT_ATTRIBUTE)).isNull();
+
+        var profileJson = result.get(ODRL_PROFILE_ATTRIBUTE).asJsonArray();
+        assertThat(profileJson).hasSize(1).first().extracting(JsonValue::asJsonObject)
+                .extracting(it -> it.getString(ID)).isEqualTo("profile");
 
         verify(context, never()).reportProblem(anyString());
         verify(participantIdMapper).toIri("assignee");


### PR DESCRIPTION
## What this PR changes/adds

Add missing serialization for `Policy` profiles

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4843

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
