### PR TITLE
feat: additional contexts on compact

### DIFF
--- a/core/common/lib/json-ld-lib/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
+++ b/core/common/lib/json-ld-lib/src/main/java/org/eclipse/edc/jsonld/TitaniumJsonLd.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -107,13 +108,17 @@ public class TitaniumJsonLd implements JsonLd {
         }
     }
 
-    @Override
     public Result<JsonObject> compact(JsonObject json, String scope) {
+        return compact(json, scope, List.of());
+    }
+
+    @Override
+    public Result<JsonObject> compact(JsonObject json, String scope, List<Object> additionalContexts) {
         try {
             var document = JsonDocument.of(json);
             var jsonFactory = createBuilderFactory(Map.of());
             var contextDocument = JsonDocument.of(jsonFactory.createObjectBuilder()
-                    .add(JsonLdKeywords.CONTEXT, createContext(scope))
+                    .add(JsonLdKeywords.CONTEXT, createContext(scope, additionalContexts))
                     .build());
             var compacted = com.apicatalog.jsonld.JsonLd.compact(document, contextDocument)
                     .options(new JsonLdOptions(documentLoader))
@@ -163,8 +168,9 @@ public class TitaniumJsonLd implements JsonLd {
         return jsonObjectBuilder.build();
     }
 
-    private JsonValue createContext(String scope) {
+    private JsonValue createContext(String scope, List<Object> additionalContext) {
         var builder = createObjectBuilder();
+
         // Adds the configured namespaces for * and the input scope
         Stream.concat(namespacesForScope(JsonLd.DEFAULT_SCOPE), namespacesForScope(scope))
                 .forEach(entry -> builder.add(entry.getKey(), entry.getValue()));
@@ -172,6 +178,17 @@ public class TitaniumJsonLd implements JsonLd {
         // Compute the additional context IRI defined for * and the input scope
         var contexts = Stream.concat(contextsForScope(JsonLd.DEFAULT_SCOPE), contextsForScope(scope))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        // Dispatch context entries (URLs as strings, objects as JsonObjects)
+        if (additionalContext != null) {
+            for (Object entry : additionalContext) {
+                if (entry instanceof String url) {
+                    contexts.add(url);
+                } else if (entry instanceof JsonObject object) {
+                    object.forEach(builder::add);
+                }
+            }
+        }
 
         var contextObject = builder.build();
         // if not empty we build a JsonArray

--- a/core/common/lib/json-ld-lib/src/test/java/org/eclipse/edc/jsonld/TitaniumJsonLdTest.java
+++ b/core/common/lib/json-ld-lib/src/test/java/org/eclipse/edc/jsonld/TitaniumJsonLdTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.net.URI;
+import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -287,6 +288,46 @@ class TitaniumJsonLdTest {
         });
 
         var compacted = service.compact(expanded.getContent(), customScope);
+
+        assertThat(compacted).isSucceeded().satisfies(c -> {
+            Assertions.assertThat(c).isEqualTo(input);
+        });
+    }
+
+    @Test
+    void expandAndCompact_withAdditionalContexts() {
+        var schemaContext = "http://schema.org/";
+        var testSchemaNs = "http://test.org/";
+
+        var inlineContext = createObjectBuilder()
+                .add("testSchema", testSchemaNs)
+                .add("surname", "testSchema:surname")
+                .add("status", createObjectBuilder().add("@id", "testSchema:status").add("@type", "@id").build())
+                .build();
+
+        var input = createObjectBuilder()
+                .add("@context", createArrayBuilder().add(schemaContext).add(inlineContext).build())
+                .add(JsonLdKeywords.TYPE, "Person")
+                .add("name", "Jane Doe")
+                .add("jobTitle", "Professor")
+                .add("surname", "Surname")
+                .add("status", "http://example.com/status/active")
+                .build();
+
+        var service = defaultService();
+
+        service.registerCachedDocument(schemaContext, TestUtils.getFileFromResourceName("schema-org-light.jsonld").toURI());
+
+        var expanded = service.expand(input);
+
+        assertThat(expanded).isSucceeded().satisfies(c -> {
+            Assertions.assertThat(c.getJsonArray(schemaContext + "name").get(0).asJsonObject().getJsonString(JsonLdKeywords.VALUE).getString()).isEqualTo("Jane Doe");
+            Assertions.assertThat(c.getJsonArray(schemaContext + "jobTitle").get(0).asJsonObject().getJsonString(JsonLdKeywords.VALUE).getString()).isEqualTo("Professor");
+            Assertions.assertThat(c.getJsonArray(testSchemaNs + "surname").get(0).asJsonObject().getJsonString(JsonLdKeywords.VALUE).getString()).isEqualTo("Surname");
+            Assertions.assertThat(c.getJsonArray(testSchemaNs + "status").get(0).asJsonObject().getJsonString(JsonLdKeywords.ID).getString()).isEqualTo("http://example.com/status/active");
+        });
+
+        var compacted = service.compact(expanded.getContent(), List.of("http://schema.org/", inlineContext));
 
         assertThat(compacted).isSucceeded().satisfies(c -> {
             Assertions.assertThat(c).isEqualTo(input);

--- a/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
+++ b/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "2.1.4",
     "urlPath": "/v1",
-    "lastUpdated": "2026-02-13T12:00:01Z",
+    "lastUpdated": "2026-02-27T12:00:01Z",
     "maturity": "stable"
   }
 ]

--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -8,7 +8,7 @@
   {
     "version": "4.0.0-beta",
     "urlPath": "/v4beta",
-    "lastUpdated": "2026-02-23T08:43:01Z",
+    "lastUpdated": "2026-02-27T08:43:01Z",
     "maturity": "beta"
   }
 ]

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/JsonLd.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/JsonLd.java
@@ -18,6 +18,7 @@ import jakarta.json.JsonObject;
 import org.eclipse.edc.spi.result.Result;
 
 import java.net.URI;
+import java.util.List;
 
 /**
  * Provides JsonLD expansion/compaction functionalities.
@@ -51,6 +52,27 @@ public interface JsonLd {
      * @return a successful {@link Result} containing the compacted {@link JsonObject} if the operation succeed, a failed one otherwise
      */
     Result<JsonObject> compact(JsonObject json, String scope);
+
+    /**
+     * Compact a JsonLD document. The context will be generated from registered contexts and namespaces.
+     *
+     * @param json               the expanded json.
+     * @param additionalContexts a list of additional contexts to apply during the compaction process. The list can contain both context IRIs or JsonObjects representing the context.
+     * @return a successful {@link Result} containing the compacted {@link JsonObject} if the operation succeed, a failed one otherwise
+     */
+    default Result<JsonObject> compact(JsonObject json, List<Object> additionalContexts) {
+        return compact(json, DEFAULT_SCOPE, additionalContexts);
+    }
+
+    /**
+     * Compact a JsonLD document. The context will be generated from registered contexts and namespaces.
+     *
+     * @param json               the expanded json.
+     * @param scope              the scope to apply during the compaction process
+     * @param additionalContexts a list of additional contexts to apply during the compaction process. The list can contain both context IRIs or JsonObjects representing the context.
+     * @return a successful {@link Result} containing the compacted {@link JsonObject} if the operation succeed, a failed one otherwise
+     */
+    Result<JsonObject> compact(JsonObject json, String scope, List<Object> additionalContexts);
 
     /**
      * Register a JsonLD namespace in the default scope


### PR DESCRIPTION
## What this PR changes/adds

Add a `compact` api that accept additional JSON-LD context definition which can be
context IRIs or `JsonObject` for inline context definition.

## Why it does that

This is somehow related to the #5518. It will be a change required for both implementation strategy

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
