### PR TITLE
refactor: add breakLease method on the StateEntityStore

### DIFF
--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/AbstractStateEntityManager.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/AbstractStateEntityManager.java
@@ -90,12 +90,10 @@ public abstract class AbstractStateEntityManager<E extends StatefulEntity<E>, S 
                             .formatted(this.getClass().getSimpleName(), entity.getClass().getSimpleName(),
                                     entity.getId(), entity.stateAsString(), error));
                 });
-
-
     }
 
     protected void breakLease(E entity) {
-        store.save(entity);
+        store.breakLease(entity);
     }
 
     public abstract static class Builder<E extends StatefulEntity<E>, S extends StateEntityStore<E>, M extends AbstractStateEntityManager<E, S>, B extends Builder<E, S, M, B>> {

--- a/core/common/lib/store-lib/src/main/java/org/eclipse/edc/store/InMemoryStatefulEntityStore.java
+++ b/core/common/lib/store-lib/src/main/java/org/eclipse/edc/store/InMemoryStatefulEntityStore.java
@@ -111,6 +111,12 @@ public class InMemoryStatefulEntityStore<T extends StatefulEntity<T>> implements
 
     }
 
+    @Override
+    public StoreResult<Void> breakLease(T entity) {
+        freeLease(entity.getId());
+        return StoreResult.success();
+    }
+
     public StoreResult<Void> delete(String id) {
         if (isLeased(id)) {
             return StoreResult.alreadyLeased("Entity is leased and cannot be deleted!");

--- a/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
+++ b/core/data-plane/data-plane-core/src/test/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImplTest.java
@@ -768,7 +768,7 @@ class DataPlaneManagerImplTest {
 
             await().untilAsserted(() -> {
                 verify(store, never()).save(argThat(it -> it.getState() == COMPLETED.code()));
-                verify(store).save(argThat(it -> it.getState() == TERMINATED.code())); // break lease
+                verify(store).breakLease(terminatedDataFlow);
             });
         }
 

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImpl.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImpl.java
@@ -115,7 +115,7 @@ public class PolicyMonitorManagerImpl extends AbstractStateEntityManager<PolicyM
         var filter = new Criterion[]{ hasState(state.code()) };
         return ProcessorImpl.Builder.newInstance(() -> store.nextNotLeased(batchSize, filter))
                 .process(telemetry.contextPropagationMiddleware(function))
-                .onNotProcessed(this::breakLease)
+                .onNotProcessed(this::update)
                 .build();
     }
 

--- a/extensions/common/sql/sql-lease-core/src/main/java/org/eclipse/edc/sql/lease/SqlLeaseCoreExtension.java
+++ b/extensions/common/sql/sql-lease-core/src/main/java/org/eclipse/edc/sql/lease/SqlLeaseCoreExtension.java
@@ -30,16 +30,14 @@ import java.time.Clock;
 public class SqlLeaseCoreExtension implements ServiceExtension {
 
     public static final String NAME = "SQL Lease Core";
+
     @Inject
     private TransactionContext transactionContext;
-
     @Inject
     private Clock clock;
-
     @Inject
     private QueryExecutor queryExecutor;
-
-    @Inject(required = false)
+    @Inject
     private LeaseStatements statements;
 
     @Override
@@ -49,13 +47,7 @@ public class SqlLeaseCoreExtension implements ServiceExtension {
 
     @Provider(isDefault = true)
     public SqlLeaseContextBuilderProvider leaseContextBuilderProvider(ServiceExtensionContext context) {
-        return new SqlLeaseContextBuilderProviderImpl(transactionContext, getStatementImpl(), context.getRuntimeId(), clock, queryExecutor);
+        return new SqlLeaseContextBuilderProviderImpl(transactionContext, statements, context.getRuntimeId(), clock, queryExecutor);
     }
-    
-    /**
-     * returns an externally-provided sql statement dialect, or postgres as a default
-     */
-    private LeaseStatements getStatementImpl() {
-        return statements != null ? statements : new BaseSqlLeaseStatements();
-    }
+
 }

--- a/extensions/common/sql/sql-lease-core/src/main/java/org/eclipse/edc/sql/lease/SqlLeaseStatementsExtension.java
+++ b/extensions/common/sql/sql-lease-core/src/main/java/org/eclipse/edc/sql/lease/SqlLeaseStatementsExtension.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.sql.lease;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.sql.lease.spi.LeaseStatements;
+
+import static org.eclipse.edc.sql.lease.SqlLeaseStatementsExtension.NAME;
+
+@Extension(NAME)
+public class SqlLeaseStatementsExtension implements ServiceExtension {
+
+    public static final String NAME = "SQL Lease Statements";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider(isDefault = true)
+    public LeaseStatements leaseStatements() {
+        return new BaseSqlLeaseStatements();
+    }
+
+}

--- a/extensions/common/sql/sql-lease-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/common/sql/sql-lease-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -12,3 +12,4 @@
 #
 #
 org.eclipse.edc.sql.lease.SqlLeaseCoreExtension
+org.eclipse.edc.sql.lease.SqlLeaseStatementsExtension

--- a/extensions/common/sql/sql-lease-spi/src/main/java/org/eclipse/edc/sql/lease/spi/SqlLeaseContextBuilderProvider.java
+++ b/extensions/common/sql/sql-lease-spi/src/main/java/org/eclipse/edc/sql/lease/spi/SqlLeaseContextBuilderProvider.java
@@ -31,6 +31,8 @@ public interface SqlLeaseContextBuilderProvider {
      * Gets the SQL statements implementation used by this provider.
      *
      * @return the {@link LeaseStatements} instance
+     * @deprecated LeaseStatements can be injected as a service instead
      */
+    @Deprecated(since = "0.17.0")
     LeaseStatements getStatements();
 }

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/SqlContractNegotiationStoreExtension.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/SqlContractNegotiationStoreExtension.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
+import org.eclipse.edc.sql.lease.spi.LeaseStatements;
 import org.eclipse.edc.sql.lease.spi.SqlLeaseContextBuilderProvider;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
@@ -63,6 +64,8 @@ public class SqlContractNegotiationStoreExtension implements ServiceExtension {
 
     @Inject
     private SqlLeaseContextBuilderProvider leaseContextBuilderProvider;
+    @Inject
+    private LeaseStatements leaseStatements;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
@@ -79,6 +82,6 @@ public class SqlContractNegotiationStoreExtension implements ServiceExtension {
      * returns an externally-provided sql statement dialect, or postgres as a default
      */
     private ContractNegotiationStatements getStatementImpl() {
-        return statements != null ? statements : new PostgresDialectStatements(leaseContextBuilderProvider.getStatements(), clock);
+        return statements != null ? statements : new PostgresDialectStatements(leaseStatements, clock);
     }
 }

--- a/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
+++ b/extensions/control-plane/store/sql/contract-negotiation-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/contractnegotiation/store/SqlContractNegotiationStore.java
@@ -164,6 +164,17 @@ public class SqlContractNegotiationStore extends AbstractSqlStore implements Con
     }
 
     @Override
+    public StoreResult<Void> breakLease(ContractNegotiation entity) {
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                return leaseContext.withConnection(connection).breakLease(entity.getId());
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    @Override
     public @Nullable ContractAgreement findContractAgreement(String contractId) {
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/SqlTransferProcessStoreExtension.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/SqlTransferProcessStoreExtension.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
+import org.eclipse.edc.sql.lease.spi.LeaseStatements;
 import org.eclipse.edc.sql.lease.spi.SqlLeaseContextBuilderProvider;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
@@ -61,6 +62,8 @@ public class SqlTransferProcessStoreExtension implements ServiceExtension {
 
     @Inject
     private SqlLeaseContextBuilderProvider leaseContextBuilderProvider;
+    @Inject
+    private LeaseStatements leaseStatements;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
@@ -78,7 +81,7 @@ public class SqlTransferProcessStoreExtension implements ServiceExtension {
      * returns an externally-provided sql statement dialect, or postgres as a default
      */
     private TransferProcessStoreStatements getStatementImpl() {
-        return statements != null ? statements : new PostgresDialectStatements(leaseContextBuilderProvider.getStatements(), clock);
+        return statements != null ? statements : new PostgresDialectStatements(leaseStatements, clock);
     }
 
 }

--- a/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/store/SqlTransferProcessStore.java
+++ b/extensions/control-plane/store/sql/transfer-process-store-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/transferprocess/store/SqlTransferProcessStore.java
@@ -152,6 +152,17 @@ public class SqlTransferProcessStore extends AbstractSqlStore implements Transfe
     }
 
     @Override
+    public StoreResult<Void> breakLease(TransferProcess entity) {
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                return leaseContext.withConnection(connection).breakLease(entity.getId());
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    @Override
     public @Nullable TransferProcess findForCorrelationId(String correlationId) {
         return transactionContext.execute(() -> {
             var query = correlationIdQuerySpec(correlationId);

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/sql/SqlDataPlaneInstanceStore.java
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/sql/SqlDataPlaneInstanceStore.java
@@ -140,6 +140,17 @@ public class SqlDataPlaneInstanceStore extends AbstractSqlStore implements DataP
     }
 
     @Override
+    public StoreResult<Void> breakLease(DataPlaneInstance entity) {
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                return leaseContext.withConnection(connection).breakLease(entity.getId());
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    @Override
     public Stream<DataPlaneInstance> getAll() {
         return transactionContext.execute(() -> {
             try {

--- a/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/sql/SqlDataPlaneInstanceStoreExtension.java
+++ b/extensions/data-plane-selector/store/sql/data-plane-instance-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/selector/store/sql/SqlDataPlaneInstanceStoreExtension.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
+import org.eclipse.edc.sql.lease.spi.LeaseStatements;
 import org.eclipse.edc.sql.lease.spi.SqlLeaseContextBuilderProvider;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
@@ -68,6 +69,8 @@ public class SqlDataPlaneInstanceStoreExtension implements ServiceExtension {
 
     @Inject
     private SqlLeaseContextBuilderProvider leaseContextBuilderProvider;
+    @Inject
+    private LeaseStatements leaseStatements;
 
     @Override
     public String name() {
@@ -86,7 +89,7 @@ public class SqlDataPlaneInstanceStoreExtension implements ServiceExtension {
      * returns an externally-provided sql statement dialect, or postgres as a default
      */
     private DataPlaneInstanceStatements getStatementImpl() {
-        return statements != null ? statements : new PostgresDataPlaneInstanceStatements(leaseContextBuilderProvider.getStatements(), clock);
+        return statements != null ? statements : new PostgresDataPlaneInstanceStatements(leaseStatements, clock);
     }
 
 }

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStore.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStore.java
@@ -145,6 +145,17 @@ public class SqlDataPlaneStore extends AbstractSqlStore implements DataPlaneStor
         });
     }
 
+    @Override
+    public StoreResult<Void> breakLease(DataFlow entity) {
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                return leaseContext.withConnection(connection).breakLease(entity.getId());
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
     private DataFlow mapDataFlow(ResultSet resultSet) throws SQLException {
         return DataFlow.Builder.newInstance()
                 .id(resultSet.getString(statements.getIdColumn()))
@@ -168,7 +179,7 @@ public class SqlDataPlaneStore extends AbstractSqlStore implements DataPlaneStor
                 .build();
     }
 
-    private @Nullable DataFlow findByIdInternal(Connection conn, String id) {
+    private DataFlow findByIdInternal(Connection conn, String id) {
         return transactionContext.execute(() -> {
             var querySpec = QuerySpec.Builder.newInstance().filter(criterion("id", "=", id)).build();
             var statement = statements.createQuery(querySpec);

--- a/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStoreExtension.java
+++ b/extensions/data-plane/store/sql/data-plane-store-sql/src/main/java/org/eclipse/edc/connector/dataplane/store/sql/SqlDataPlaneStoreExtension.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
+import org.eclipse.edc.sql.lease.spi.LeaseStatements;
 import org.eclipse.edc.sql.lease.spi.SqlLeaseContextBuilderProvider;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
@@ -65,6 +66,8 @@ public class SqlDataPlaneStoreExtension implements ServiceExtension {
 
     @Inject
     private SqlLeaseContextBuilderProvider leaseContextBuilderProvider;
+    @Inject
+    private LeaseStatements leaseStatements;
 
     @Override
     public String name() {
@@ -83,6 +86,6 @@ public class SqlDataPlaneStoreExtension implements ServiceExtension {
      * returns an externally-provided sql statement dialect, or postgres as a default
      */
     private DataFlowStatements getStatementImpl() {
-        return statements != null ? statements : new PostgresDataFlowStatements(leaseContextBuilderProvider.getStatements(), clock);
+        return statements != null ? statements : new PostgresDataFlowStatements(leaseStatements, clock);
     }
 }

--- a/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/SqlPolicyMonitorStore.java
+++ b/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/SqlPolicyMonitorStore.java
@@ -129,6 +129,17 @@ public class SqlPolicyMonitorStore extends AbstractSqlStore implements PolicyMon
         });
     }
 
+    @Override
+    public StoreResult<Void> breakLease(PolicyMonitorEntry entity) {
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                return leaseContext.withConnection(connection).breakLease(entity.getId());
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
     private @Nullable PolicyMonitorEntry findByIdInternal(Connection conn, String id) {
         return transactionContext.execute(() -> {
             var querySpec = QuerySpec.Builder.newInstance().filter(criterion("id", "=", id)).build();

--- a/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/SqlPolicyMonitorStoreExtension.java
+++ b/extensions/policy-monitor/store/sql/policy-monitor-store-sql/src/main/java/org/eclipse/edc/connector/policy/monitor/store/sql/SqlPolicyMonitorStoreExtension.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
+import org.eclipse.edc.sql.lease.spi.LeaseStatements;
 import org.eclipse.edc.sql.lease.spi.SqlLeaseContextBuilderProvider;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
@@ -59,6 +60,8 @@ public class SqlPolicyMonitorStoreExtension implements ServiceExtension {
 
     @Inject
     private SqlLeaseContextBuilderProvider leaseContextBuilderProvider;
+    @Inject
+    private LeaseStatements leaseStatements;
 
     @Provider
     public PolicyMonitorStore policyMonitorStore(ServiceExtensionContext context) {
@@ -77,7 +80,7 @@ public class SqlPolicyMonitorStoreExtension implements ServiceExtension {
      * returns an externally-provided sql statement dialect, or postgres as a default
      */
     private PolicyMonitorStatements getStatementImpl() {
-        return statements != null ? statements : new PostgresPolicyMonitorStatements(leaseContextBuilderProvider.getStatements(), clock);
+        return statements != null ? statements : new PostgresPolicyMonitorStatements(leaseStatements, clock);
     }
 
 }

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/persistence/StateEntityStore.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/persistence/StateEntityStore.java
@@ -87,4 +87,12 @@ public interface StateEntityStore<T> {
      * @param entity the entity.
      */
     StoreResult<Void> save(T entity);
+
+    /**
+     * Break the lease eventually existent on the entity
+     *
+     * @param entity the entity
+     * @return success if lease broken successfully, failure otherwise
+     */
+    StoreResult<Void> breakLease(T entity);
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds the `breakLease` method on the `StateEntityStore` so it will possible for state machines to break the lease without having to update the related entity.

## Why it does that

optimization

## Further notes
- added a `SqlLeaseStatementsExtension` to provide the default `LeaseStatement` implementation so there's no need to request from the `SqlLeaseContextBuilderProvider` (I feel like the `ContextBuilderProvider` + `ContextBuilder` + `LeaseContext` design could be simplified a little, eventually on subsequent PRs)


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5050 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
