### PR TITLE
refactor: remove well known path configuration

### DIFF
--- a/data-protocols/dsp/dsp-core/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/DspHttpCoreExtension.java
+++ b/data-protocols/dsp/dsp-core/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/DspHttpCoreExtension.java
@@ -48,7 +48,6 @@ import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
-import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.iam.AudienceResolver;
 import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -75,11 +74,6 @@ import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 public class DspHttpCoreExtension implements ServiceExtension {
 
     public static final String NAME = "Dataspace Protocol Core Extension";
-
-    private static final boolean DEFAULT_WELL_KNOWN_PATH = false;
-
-    @Setting(description = "If set enable the well known path resolution scheme will be used", key = "edc.dsp.well-known-path.enabled", required = false, defaultValue = DEFAULT_WELL_KNOWN_PATH + "")
-    private boolean wellKnownPathEnabled;
 
     @Inject
     private EdcHttpClient httpClient;
@@ -151,9 +145,9 @@ public class DspHttpCoreExtension implements ServiceExtension {
         return dspTransformerRegistry;
     }
 
-    @Provider
+    @Provider(isDefault = true)
     public DspRequestBasePathProvider dspRequestBasePathProvider() {
-        return new DspRequestBasePathProviderImpl(dataspaceProfileContextRegistry, wellKnownPathEnabled);
+        return new DspRequestBasePathProviderImpl();
     }
 
     private void registerNegotiationPolicyScopes(DspHttpRemoteMessageDispatcher dispatcher) {

--- a/data-protocols/dsp/dsp-core/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspRequestBasePathProviderImpl.java
+++ b/data-protocols/dsp/dsp-core/dsp-http-core/src/main/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspRequestBasePathProviderImpl.java
@@ -15,43 +15,16 @@
 package org.eclipse.edc.protocol.dsp.http.dispatcher;
 
 import org.eclipse.edc.protocol.dsp.http.spi.dispatcher.DspRequestBasePathProvider;
-import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
-import org.eclipse.edc.protocol.spi.ProtocolVersion;
-import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
-
-import java.util.Optional;
-
-import static java.lang.String.format;
 
 public class DspRequestBasePathProviderImpl implements DspRequestBasePathProvider {
 
-    private final DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
-    private final boolean wellKnownPath;
-
-    public DspRequestBasePathProviderImpl(DataspaceProfileContextRegistry dataspaceProfileContextRegistry, boolean wellKnownPath) {
-        this.dataspaceProfileContextRegistry = dataspaceProfileContextRegistry;
-        this.wellKnownPath = wellKnownPath;
+    public DspRequestBasePathProviderImpl() {
     }
 
     @Override
     public String provideBasePath(RemoteMessage message) {
-        if (!wellKnownPath) {
-            return message.getCounterPartyAddress();
-        }
-
-        var protocolPath = Optional.ofNullable(dataspaceProfileContextRegistry.getProtocolVersion(message.getProtocol()))
-                .map(ProtocolVersion::path)
-                .map(this::removeTrailingSlash)
-                .orElseThrow(() -> new EdcException(format("No protocol version found for protocol: %s", message.getProtocol())));
-
-        return message.getCounterPartyAddress() + protocolPath;
+        return message.getCounterPartyAddress();
     }
 
-    private String removeTrailingSlash(String path) {
-        if (path.endsWith("/")) {
-            return path.substring(0, path.length() - 1);
-        }
-        return path;
-    }
 }


### PR DESCRIPTION
## What this PR changes/adds

remove well known path configuration `edc.dsp.well-known-path.enabled`.  
The injectable service impl `DspRequestBasePathProvider` has been changed to default provider, similar behavior 
can be achieved by custom `DspRequestBasePathProvider` if necessary



## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5525 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
