### PR TITLE
refactor: move federated catalog spi files to Connector repo

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -286,6 +286,8 @@ include(":spi:data-plane:data-plane-http-spi")
 
 include(":spi:data-plane-selector:data-plane-selector-spi")
 include(":spi:policy-monitor:policy-monitor-spi")
+include(":spi:crawler-spi")
+include(":spi:federated-catalog-spi")
 
 
 // modules for system tests ------------------------------------------------------------------------

--- a/spi/crawler-spi/build.gradle.kts
+++ b/spi/crawler-spi/build.gradle.kts
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `java-test-fixtures`
+}
+
+dependencies {
+    api(project(":spi:control-plane:catalog-spi"))
+    api(project(":spi:common:core-spi"))
+
+    testFixturesImplementation(project(":core:common:junit"))
+}

--- a/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/CrawlerAction.java
+++ b/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/CrawlerAction.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.crawler.spi;
+
+import org.eclipse.edc.crawler.spi.model.UpdateRequest;
+import org.eclipse.edc.crawler.spi.model.UpdateResponse;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * Takes an {@link UpdateRequest}, sends it to the intended endpoint using a particular application protocol (e.g. HTTP) to get that
+ * endpoint's data.
+ * <p>
+ * For example, one could devise a {@code WeatherForecastAction} that queries a weather forecast endpoint.
+ */
+public interface CrawlerAction extends Function<UpdateRequest, CompletableFuture<UpdateResponse>> {
+}

--- a/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/CrawlerActionRegistry.java
+++ b/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/CrawlerActionRegistry.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.crawler.spi;
+
+import java.util.Collection;
+
+/**
+ * Registry where {@link CrawlerAction} instances are stored and maintained.
+ */
+public interface CrawlerActionRegistry {
+
+    /**
+     * Finds a {@link CrawlerAction} that was registered for the given protocol name.
+     *
+     * @param protocolName An arbitrary String identifying the protocol.
+     * @return A list of protocol adapters that can handle that protocol, or an empty list if none was found.
+     */
+    Collection<CrawlerAction> findForProtocol(String protocolName);
+
+    /**
+     * Registers a {@link CrawlerAction} for a given protocol
+     */
+    void register(String protocolName, CrawlerAction adapter);
+
+    /**
+     * Removes a specific {@link CrawlerAction} registration
+     */
+    void unregister(String protocolName, CrawlerAction adapter);
+}

--- a/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/CrawlerErrorHandler.java
+++ b/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/CrawlerErrorHandler.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.crawler.spi;
+
+import java.util.function.Consumer;
+
+/**
+ * Invoked whenever a {@link CrawlerAction} was completed unsuccessfully. Error handlers receive the entire {@link WorkItem}
+ * to enable features like re-enqueueing it after a transient failure.
+ * Inpsect {@link WorkItem#getErrors()} to obtain the actual errors.
+ */
+@FunctionalInterface
+public interface CrawlerErrorHandler extends Consumer<WorkItem> {
+}

--- a/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/CrawlerSuccessHandler.java
+++ b/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/CrawlerSuccessHandler.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.crawler.spi;
+
+import org.eclipse.edc.crawler.spi.model.UpdateResponse;
+
+import java.util.function.Consumer;
+
+/**
+ * Handler to be called when a crawler has successfully executed its {@link CrawlerAction}
+ */
+@FunctionalInterface
+public interface CrawlerSuccessHandler extends Consumer<UpdateResponse> {
+}

--- a/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/TargetNode.java
+++ b/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/TargetNode.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.crawler.spi;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * Represents an abstract crawl target, i.e. some endpoint, that a crawler can target using a specific {@link CrawlerAction}.
+ * All {@link TargetNode} entries are maintained in a {@link TargetNodeDirectory}.
+ */
+public record TargetNode(@JsonProperty("name") String name,
+                         @JsonProperty("id") String id,
+                         @JsonProperty("url") String targetUrl,
+                         @JsonProperty("supportedProtocols") List<String> supportedProtocols) {
+    @JsonCreator
+    public TargetNode {
+    }
+}

--- a/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/TargetNodeDirectory.java
+++ b/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/TargetNodeDirectory.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.crawler.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+
+import java.util.List;
+
+/**
+ * A global list of all {@link TargetNode} entries, that are available to crawl in a data space, much like a "phone book" for catalog endpoints.
+ * Each {@link TargetNode} is queryable using a particular protocol.
+ */
+@ExtensionPoint
+public interface TargetNodeDirectory {
+
+    /**
+     * Get all nodes.
+     */
+    List<TargetNode> getAll();
+
+    /**
+     * Inserts (="registers") a node into the directory.
+     */
+    void insert(TargetNode node);
+
+    /**
+     * Removes (="unregisters") a node from the directory by its ID.
+     *
+     * @param id ID of the node to be removed.
+     * @return TargetNode containing the removed node if it was found and removed, otherwise null.
+     */
+    TargetNode remove(String id);
+}

--- a/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/TargetNodeFilter.java
+++ b/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/TargetNodeFilter.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.crawler.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+
+import java.util.function.Predicate;
+
+/**
+ * Marker interface to select {@link TargetNode} instances which should be crawled (or skipped).
+ */
+@ExtensionPoint
+public interface TargetNodeFilter extends Predicate<TargetNode> {
+    // marker interface to make it easily injectable
+}

--- a/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/WorkItem.java
+++ b/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/WorkItem.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.crawler.spi;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a job in a crawl run. Every {@link TargetNode} is converted into a {@code WorkItem}, which is then fed to a
+ * {@code Crawler} alongside a {@link CrawlerAction}.
+ * The {@code Crawler} takes the {@link WorkItem} and executes the {@link CrawlerAction} against it.
+ */
+public class WorkItem {
+    private final String id;
+    private final String url;
+    private final String protocol;
+    private final List<String> errors;
+
+    public WorkItem(String id, String url, String protocol) {
+        this.id = id;
+        this.url = url;
+        this.protocol = protocol;
+        errors = new ArrayList<>();
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void error(String message) {
+        errors.add(message);
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    @Override
+    public String toString() {
+        return "WorkItem{" +
+                "id='" + id + '\'' +
+                ", url='" + url + '\'' +
+                ", protocol='" + protocol + '\'' +
+                ", errors=" + errors +
+                '}';
+    }
+}

--- a/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/model/ExecutionPlan.java
+++ b/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/model/ExecutionPlan.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *       Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. - Add stop method
+ *
+ */
+
+package org.eclipse.edc.crawler.spi.model;
+
+/**
+ * Interface for any sort of planned execution of a {@link Runnable} task.
+ */
+public interface ExecutionPlan {
+
+    /**
+     * Execute the task. While not strictly required, spawning another
+     * thread it is highly recommended e.g. by forwarding to an {@link java.util.concurrent.Executor}
+     *
+     * @param task A runnable
+     */
+    void run(Runnable task);
+
+    /**
+     * Stops the execution of the task. It is recommended to ensure that all
+     * resources are properly released and any ongoing tasks are gracefully
+     * terminated.
+     */
+    void stop();
+}

--- a/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/model/UpdateRequest.java
+++ b/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/model/UpdateRequest.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.crawler.spi.model;
+
+import org.eclipse.edc.crawler.spi.CrawlerAction;
+
+/**
+ * {@link CrawlerAction}s accept {@code UpdateRequests} to execute
+ */
+public record UpdateRequest(String nodeId, String nodeUrl, String protocol) {
+}

--- a/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/model/UpdateResponse.java
+++ b/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/model/UpdateResponse.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.crawler.spi.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.edc.crawler.spi.CrawlerAction;
+
+/**
+ * {@link CrawlerAction}s return {@code UpdateResponse} objects after it completes. Contains information about the {@code source}, i.e. where the response comes from
+ * <p>
+ * Implementors of the {@link CrawlerAction} are expected to provide their specialization of the UpdateResponse
+ */
+public abstract class UpdateResponse {
+    private final String source;
+
+    @JsonCreator
+    public UpdateResponse(@JsonProperty("source") String source) {
+        this.source = source;
+    }
+
+    /**
+     * The URL from which the catalog update originates, i.e. the catalog's sender
+     */
+    public String getSource() {
+        return source;
+    }
+}

--- a/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/package-info.java
+++ b/spi/crawler-spi/src/main/java/org/eclipse/edc/crawler/spi/package-info.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+@Spi("Crawler services")
+package org.eclipse.edc.crawler.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Spi;

--- a/spi/crawler-spi/src/testFixtures/java/org/eclipse/edc/catalog/spi/testfixtures/TargetNodeDirectoryTestBase.java
+++ b/spi/crawler-spi/src/testFixtures/java/org/eclipse/edc/catalog/spi/testfixtures/TargetNodeDirectoryTestBase.java
@@ -1,0 +1,107 @@
+/*
+ *  Copyright (c) 2024 Amadeus IT Group
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus IT Group - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.spi.testfixtures;
+
+import org.eclipse.edc.crawler.spi.TargetNode;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class TargetNodeDirectoryTestBase {
+
+    protected abstract TargetNodeDirectory getStore();
+
+    private TargetNode createTargetNode(String id) {
+        return new TargetNode(UUID.randomUUID().toString(), id, "http://example.com", List.of());
+    }
+
+    @Nested
+    class Insert {
+
+        @Test
+        void insert_notExisting_shouldInsert() {
+            var node = createTargetNode(UUID.randomUUID().toString());
+
+            getStore().insert(node);
+
+            var result = getStore().getAll();
+
+            assertThat(result)
+                    .hasSize(1)
+                    .allSatisfy(n -> assertThat(n).usingRecursiveComparison().isEqualTo(node));
+        }
+
+        @Test
+        void insert_existing_shouldUpdate() {
+            var id = UUID.randomUUID().toString();
+            var node1 = createTargetNode(id);
+            var node2 = createTargetNode(id);
+
+            getStore().insert(node1);
+            getStore().insert(node2);
+
+            var result = getStore().getAll();
+
+            assertThat(result)
+                    .hasSize(1)
+                    .allSatisfy(n -> assertThat(n).usingRecursiveComparison().isEqualTo(node2));
+        }
+    }
+
+    @Nested
+    class GetAll {
+
+        @Test
+        void getAll() {
+            var nodes = List.of(createTargetNode(UUID.randomUUID().toString()), createTargetNode(UUID.randomUUID().toString()));
+
+            nodes.forEach(getStore()::insert);
+
+            var result = getStore().getAll();
+
+            assertThat(result)
+                    .hasSize(2)
+                    .anySatisfy(n -> assertThat(n.id()).isEqualTo(nodes.get(0).id()))
+                    .anySatisfy(n -> assertThat(n.id()).isEqualTo(nodes.get(1).id()));
+        }
+    }
+
+    @Nested
+    class Remove {
+
+        @Test
+        void remove_shouldRemoveAndReturnNode() {
+            var node = createTargetNode(UUID.randomUUID().toString());
+            getStore().insert(node);
+
+            var removed = getStore().remove(node.id());
+
+            assertThat(removed).usingRecursiveComparison().isEqualTo(node);
+            assertThat(getStore().getAll()).isEmpty();
+        }
+
+        @Test
+        void remove_notFound_shouldReturnNull() {
+            var result = getStore().remove("non-existent-id");
+
+            assertThat(result).isNull();
+        }
+    }
+}

--- a/spi/federated-catalog-spi/build.gradle.kts
+++ b/spi/federated-catalog-spi/build.gradle.kts
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `java-test-fixtures`
+}
+
+dependencies {
+    api(project(":spi:crawler-spi"))
+    api(project(":spi:control-plane:catalog-spi"))
+    api(project(":spi:common:core-spi"))
+
+    testFixturesImplementation(project(":core:common:junit"))
+}

--- a/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogConstants.java
+++ b/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogConstants.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.spi;
+
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
+public interface CatalogConstants {
+    String PROPERTY_ORIGINATOR = EDC_NAMESPACE + "originator";
+    @Deprecated(since = "0.14.1")
+    String DATASPACE_PROTOCOL = "dataspace-protocol-http";
+}

--- a/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogCrawlerConfiguration.java
+++ b/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/CatalogCrawlerConfiguration.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+
+import java.util.Optional;
+
+import static java.lang.String.format;
+
+@Settings
+public record CatalogCrawlerConfiguration(
+
+        @Setting(
+                description = "Determines whether catalog crawling is globally enabled or disabled",
+                key = "edc.catalog.cache.execution.enabled",
+                defaultValue = "true")
+        boolean enabled,
+
+        @Setting(
+                description = "The number of crawlers (execution threads) that should be used. The engine will re-use crawlers when necessary.",
+                key = "edc.catalog.cache.partition.num.crawlers",
+                defaultValue = "2")
+        int numCrawlers,
+
+        @Setting(
+                description = "The time to elapse between two crawl runs",
+                key = "edc.catalog.cache.execution.period.seconds",
+                defaultValue = "60")
+        long periodSeconds,
+
+        @Setting(
+                description = "The initial delay for the cache crawler engine",
+                key = "edc.catalog.cache.execution.delay.seconds",
+                required = false,
+                defaultValue = "0")
+        int delaySeconds,
+
+        @Setting(
+                description = "How many retries will be executed in case of crawler failure",
+                key = "edc.catalog.cache.retry.retries.max",
+                defaultValue = "5")
+        int maxRetries,
+
+        @Setting(
+                description = "How many seconds the crawler will await after a failure before retry",
+                key = "edc.catalog.cache.retry.delay.seconds",
+                defaultValue = "10")
+        int retryDelaySeconds
+
+) {
+    private static final int LOW_EXECUTION_PERIOD_SECONDS_THRESHOLD = 10;
+
+    public Optional<String> checkPeriodSeconds() {
+        if (periodSeconds() < LOW_EXECUTION_PERIOD_SECONDS_THRESHOLD) {
+            var message = format("An execution period of %d seconds is very low (threshold = %d). This might result in the work queue to be ever growing." +
+                    " A longer execution period or more crawler threads (currently using %d) should be considered.", periodSeconds(), LOW_EXECUTION_PERIOD_SECONDS_THRESHOLD, numCrawlers());
+            return Optional.of(message);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/FccApiContexts.java
+++ b/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/FccApiContexts.java
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.spi;
+
+public interface FccApiContexts {
+    String CATALOG_QUERY = "catalog";
+}

--- a/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/FederatedCatalogCache.java
+++ b/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/FederatedCatalogCache.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.spi;
+
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.query.QuerySpec;
+
+import java.util.Collection;
+
+/**
+ * Internal datastore where all the catalogs from all the other connectors are stored by the FederatedCatalogCache.
+ */
+@ExtensionPoint
+public interface FederatedCatalogCache {
+
+    /**
+     * Adds an {@code ContractOffer} to the store
+     */
+    void save(Catalog catalog);
+
+    /**
+     * Queries the store for {@code ContractOffer}s
+     *
+     * @param query A list of criteria the asset must fulfill
+     * @return A collection of assets that are already in the store and that satisfy a given list of criteria.
+     */
+    Collection<Catalog> query(QuerySpec query);
+
+    /**
+     * Deletes all entries from the cache that are marked as "expired"
+     */
+    void deleteExpired();
+
+    /**
+     * Marks all entries as "expired", i.e. marks them for deletion
+     */
+    void expireAll();
+}

--- a/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/QueryResponse.java
+++ b/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/QueryResponse.java
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.spi;
+
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class QueryResponse {
+    private Status status;
+    private List<String> errors = new ArrayList<>();
+    private List<Catalog> catalogs = new ArrayList<>();
+
+    private QueryResponse(Status status) {
+        this.status = status;
+        errors = new ArrayList<>();
+    }
+
+    public QueryResponse() {
+    }
+
+    public static QueryResponse ok(List<Catalog> result) {
+        return Builder.newInstance()
+                .status(Status.ACCEPTED)
+                .catalogs(result)
+                .build();
+    }
+
+    public List<Catalog> getCatalogs() {
+        return catalogs;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    public enum Status {
+        ACCEPTED,
+        NO_ADAPTER_FOUND
+    }
+
+    public static final class Builder {
+
+        private final QueryResponse response;
+
+        private Builder() {
+            response = new QueryResponse();
+            response.status = Status.ACCEPTED; //that's the default
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder catalogs(List<Catalog> catalogs) {
+            response.catalogs = catalogs;
+            return this;
+        }
+
+        public Builder status(Status status) {
+            response.status = status;
+            return this;
+        }
+
+        public QueryResponse build() {
+            return response;
+        }
+
+        public Builder error(String error) {
+            response.errors.add(error);
+            return this;
+        }
+    }
+}

--- a/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/QueryService.java
+++ b/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/QueryService.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.spi;
+
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+import java.util.Collection;
+
+/**
+ * Accepts a {@link QuerySpec} and fetches a collection of {@link Asset} that conform to that query.
+ */
+@FunctionalInterface
+public interface QueryService {
+
+    ServiceResult<Collection<Catalog>> getCatalog(QuerySpec query);
+}

--- a/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/model/CatalogUpdateResponse.java
+++ b/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/model/CatalogUpdateResponse.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.spi.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.crawler.spi.model.UpdateResponse;
+
+public class CatalogUpdateResponse extends UpdateResponse {
+    private final Catalog catalog;
+
+    @JsonCreator
+    public CatalogUpdateResponse(@JsonProperty("source") String source, @JsonProperty("catalog") Catalog catalog) {
+        super(source);
+        this.catalog = catalog;
+    }
+
+    public Catalog getCatalog() {
+        return catalog;
+    }
+}

--- a/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/package-info.java
+++ b/spi/federated-catalog-spi/src/main/java/org/eclipse/edc/catalog/spi/package-info.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+@Spi("Catalog services")
+package org.eclipse.edc.catalog.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Spi;

--- a/spi/federated-catalog-spi/src/testFixtures/java/org/eclipse/edc/catalog/spi/testfixtures/FederatedCatalogCacheTestBase.java
+++ b/spi/federated-catalog-spi/src/testFixtures/java/org/eclipse/edc/catalog/spi/testfixtures/FederatedCatalogCacheTestBase.java
@@ -1,0 +1,260 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.spi.testfixtures;
+
+import org.eclipse.edc.catalog.spi.CatalogConstants;
+import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class FederatedCatalogCacheTestBase {
+
+    protected abstract FederatedCatalogCache getStore();
+
+    private Catalog createCatalog(String id, Asset asset) {
+        return createCatalogBuilder(id, asset).build();
+    }
+
+    private Catalog.Builder createCatalogBuilder(String id, Asset asset) {
+        return createCatalogBuilder(id, asset, null);
+    }
+
+    private Catalog.Builder createCatalogBuilder(String id, Asset asset, String ednpointUrl) {
+        var dataService = DataService.Builder.newInstance().endpointUrl(ednpointUrl).build();
+        var dataset = Dataset.Builder.newInstance().id(asset.getId()).properties(asset.getProperties()).distributions(List.of(Distribution.Builder.newInstance().dataService(dataService).format("test-format").build())).build();
+
+        var nestedCatalog = Catalog.Builder.newInstance().participantId("participantId").build();
+
+        return Catalog.Builder.newInstance()
+                .id(id)
+                .dataServices(List.of(dataService))
+                .datasets(List.of(dataset, nestedCatalog))
+                .property(CatalogConstants.PROPERTY_ORIGINATOR, "https://test.source/" + id);
+    }
+
+    private Asset createAsset(String id) {
+        return createAssetBuilder(id)
+                .build();
+    }
+
+    private Asset.Builder createAssetBuilder(String id) {
+        return Asset.Builder.newInstance()
+                .id(id);
+    }
+
+    @Nested
+    class Save {
+
+        @Test
+        void save_shouldReturnUniqueElement() {
+            var contractOfferId = UUID.randomUUID().toString();
+            var assetId = UUID.randomUUID().toString();
+            var catalogEntry = createCatalog(contractOfferId, createAsset(assetId));
+
+            getStore().save(catalogEntry);
+
+            var result = getStore().query(QuerySpec.none());
+
+            assertThat(result)
+                    .hasSize(1)
+                    .allSatisfy(co -> {
+                        assertThat(co.getDatasets().get(0).getId()).isEqualTo(assetId);
+                        assertThat(co.getDatasets().get(1)).isInstanceOf(Catalog.class);
+                    });
+        }
+
+        @Test
+        void save_shouldReturnLastInsertedContractOfferOnly() {
+            var contractOfferId1 = UUID.randomUUID().toString();
+            var assetId = UUID.randomUUID().toString();
+            var entry1 = createCatalog(contractOfferId1, createAsset(assetId));
+            var entry2 = createCatalog(contractOfferId1, createAsset(assetId));
+
+            getStore().save(entry1);
+            getStore().save(entry2);
+
+            var result = getStore().query(QuerySpec.none());
+
+            assertThat(result)
+                    .hasSize(1)
+                    .allSatisfy(co -> {
+                        assertThat(co.getId()).isEqualTo(contractOfferId1);
+                        assertThat(co.getDatasets().get(0).getId()).isEqualTo(assetId);
+                    });
+        }
+
+        @Test
+        void save_shouldReturnBothContractOffers() {
+            var contractOfferId1 = UUID.randomUUID().toString();
+            var contractOfferId2 = UUID.randomUUID().toString();
+            var assetId1 = UUID.randomUUID().toString();
+            var assetId2 = UUID.randomUUID().toString();
+            var entry1 = createCatalog(contractOfferId1, createAsset(assetId1));
+            var entry2 = createCatalog(contractOfferId2, createAsset(assetId2));
+
+            getStore().save(entry1);
+            getStore().save(entry2);
+
+            var result = getStore().query(QuerySpec.none());
+
+            assertThat(result)
+                    .hasSize(2)
+                    .anySatisfy(co -> assertThat(co.getDatasets().get(0).getId()).isEqualTo(assetId1))
+                    .anySatisfy(co -> assertThat(co.getDatasets().get(0).getId()).isEqualTo(assetId2));
+        }
+    }
+
+    @Nested
+    class Query {
+
+        @Test
+        void queryByParticipantId() {
+            var contractOfferId1 = UUID.randomUUID().toString();
+            var contractOfferId2 = UUID.randomUUID().toString();
+            var assetId1 = UUID.randomUUID().toString();
+            var assetId2 = UUID.randomUUID().toString();
+            var entry1 = createCatalogBuilder(contractOfferId1, createAsset(assetId1)).participantId("participant1").build();
+            var entry2 = createCatalogBuilder(contractOfferId2, createAsset(assetId2)).participantId("participant2").build();
+
+            getStore().save(entry1);
+            getStore().save(entry2);
+
+            var query = QuerySpec.Builder.newInstance().filter(Criterion.criterion("participantId", "=", entry1.getParticipantId())).build();
+            var result = getStore().query(query);
+
+            assertThat(result)
+                    .hasSize(1)
+                    .allSatisfy(co -> assertThat(co.getParticipantId()).isEqualTo(entry1.getParticipantId()));
+        }
+
+        @Test
+        void queryByDatasetId() {
+            var contractOfferId1 = UUID.randomUUID().toString();
+            var contractOfferId2 = UUID.randomUUID().toString();
+            var assetId1 = UUID.randomUUID().toString();
+            var assetId2 = UUID.randomUUID().toString();
+            var entry1 = createCatalogBuilder(contractOfferId1, createAsset(assetId1)).build();
+            var entry2 = createCatalogBuilder(contractOfferId2, createAsset(assetId2)).build();
+
+            getStore().save(entry1);
+            getStore().save(entry2);
+
+            var query = QuerySpec.Builder.newInstance().filter(Criterion.criterion("datasets.id", "=", assetId2)).build();
+            var result = getStore().query(query);
+
+            assertThat(result)
+                    .hasSize(1)
+                    .allSatisfy(co -> assertThat(co.getDatasets().get(0).getId()).isEqualTo(assetId2));
+        }
+
+        @Test
+        void queryByCatalogProperty() {
+            var contractOfferId1 = UUID.randomUUID().toString();
+            var contractOfferId2 = UUID.randomUUID().toString();
+            var assetId1 = UUID.randomUUID().toString();
+            var assetId2 = UUID.randomUUID().toString();
+            var entry1 = createCatalogBuilder(contractOfferId1, createAsset(assetId1)).property("name", "value").build();
+            var entry2 = createCatalogBuilder(contractOfferId2, createAsset(assetId2)).build();
+
+            getStore().save(entry1);
+            getStore().save(entry2);
+
+            var query = QuerySpec.Builder.newInstance().filter(Criterion.criterion("properties.name", "=", "value")).build();
+            var result = getStore().query(query);
+
+            assertThat(result)
+                    .hasSize(1)
+                    .allSatisfy(co -> assertThat(co.getProperties().get("name")).isEqualTo("value"));
+        }
+
+        @Test
+        void queryByDataServiceEndpoint() {
+            var contractOfferId1 = UUID.randomUUID().toString();
+            var contractOfferId2 = UUID.randomUUID().toString();
+            var endpoint = "http://endpoint";
+            var assetId1 = UUID.randomUUID().toString();
+            var assetId2 = UUID.randomUUID().toString();
+            var entry1 = createCatalogBuilder(contractOfferId1, createAsset(assetId1), endpoint).build();
+            var entry2 = createCatalogBuilder(contractOfferId2, createAsset(assetId2)).build();
+
+            getStore().save(entry1);
+            getStore().save(entry2);
+
+            var query = QuerySpec.Builder.newInstance().filter(Criterion.criterion("dataServices.endpointUrl", "=", endpoint)).build();
+            var result = getStore().query(query);
+
+            assertThat(result)
+                    .hasSize(1)
+                    .allSatisfy(co -> assertThat(co.getDataServices().get(0).getEndpointUrl()).isEqualTo(endpoint));
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void removedMarked_noneMarked() {
+            var contractOfferId1 = UUID.randomUUID().toString();
+            var contractOfferId2 = UUID.randomUUID().toString();
+            var assetId1 = UUID.randomUUID().toString();
+            var assetId2 = UUID.randomUUID().toString();
+            var entry1 = createCatalog(contractOfferId1, createAsset(assetId1));
+            var entry2 = createCatalog(contractOfferId2, createAsset(assetId2));
+
+            getStore().save(entry1);
+            getStore().save(entry2);
+
+            assertThat(getStore().query(QuerySpec.none())).hasSize(2);
+
+            getStore().deleteExpired(); // none of them is marked, d
+            assertThat(getStore().query(QuerySpec.none())).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(entry1, entry2);
+
+        }
+
+        @Test
+        void removedMarked_shouldDeleteMarked() {
+            var contractOfferId1 = UUID.randomUUID().toString();
+            var contractOfferId2 = UUID.randomUUID().toString();
+            var assetId1 = UUID.randomUUID().toString();
+            var assetId2 = UUID.randomUUID().toString();
+            var entry1 = createCatalog(contractOfferId1, createAsset(assetId1));
+            var entry2 = createCatalog(contractOfferId2, createAsset(assetId2));
+
+            getStore().save(entry1);
+            getStore().save(entry2);
+
+            assertThat(getStore().query(QuerySpec.none())).hasSize(2);
+
+            getStore().expireAll(); // two items marked
+            getStore().save(createCatalog(UUID.randomUUID().toString(), createAsset(UUID.randomUUID().toString())));
+            getStore().deleteExpired(); // should delete only marked items
+            assertThat(getStore().query(QuerySpec.none())).hasSize(1)
+                    .doesNotContain(entry1, entry2);
+
+        }
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Move the federated catalog SPIs to the Connector repo. This is the first step out of 4 steps to completely move all federated catalog components. This is related to this [decision record](https://github.com/eclipse-edc/eclipse-edc.github.io/tree/ef760eeabaf0b0baa2a74580b87c2071d4419217/developer/decision-records/2026-03-02-catalog-crawler).

- [x] Move the federated catalog SPIs
- [ ] Move the core components 
- [ ] Move the extensions 
- [ ] move/modify the Boms

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Related to #5530

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
