### PR TITLE
refactor: move federated catalog core modules to connector repo

### DIFF
--- a/core/common/lib/catalog-util-lib/build.gradle.kts
+++ b/core/common/lib/catalog-util-lib/build.gradle.kts
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:control-plane:catalog-spi"))
+
+    testImplementation(project(":core:common:junit"))
+}
+

--- a/core/common/lib/catalog-util-lib/src/main/java/org/eclipse/edc/federatedcatalog/util/FederatedCatalogUtil.java
+++ b/core/common/lib/catalog-util-lib/src/main/java/org/eclipse/edc/federatedcatalog/util/FederatedCatalogUtil.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.federatedcatalog.util;
+
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.Optional.ofNullable;
+
+public class FederatedCatalogUtil {
+    /**
+     * Merges two catalogs by adding all datasets, dataservices, properties and distributions of the source into the target
+     */
+    public static Catalog merge(Catalog destination, Catalog source) {
+        return copy(destination)
+                .datasets(source.getDatasets())
+                .dataServices(Stream.concat(destination.getDataServices().stream(), source.getDataServices().stream()).toList())
+                .properties(source.getProperties())
+                .distributions(source.getDistributions())
+                .build();
+    }
+
+    /**
+     * Creates an exact copy of the given catalog
+     */
+    public static Catalog.Builder copy(Catalog catalog) {
+        return Catalog.Builder.newInstance().id(catalog.getId())
+                .participantId(catalog.getParticipantId())
+                .properties(ofNullable(catalog.getProperties()).orElseGet(HashMap::new))
+                .dataServices(ofNullable(catalog.getDataServices()).orElseGet(ArrayList::new))
+                .distributions(ofNullable(catalog.getDistributions()).orElseGet(ArrayList::new))
+                .datasets(ofNullable(catalog.getDatasets()).orElseGet(ArrayList::new));
+    }
+
+    /**
+     * Creates an exact copy of the given catalog, but uses the given list of Datasets instead of the original's
+     */
+    public static Catalog.Builder copy(Catalog catalog, List<Dataset> datasets) {
+        return Catalog.Builder.newInstance().id(catalog.getId())
+                .participantId(catalog.getParticipantId())
+                .properties(ofNullable(catalog.getProperties()).orElseGet(HashMap::new))
+                .dataServices(ofNullable(catalog.getDataServices()).orElseGet(ArrayList::new))
+                .distributions(ofNullable(catalog.getDistributions()).orElseGet(ArrayList::new))
+                .datasets(datasets);
+    }
+
+    /**
+     * Takes a catalog that may contain subcatalogs and flattens the list of datasets etc.
+     */
+    public static Catalog flatten(Catalog rootCatalog) {
+        var datasets = getDatasets(rootCatalog, Dataset.class); // will add nested catalogs later
+        var flattenedCatalog = FederatedCatalogUtil.copy(rootCatalog, datasets).build(); // remove all sub-catalogs
+
+        var subCatalogs = getDatasets(rootCatalog, Catalog.class);
+
+        // recursively merge every sub-catalog with the root catalog
+        if (!subCatalogs.isEmpty()) {
+            return subCatalogs.stream()
+                    .map(FederatedCatalogUtil::flatten)
+                    .filter(Objects::nonNull)
+                    .reduce(FederatedCatalogUtil::merge)
+                    .map(c -> merge(flattenedCatalog, c))
+                    .orElse(null);
+        }
+
+        return flattenedCatalog;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Dataset> List<T> getDatasets(Catalog catalog, Class<T> datasetType) {
+        var partitions = catalog.getDatasets().stream().collect(Collectors.groupingBy(Dataset::getClass));
+        return ofNullable(partitions.get(datasetType))
+                .map(datasets -> datasets.stream().map(d -> (T) d).toList())
+                .orElse(new ArrayList<>());
+    }
+}

--- a/core/common/lib/catalog-util-lib/src/test/java/org/eclipse/edc/federatedcatalog/util/FederatedCatalogUtilTest.java
+++ b/core/common/lib/catalog-util-lib/src/test/java/org/eclipse/edc/federatedcatalog/util/FederatedCatalogUtilTest.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.federatedcatalog.util;
+
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FederatedCatalogUtilTest {
+
+    @Test
+    void flatten() {
+        var rootCatalog = createCatalog("root")
+                .dataset(createCatalog("sub1").build())
+                .dataset(createCatalog("sub2")
+                        .dataset(createCatalog("subsub1").build())
+                        .build())
+                .build();
+
+        var flattened = FederatedCatalogUtil.flatten(rootCatalog);
+
+        assertThat(flattened.getDatasets()).hasSize(8);
+        assertThat(flattened.getDataServices()).hasSize(4);
+    }
+
+    @Test
+    void flatten_noHierarchy() {
+        var rootCatalog = createCatalog("root").build();
+
+        var flattened = FederatedCatalogUtil.flatten(rootCatalog);
+
+        assertThat(flattened).usingRecursiveComparison().isEqualTo(rootCatalog);
+    }
+
+    @Test
+    void merge() {
+        var catalog1 = createCatalog("cat1").build();
+        var catalog2 = createCatalog("cat2").build();
+
+        var merged = FederatedCatalogUtil.merge(catalog1, catalog2);
+
+        assertThat(merged.getDatasets()).hasSize(4);
+        assertThat(merged.getDataServices()).hasSize(2);
+    }
+
+    @Test
+    void copy() {
+        var catalog1 = createCatalog("cat1").build();
+        var copy = FederatedCatalogUtil.copy(catalog1).build();
+
+        assertThat(catalog1).usingRecursiveComparison().isEqualTo(copy);
+    }
+
+    @Test
+    void copy_withDatasets() {
+        var catalog1 = createCatalog("cat1").build();
+        var datasets = List.of(Dataset.Builder.newInstance().id("new-dataset").build());
+
+        var copy = FederatedCatalogUtil.copy(catalog1, datasets).build();
+
+        assertThat(catalog1.getDataServices()).isEqualTo(copy.getDataServices());
+        assertThat(catalog1.getParticipantId()).isEqualTo(copy.getParticipantId());
+        assertThat(copy.getDatasets()).isEqualTo(datasets).doesNotContain(catalog1.getDatasets().toArray(new Dataset[0]));
+    }
+
+    private Catalog.Builder createCatalog(String prefix) {
+        return Catalog.Builder.newInstance()
+                .id(prefix)
+                .dataService(DataService.Builder.newInstance().id(prefix + "-service").build())
+                .dataset(Dataset.Builder.newInstance().id(prefix + "-dataset-1").build())
+                .dataset(Dataset.Builder.newInstance().id(prefix + "-dataset-2").build());
+    }
+}

--- a/core/crawler-core/build.gradle.kts
+++ b/core/crawler-core/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `java-test-fixtures`
+}
+
+dependencies {
+    api(project(":spi:crawler-spi"))
+    api(project(":spi:federated-catalog-spi"))
+    api(project(":spi:common:core-spi"))
+    api(project(":spi:common:web-spi"))
+    api(project(":spi:control-plane:contract-spi"))
+
+
+    testImplementation(project(":core:common:junit"))
+    testImplementation(project(":extensions:common:http"))
+    testImplementation(libs.awaitility)
+}

--- a/core/crawler-core/src/main/java/org/eclipse/edc/catalog/cache/ExecutionManager.java
+++ b/core/crawler-core/src/main/java/org/eclipse/edc/catalog/cache/ExecutionManager.java
@@ -1,0 +1,208 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *       Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. - Add shutdown method
+ *
+ */
+
+package org.eclipse.edc.catalog.cache;
+
+import org.eclipse.edc.catalog.spi.CatalogCrawlerConfiguration;
+import org.eclipse.edc.crawler.spi.CrawlerActionRegistry;
+import org.eclipse.edc.crawler.spi.CrawlerSuccessHandler;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
+import org.eclipse.edc.crawler.spi.TargetNodeFilter;
+import org.eclipse.edc.crawler.spi.WorkItem;
+import org.eclipse.edc.crawler.spi.model.ExecutionPlan;
+import org.eclipse.edc.crawler.spi.model.UpdateRequest;
+import org.eclipse.edc.spi.monitor.Monitor;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+
+/**
+ * The execution manager is responsible for instantiating crawlers and delegating the incoming work items among them.
+ * Work items are fetched directly from the {@link TargetNodeDirectory}, crawlers are instantiated before starting the run and will be reused.
+ * <p>
+ * Pre- and Post-Tasks can be registered to perform preparatory or cleanup operations.
+ * <p>
+ * The ExecutionManager delegates the actual task to the {@link ExecutionPlan}, which determines, when and how often it needs to be run.
+ */
+public class ExecutionManager {
+
+    private Monitor monitor;
+    private Runnable preExecutionTask;
+    private Runnable postExecutionTask;
+    private TargetNodeDirectory directory;
+    private TargetNodeFilter nodeFilter;
+    private CrawlerActionRegistry crawlerActionRegistry;
+    private CrawlerSuccessHandler successHandler;
+    private ScheduledExecutorService crawlers;
+    private CatalogCrawlerConfiguration configuration;
+
+    private ExecutionManager() {
+        nodeFilter = n -> true;
+    }
+
+    public void executePlan(ExecutionPlan plan) {
+        if (!configuration.enabled()) {
+            monitor.warning("Execution of crawlers is globally disabled.");
+            return;
+        }
+
+        plan.run(() -> {
+            runTask("pre-execution", preExecutionTask);
+            doWork();
+            runTask("post-execution", postExecutionTask);
+        });
+
+    }
+
+    public void shutdownPlan(ExecutionPlan plan) {
+        if (!configuration.enabled()) {
+            monitor.warning("Execution of crawlers is globally disabled.");
+            return;
+        }
+        plan.stop();
+    }
+
+    private void doWork() {
+        var workItems = fetchWorkItems();
+        if (workItems.isEmpty()) {
+            return;
+        }
+
+        monitor.debug("Loaded " + workItems.size() + " work items from storage");
+
+        workItems.stream().map(this::createCrawler).forEach(crawler -> crawlers.execute(crawler));
+    }
+
+    private Runnable createCrawler(WorkItem item) {
+        return () -> {
+            var adapter = crawlerActionRegistry.findForProtocol(item.getProtocol()).stream().findFirst();
+            if (adapter.isEmpty()) {
+                monitor.warning(format("No protocol adapter found for protocol '%s'", item.getProtocol()));
+            } else {
+                var updateRequest = new UpdateRequest(item.getId(), item.getUrl(), item.getProtocol());
+                adapter.get().apply(updateRequest)
+                        .thenAccept(successHandler)
+                        .whenComplete((v, throwable) -> onCompletion(item, throwable));
+            }
+        };
+    }
+
+    private void onCompletion(WorkItem item, Throwable throwable) {
+        if (throwable == null) {
+            monitor.debug(format("WorkItem [%s] is done", item.getId()));
+        } else {
+            item.error(throwable.getMessage());
+            monitor.severe("Unexpected exception occurred while crawling: " + item.getId(), throwable);
+            if (item.getErrors().size() > configuration.maxRetries()) {
+                monitor.severe(format("The following WorkItem has errored out more than %d times. We'll discard it now: [%s]", configuration.maxRetries(), item));
+            } else {
+                monitor.debug(format("The following work item has errored out. Will re-queue after a delay of %s seconds: [%s]", configuration.retryDelaySeconds(), item));
+                crawlers.schedule(createCrawler(item), configuration.retryDelaySeconds(), TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    private void runTask(String description, Runnable runnable) {
+        if (runnable != null) {
+            try {
+                runnable.run();
+            } catch (Throwable throwable) {
+                monitor.severe("Error running %s task".formatted(description), throwable);
+            }
+        }
+    }
+
+    private List<WorkItem> fetchWorkItems() {
+        // use all nodes EXCEPT self
+        return directory.getAll().stream()
+                .filter(nodeFilter)
+                .map(n -> new WorkItem(n.id(), n.targetUrl(), selectProtocol(n.supportedProtocols())))
+                .collect(Collectors.toList());
+    }
+
+    private String selectProtocol(List<String> supportedProtocols) {
+        return supportedProtocols.isEmpty() ? null : supportedProtocols.get(0);
+    }
+
+    public static final class Builder {
+
+        private final ExecutionManager instance;
+
+        private Builder() {
+            instance = new ExecutionManager();
+        }
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder monitor(Monitor monitor) {
+            instance.monitor = monitor;
+            return this;
+        }
+
+        public Builder preExecutionTask(Runnable preExecutionTask) {
+            instance.preExecutionTask = preExecutionTask;
+            return this;
+        }
+
+        public Builder postExecutionTask(Runnable postExecutionTask) {
+            instance.postExecutionTask = postExecutionTask;
+            return this;
+        }
+
+        public Builder nodeQueryAdapterRegistry(CrawlerActionRegistry registry) {
+            instance.crawlerActionRegistry = registry;
+            return this;
+        }
+
+        public Builder nodeDirectory(TargetNodeDirectory directory) {
+            instance.directory = directory;
+            return this;
+        }
+
+        public Builder nodeFilterFunction(TargetNodeFilter filter) {
+            instance.nodeFilter = filter;
+            return this;
+        }
+
+        public Builder onSuccess(CrawlerSuccessHandler successConsumer) {
+            instance.successHandler = successConsumer;
+            return this;
+        }
+
+        public Builder configuration(CatalogCrawlerConfiguration catalogCrawlerConfiguration) {
+            instance.configuration = catalogCrawlerConfiguration;
+            return this;
+        }
+
+        public ExecutionManager build() {
+            Objects.requireNonNull(instance.configuration, "ExecutionManager.Builder: Configuration cannot be null");
+            Objects.requireNonNull(instance.monitor, "ExecutionManager.Builder: Monitor cannot be null");
+            Objects.requireNonNull(instance.crawlerActionRegistry, "ExecutionManager.Builder: nodeQueryAdapterRegistry cannot be null");
+            Objects.requireNonNull(instance.directory, "ExecutionManager.Builder: nodeDirectory cannot be null");
+
+            instance.crawlers = Executors.newScheduledThreadPool(instance.configuration.numCrawlers());
+
+            return instance;
+        }
+    }
+}

--- a/core/crawler-core/src/main/java/org/eclipse/edc/catalog/cache/crawler/CrawlerActionRegistryImpl.java
+++ b/core/crawler-core/src/main/java/org/eclipse/edc/catalog/cache/crawler/CrawlerActionRegistryImpl.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache.crawler;
+
+import org.eclipse.edc.crawler.spi.CrawlerAction;
+import org.eclipse.edc.crawler.spi.CrawlerActionRegistry;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CrawlerActionRegistryImpl implements CrawlerActionRegistry {
+
+    private final Map<String, List<CrawlerAction>> map;
+
+    public CrawlerActionRegistryImpl() {
+        map = new ConcurrentHashMap<>();
+    }
+
+
+    @Override
+    public Collection<CrawlerAction> findForProtocol(String protocolName) {
+        if (!map.containsKey(protocolName)) {
+            return Collections.emptyList();
+        }
+        return map.get(protocolName);
+    }
+
+    @Override
+    public void register(String protocolName, CrawlerAction adapter) {
+        if (!map.containsKey(protocolName)) {
+            map.put(protocolName, new ArrayList<>());
+        }
+        map.get(protocolName).add(adapter);
+    }
+
+    @Override
+    public void unregister(String protocolName, CrawlerAction adapter) {
+        if (map.containsKey(protocolName)) {
+            map.get(protocolName).remove(adapter);
+
+            if (map.get(protocolName).isEmpty()) {
+                map.remove(protocolName);
+            }
+        }
+    }
+}

--- a/core/crawler-core/src/test/java/org/eclipse/edc/catalog/cache/ExecutionManagerTest.java
+++ b/core/crawler-core/src/test/java/org/eclipse/edc/catalog/cache/ExecutionManagerTest.java
@@ -1,0 +1,216 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache;
+
+import org.eclipse.edc.catalog.spi.CatalogCrawlerConfiguration;
+import org.eclipse.edc.crawler.spi.CrawlerAction;
+import org.eclipse.edc.crawler.spi.CrawlerActionRegistry;
+import org.eclipse.edc.crawler.spi.CrawlerSuccessHandler;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
+import org.eclipse.edc.crawler.spi.TargetNodeFilter;
+import org.eclipse.edc.crawler.spi.model.ExecutionPlan;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletionException;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.catalog.test.TestUtil.TEST_PROTOCOL;
+import static org.eclipse.edc.catalog.test.TestUtil.createNode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class ExecutionManagerTest {
+
+    private final TargetNodeDirectory nodeDirectoryMock = mock();
+    private final Monitor monitorMock = mock();
+    private final CrawlerActionRegistry crawlerActionRegistry = mock();
+    private final Runnable preExecutionTaskMock = mock();
+    private final CrawlerAction queryAdapterMock = mock();
+    private final CrawlerSuccessHandler successHandler = mock();
+    private final Runnable postExecutionTask = mock();
+    private ExecutionManager manager = createManagerBuilder().build();
+
+    @BeforeEach
+    void setUp() {
+        manager = createManagerBuilder().build();
+    }
+
+    @Test
+    void executePlan() {
+        when(nodeDirectoryMock.getAll()).thenReturn(List.of(createNode()));
+        when(crawlerActionRegistry.findForProtocol(TEST_PROTOCOL)).thenReturn(List.of(queryAdapterMock));
+        when(queryAdapterMock.apply(any())).thenReturn(completedFuture(new TestUpdateResponse("test-url")));
+
+        manager.executePlan(simplePlan());
+
+        await().untilAsserted(() -> {
+            var inOrder = inOrder(preExecutionTaskMock, queryAdapterMock, successHandler);
+            inOrder.verify(preExecutionTaskMock).run();
+            inOrder.verify(queryAdapterMock).apply(any());
+            inOrder.verify(successHandler).accept(any());
+        });
+    }
+
+    @Test
+    void executePlan_noQueryAdapter() {
+        when(nodeDirectoryMock.getAll()).thenReturn(List.of(createNode()));
+        when(crawlerActionRegistry.findForProtocol(TEST_PROTOCOL)).thenReturn(List.of());
+
+        manager.executePlan(simplePlan());
+
+        var inOrder = inOrder(preExecutionTaskMock);
+        inOrder.verify(preExecutionTaskMock).run();
+        verifyNoInteractions(queryAdapterMock, successHandler);
+    }
+
+    @Test
+    void executePlan_preTaskThrowsException() {
+        doThrow(new RuntimeException("test-exception")).when(preExecutionTaskMock).run();
+        when(nodeDirectoryMock.getAll()).thenReturn(List.of(createNode()));
+        when(crawlerActionRegistry.findForProtocol(TEST_PROTOCOL)).thenReturn(List.of(queryAdapterMock));
+        when(queryAdapterMock.apply(any())).thenReturn(completedFuture(new TestUpdateResponse("test-url")));
+
+        manager.executePlan(simplePlan());
+
+        await().untilAsserted(() -> {
+            verify(successHandler).accept(any());
+            verify(monitorMock, atLeastOnce()).severe(anyString(), any(Throwable.class));
+        });
+    }
+
+    @Test
+    void executePlan_postTaskThrowsException() {
+        doThrow(new RuntimeException("test-exception")).when(postExecutionTask).run();
+        when(nodeDirectoryMock.getAll()).thenReturn(List.of(createNode()));
+        when(crawlerActionRegistry.findForProtocol(TEST_PROTOCOL)).thenReturn(List.of(queryAdapterMock));
+        when(queryAdapterMock.apply(any())).thenReturn(completedFuture(new TestUpdateResponse("test-url")));
+
+        manager.executePlan(simplePlan());
+
+        await().untilAsserted(() -> {
+            verify(successHandler).accept(any());
+            verify(monitorMock, atLeastOnce()).severe(anyString(), any(Throwable.class));
+        });
+    }
+
+    @Test
+    void executePlan_completesExceptionally() {
+        when(nodeDirectoryMock.getAll()).thenReturn(List.of(createNode()));
+        when(crawlerActionRegistry.findForProtocol(TEST_PROTOCOL)).thenReturn(List.of(queryAdapterMock));
+        var exc = new EdcException("some exception");
+        when(queryAdapterMock.apply(any())).thenReturn(failedFuture(exc));
+
+        manager.executePlan(simplePlan());
+
+        var inOrder = inOrder(preExecutionTaskMock, queryAdapterMock, successHandler);
+        inOrder.verify(preExecutionTaskMock).run();
+        inOrder.verify(queryAdapterMock).apply(any());
+
+        verifyNoInteractions(successHandler);
+        verify(monitorMock, atLeastOnce()).severe(anyString(), isA(CompletionException.class));
+    }
+
+    @Test
+    void executePlan_workItemsEmpty() {
+        when(nodeDirectoryMock.getAll()).thenReturn(List.of());
+        manager.executePlan(simplePlan());
+
+        verifyNoInteractions(crawlerActionRegistry);
+    }
+
+    @Test
+    void executePlan_withCustomFiltering() {
+        when(nodeDirectoryMock.getAll()).thenReturn(List.of(createNode(), createNode(), createNode()));
+        var filter = mock(TargetNodeFilter.class);
+        manager = createManagerBuilder().nodeFilterFunction(filter).build();
+
+        manager.executePlan(simplePlan());
+
+        verify(filter, times(3)).test(any());
+    }
+
+    @Test
+    void shutdownPlan_shouldNotStopPlanWhenGloballyDisabled() {
+
+        manager = createManagerBuilder().configuration(disabledCrawler()).build();
+        var mockPlan = mock(ExecutionPlan.class);
+        manager.shutdownPlan(mockPlan);
+
+        verify(monitorMock).warning(anyString());
+        verifyNoInteractions(mockPlan);
+    }
+
+    @Test
+    void shutdownPlan_shouldStopPlanWhenGloballyEnabled() {
+        manager = createManagerBuilder().configuration(enabledCrawler()).build();
+        var mockPlan = mock(ExecutionPlan.class);
+        manager.shutdownPlan(mockPlan);
+
+        verify(mockPlan).stop();
+        verifyNoMoreInteractions(monitorMock);
+    }
+
+    private CatalogCrawlerConfiguration disabledCrawler() {
+        return new CatalogCrawlerConfiguration(false, 5, 5, 5, 5, 5);
+    }
+
+    private CatalogCrawlerConfiguration enabledCrawler() {
+        return new CatalogCrawlerConfiguration(true, 5, 5, 5, 5, 5);
+    }
+
+    private ExecutionPlan simplePlan() {
+        return new ExecutionPlan() {
+            @Override
+            public void run(Runnable task) {
+                task.run();
+            }
+
+            @Override
+            public void stop() {
+
+            }
+        };
+    }
+
+    @NotNull
+    private ExecutionManager.Builder createManagerBuilder() {
+        return ExecutionManager.Builder.newInstance()
+                .configuration(enabledCrawler())
+                .nodeDirectory(nodeDirectoryMock)
+                .nodeQueryAdapterRegistry(crawlerActionRegistry)
+                .preExecutionTask(preExecutionTaskMock)
+                .postExecutionTask(postExecutionTask)
+                .monitor(monitorMock)
+                .onSuccess(successHandler);
+    }
+
+}

--- a/core/crawler-core/src/test/java/org/eclipse/edc/catalog/cache/TestUpdateResponse.java
+++ b/core/crawler-core/src/test/java/org/eclipse/edc/catalog/cache/TestUpdateResponse.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache;
+
+import org.eclipse.edc.crawler.spi.model.UpdateResponse;
+
+public class TestUpdateResponse extends UpdateResponse {
+    public TestUpdateResponse(String source) {
+        super(source);
+    }
+}

--- a/core/crawler-core/src/testFixtures/java/org/eclipse/edc/catalog/test/TestUtil.java
+++ b/core/crawler-core/src/testFixtures/java/org/eclipse/edc/catalog/test/TestUtil.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.test;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.crawler.spi.TargetNode;
+import org.eclipse.edc.policy.model.Policy;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.UUID;
+
+public class TestUtil {
+
+    public static final String TEST_PROTOCOL = "test-protocol";
+
+
+    @NotNull
+    public static ContractOffer createOffer(String id) {
+        return ContractOffer.Builder.newInstance()
+                .id(id)
+                .assetId(id)
+                .policy(Policy.Builder.newInstance().build())
+                .build();
+    }
+
+
+    @NotNull
+    public static TargetNode createNode() {
+        return new TargetNode("testnode" + UUID.randomUUID(), "did:web:" + UUID.randomUUID(), "http://test.com", List.of(TEST_PROTOCOL));
+    }
+}

--- a/core/federated-catalog-core-2025/README.md
+++ b/core/federated-catalog-core-2025/README.md
@@ -1,0 +1,6 @@
+This module contains implementations for the Federated Catalog Cache, which is a database that contains a snapshot of
+all the catalogs offered by all the connectors in a dataspace.
+
+It collects those catalogs using `Crawler` objects that run periodically.
+
+**This module is currently under development and should not be considered stable!**

--- a/core/federated-catalog-core-2025/build.gradle.kts
+++ b/core/federated-catalog-core-2025/build.gradle.kts
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `java-test-fixtures`
+}
+
+dependencies {
+    api(project(":core:federated-catalog-core"))
+    implementation(project(":data-protocols:dsp:dsp-2025:dsp-catalog-2025:dsp-catalog-transform-2025"))
+
+    testImplementation(libs.awaitility)
+    testImplementation(project(":core:common:junit"))
+    implementation(project(":core:common:lib:json-ld-lib"))
+    testImplementation(testFixtures(project(":spi:federated-catalog-spi")))
+    testImplementation(testFixtures(project(":spi:crawler-spi")))
+    testImplementation(testFixtures(project(":core:federated-catalog-core")))
+
+    testFixturesImplementation(project(":core:common:lib:json-lib"))
+    testFixturesImplementation(project(":data-protocols:dsp:dsp-lib:dsp-catalog-lib:dsp-catalog-transform-lib"))
+    testFixturesImplementation(project(":core:common:lib:json-ld-lib"))
+    testFixturesImplementation(project(":core:control-plane:control-plane-transform"))
+    testFixturesImplementation(project(":data-protocols:dsp:dsp-2025:dsp-catalog-2025:dsp-catalog-transform-2025"))
+}

--- a/core/federated-catalog-core-2025/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtension.java
+++ b/core/federated-catalog-core-2025/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtension.java
@@ -1,0 +1,108 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *       Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. - Add shutdown method
+ *
+ */
+
+package org.eclipse.edc.catalog.cache;
+
+import jakarta.json.Json;
+import org.eclipse.edc.catalog.cache.query.DspCatalogRequestAction;
+import org.eclipse.edc.catalog.transform.JsonObjectToCatalogTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDataServiceTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDatasetTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDistributionTransformer;
+import org.eclipse.edc.connector.controlplane.transform.odrl.from.JsonObjectFromPolicyTransformer;
+import org.eclipse.edc.connector.controlplane.transform.odrl.to.JsonObjectToPolicyTransformer;
+import org.eclipse.edc.crawler.spi.CrawlerActionRegistry;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participant.spi.ParticipantIdMapper;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDataServiceTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDatasetTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDistributionTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.v2025.from.JsonObjectFromCatalogV2025Transformer;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToCriterionTransformer;
+import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToQuerySpecTransformer;
+import org.eclipse.edc.transform.transformer.edc.to.JsonValueToGenericTypeTransformer;
+
+import java.util.Map;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_TRANSFORMER_CONTEXT_V_2025_1;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+@Extension(value = FederatedCatalogCacheExtension.NAME)
+public class FederatedCatalogCacheExtension implements ServiceExtension {
+
+    public static final String NAME = "Federated Catalog Cache DSP 2025/1";
+
+    @Inject
+    private RemoteMessageDispatcherRegistry dispatcherRegistry;
+    @Inject
+    private CrawlerActionRegistry crawlerActionRegistry;
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private ParticipantIdMapper participantIdMapper;
+    @Inject
+    private TypeTransformerRegistry registry;
+    @Inject
+    private JsonLd jsonLdService;
+    @Inject
+    private TypeTransformerRegistry transformerRegistry;
+    @Inject
+    private SingleParticipantContextSupplier participantContextSupplier;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        registerTransformers();
+
+        var mapper = typeManager.getMapper(JSON_LD);
+        var dspTransformerRegistry = registry.forContext(DSP_TRANSFORMER_CONTEXT_V_2025_1);
+        var adapter = new DspCatalogRequestAction(dispatcherRegistry, participantContextSupplier, context.getMonitor(), mapper, dspTransformerRegistry, jsonLdService);
+        crawlerActionRegistry.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, adapter);
+    }
+
+    private void registerTransformers() {
+        transformerRegistry.register(new JsonObjectToCatalogTransformer());
+        transformerRegistry.register(new JsonObjectToDatasetTransformer());
+        transformerRegistry.register(new JsonObjectToDataServiceTransformer());
+        transformerRegistry.register(new JsonObjectToDistributionTransformer());
+        transformerRegistry.register(new JsonObjectToQuerySpecTransformer());
+        transformerRegistry.register(new JsonObjectToCriterionTransformer());
+
+        var jsonFactory = Json.createBuilderFactory(Map.of());
+        transformerRegistry.register(new JsonObjectFromCatalogV2025Transformer(jsonFactory, typeManager, JSON_LD, participantIdMapper, DSP_NAMESPACE_V_2025_1));
+        transformerRegistry.register(new JsonObjectFromDatasetTransformer(jsonFactory, typeManager, JSON_LD));
+        transformerRegistry.register(new JsonObjectFromDistributionTransformer(jsonFactory));
+        transformerRegistry.register(new JsonObjectFromDataServiceTransformer(jsonFactory));
+
+        transformerRegistry.register(new JsonObjectFromPolicyTransformer(jsonFactory, participantIdMapper));
+        transformerRegistry.register(new JsonObjectToPolicyTransformer(participantIdMapper));
+        transformerRegistry.register(new JsonValueToGenericTypeTransformer(typeManager, JSON_LD));
+    }
+
+}

--- a/core/federated-catalog-core-2025/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToCatalogTransformer.java
+++ b/core/federated-catalog-core-2025/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToCatalogTransformer.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_CATALOG_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATASET_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATA_SERVICE_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DISTRIBUTION_TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DSPACE_PROPERTY_PARTICIPANT_ID_TERM;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
+
+/**
+ * Converts from a DCAT catalog as a {@link JsonObject} in JSON-LD expanded form to a {@link Catalog}.
+ */
+public class JsonObjectToCatalogTransformer extends AbstractJsonLdTransformer<JsonObject, Catalog> {
+
+    public JsonObjectToCatalogTransformer() {
+        super(JsonObject.class, Catalog.class);
+    }
+
+    @Override
+    public @Nullable Catalog transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
+        var builder = Catalog.Builder.newInstance();
+
+        builder.id(nodeId(object));
+        visitProperties(object, (key, value) -> transformProperties(key, value, builder, context));
+
+        return builderResult(builder::build, context);
+    }
+
+    private @Nullable Dataset transformDataset(JsonValue datasetJsonObj, TransformerContext context) {
+        return transformObject(datasetJsonObj, Dataset.class, context);
+    }
+
+    private void transformProperties(String key, JsonValue value, Catalog.Builder builder, TransformerContext context) {
+        if (DCAT_DATASET_ATTRIBUTE.equalsIgnoreCase(key)) {
+            if (value.getValueType().equals(JsonValue.ValueType.ARRAY)) {
+                value.asJsonArray().stream()
+                        .map(jv -> transformDataset(jv, context))
+                        .forEach(builder::dataset);
+            } else {
+                builder.dataset(transformDataset(value, context));
+            }
+        } else if (DCAT_CATALOG_ATTRIBUTE.equalsIgnoreCase(key)) {
+            transformArrayOrObject(value, Catalog.class, builder::dataset, context);
+        } else if (DCAT_DATA_SERVICE_ATTRIBUTE.equalsIgnoreCase(key)) {
+            transformArrayOrObject(value, DataService.class, builder::dataService, context);
+        } else if (DSP_NAMESPACE_V_2025_1.toIri(DSPACE_PROPERTY_PARTICIPANT_ID_TERM).equalsIgnoreCase(key)) {
+            builder.participantId(transformString(value, context));
+        } else if (DCAT_DISTRIBUTION_TYPE.equalsIgnoreCase(key)) {
+            transformArrayOrObject(value, Distribution.class, builder::distribution, context);
+        } else {
+            builder.property(key, transformGenericProperty(value, context));
+        }
+    }
+}

--- a/core/federated-catalog-core-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/core/federated-catalog-core-2025/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,1 @@
+org.eclipse.edc.catalog.cache.FederatedCatalogCacheExtension

--- a/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/TestUtil.java
+++ b/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/TestUtil.java
@@ -1,0 +1,127 @@
+/*
+ *  Copyright (c) 2025 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog;
+
+import jakarta.json.Json;
+import org.eclipse.edc.catalog.transform.JsonObjectToCatalogTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDataServiceTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDatasetTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDistributionTransformer;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
+import org.eclipse.edc.connector.controlplane.transform.odrl.from.JsonObjectFromPolicyTransformer;
+import org.eclipse.edc.connector.controlplane.transform.odrl.to.JsonObjectToPolicyTransformer;
+import org.eclipse.edc.crawler.spi.TargetNode;
+import org.eclipse.edc.json.JacksonTypeManager;
+import org.eclipse.edc.participant.spi.ParticipantIdMapper;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDataServiceTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDatasetTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDistributionTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.v2025.from.JsonObjectFromCatalogV2025Transformer;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+public class TestUtil {
+
+    public static final String TEST_PROTOCOL = "test-protocol";
+
+    public static Catalog createCatalog(String id) {
+        var dataService = DataService.Builder.newInstance()
+                .endpointUrl("https://test-dataservice.endpoint.url")
+                .endpointDescription("test endpoint description")
+                .build();
+        return buildCatalog(id)
+                .datasets(List.of(Dataset.Builder.newInstance()
+                        .id(id + "-dataset")
+                        .distributions(List.of(Distribution.Builder.newInstance()
+                                .dataService(dataService)
+                                .format("test-format").build()))
+                        .build()))
+                .dataServices(List.of(dataService))
+                .build();
+    }
+
+    public static Catalog.Builder buildCatalog(String id) {
+        return Catalog.Builder.newInstance()
+                .participantId("test-participant")
+                .id(id)
+                .properties(new HashMap<>());
+    }
+
+    @NotNull
+    public static TargetNode createNode() {
+        return new TargetNode("testnode" + UUID.randomUUID(), "did:web:" + UUID.randomUUID(), "http://test.com", List.of(TEST_PROTOCOL));
+    }
+
+    public static Catalog createCatalog(int howManyOffers) {
+        var datasets = IntStream.range(0, howManyOffers)
+                .mapToObj(i -> createDataset("dataset-" + i))
+                .collect(Collectors.toList());
+
+        var build = List.of(DataService.Builder.newInstance().build());
+        return Catalog.Builder.newInstance().participantId("test-participant").id("catalog").datasets(datasets).dataServices(build).build();
+    }
+
+    public static Dataset createDataset(String id) {
+        return Dataset.Builder.newInstance()
+                .offer("test-offer", Policy.Builder.newInstance().build())
+                .distribution(Distribution.Builder.newInstance().format("test-format").dataService(DataService.Builder.newInstance().build()).build())
+                .id(id)
+                .build();
+    }
+
+    // registers all the necessary transformers to avoid duplicating their behaviour in mocks
+    public static void registerTransformers(TypeTransformerRegistry registry) {
+        var factory = Json.createBuilderFactory(Map.of());
+        var typeManager = new JacksonTypeManager();
+        var participantIdMapper = new NoOpParticipantIdMapper();
+        registry.register(new JsonObjectFromCatalogV2025Transformer(factory, typeManager, JSON_LD, participantIdMapper, DSP_NAMESPACE_V_2025_1));
+
+        registry.register(new JsonObjectFromDatasetTransformer(factory, typeManager, JSON_LD));
+        registry.register(new JsonObjectFromDataServiceTransformer(factory));
+        registry.register(new JsonObjectFromPolicyTransformer(factory, participantIdMapper));
+        registry.register(new JsonObjectFromDistributionTransformer(factory));
+        registry.register(new JsonObjectToCatalogTransformer());
+        registry.register(new JsonObjectToDatasetTransformer());
+        registry.register(new JsonObjectToDataServiceTransformer());
+        registry.register(new JsonObjectToPolicyTransformer(participantIdMapper));
+        registry.register(new JsonObjectToDistributionTransformer());
+    }
+
+    public static class NoOpParticipantIdMapper implements ParticipantIdMapper {
+        @Override
+        public String toIri(String id) {
+            return id;
+        }
+
+        @Override
+        public String fromIri(String id) {
+            return id;
+        }
+    }
+}

--- a/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtensionTest.java
+++ b/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/cache/FederatedCatalogCacheExtensionTest.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache;
+
+import org.eclipse.edc.boot.system.injection.ObjectFactory;
+import org.eclipse.edc.catalog.cache.query.DspCatalogRequestAction;
+import org.eclipse.edc.catalog.crawler.RecurringExecutionPlan;
+import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
+import org.eclipse.edc.crawler.spi.CrawlerActionRegistry;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
+import org.eclipse.edc.crawler.spi.TargetNodeFilter;
+import org.eclipse.edc.crawler.spi.model.ExecutionPlan;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class FederatedCatalogCacheExtensionTest {
+    private final FederatedCatalogCache storeMock = mock();
+    private final TargetNodeDirectory nodeDirectoryMock = mock();
+    private final CrawlerActionRegistry crawlerActionRegistry = mock();
+    private FederatedCatalogCacheExtension extension;
+
+    @BeforeEach
+    void setUp(ServiceExtensionContext context, ObjectFactory factory) {
+        var monitorWithPrefix = mock(Monitor.class);
+        var monitor = mock(Monitor.class);
+        when(monitor.withPrefix(anyString())).thenReturn(monitorWithPrefix);
+
+        context.registerService(TargetNodeDirectory.class, nodeDirectoryMock);
+        context.registerService(FederatedCatalogCache.class, storeMock);
+        context.registerService(TargetNodeFilter.class, null);
+        context.registerService(ExecutionPlan.class, new RecurringExecutionPlan(Duration.ofSeconds(1), Duration.ofSeconds(0), mock()));
+        context.registerService(TypeManager.class, mock());
+        context.registerService(Monitor.class, monitor);
+        context.registerService(CrawlerActionRegistry.class, crawlerActionRegistry);
+
+        extension = factory.constructInstance(FederatedCatalogCacheExtension.class);
+    }
+
+    @Test
+    void initialize(ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(context, atLeastOnce()).getMonitor();
+    }
+
+    @Test
+    void initialize_withDisabledExecution(ServiceExtensionContext context, ObjectFactory factory) {
+        var mockedConfig = ConfigFactory.fromMap(Map.of("edc.catalog.cache.execution.enabled", Boolean.FALSE.toString()));
+        when(context.getConfig()).thenReturn(mockedConfig);
+        var mockedPlan = mock(ExecutionPlan.class);
+        context.registerService(ExecutionPlan.class, mockedPlan);
+
+        extension = factory.constructInstance(FederatedCatalogCacheExtension.class);
+
+        extension.initialize(context);
+        extension.start();
+
+        verifyNoInteractions(mockedPlan);
+    }
+
+    @Test
+    void start(ServiceExtensionContext context) {
+        extension.initialize(context);
+    }
+
+    @Test
+    void verifyProvider_cacheNodeAdapterRegistry(FederatedCatalogCacheExtension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(crawlerActionRegistry).register(eq(DATASPACE_PROTOCOL_HTTP_V_2025_1), isA(DspCatalogRequestAction.class));
+    }
+
+}

--- a/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestActionTest.java
+++ b/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestActionTest.java
@@ -1,0 +1,139 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache.query;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.catalog.spi.model.CatalogUpdateResponse;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.crawler.spi.model.UpdateRequest;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.transform.TypeTransformerRegistryImpl;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.catalog.TestUtil.createCatalog;
+import static org.eclipse.edc.catalog.TestUtil.registerTransformers;
+import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DspCatalogRequestActionTest {
+
+    private final RemoteMessageDispatcherRegistry dispatcherRegistry = mock();
+    private final TypeTransformerRegistry typeTransformerRegistry = new TypeTransformerRegistryImpl();
+    private final TitaniumJsonLd jsonLdService = new TitaniumJsonLd(mock());
+    private final ObjectMapper objectMapper = createObjectMapper();
+    private final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(
+            ParticipantContext.Builder.newInstance().participantContextId("participantContext").identity("identity").build());
+    private final DspCatalogRequestAction action = new DspCatalogRequestAction(dispatcherRegistry, participantContextSupplier, mock(), objectMapper, typeTransformerRegistry, jsonLdService);
+
+    @BeforeEach
+    void setup() {
+        registerTransformers(typeTransformerRegistry);
+    }
+
+    @Test
+    void apply_withFlatCatalog() {
+        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id", DATASPACE_PROTOCOL_HTTP_V_2025_1);
+
+        var catalog = toBytes(createCatalog("test-catalog-id"));
+        when(dispatcherRegistry.dispatch(any(), eq(byte[].class), any(CatalogRequestMessage.class)))
+                .thenReturn(completedFuture(catalog));
+
+        assertThat(action.apply(request)).isCompletedWithValueMatching(updateResponse -> {
+            if (updateResponse instanceof CatalogUpdateResponse cr) {
+                return cr.getCatalog() != null &&
+                        cr.getCatalog().getId().equals("test-catalog-id") &&
+                        cr.getSource().equals("https://example.com/test-node-id");
+            }
+            return false;
+        });
+    }
+
+    @Test
+    void apply_withOnlyNestedCatalog() {
+        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id", DATASPACE_PROTOCOL_HTTP_V_2025_1);
+
+        var rootCatalog = createCatalog("root-catalog-id");
+        rootCatalog.getDatasets().clear();
+        var nestedCatalog = createCatalog("nested-catalog-id");
+        rootCatalog.getDatasets().add(nestedCatalog);
+
+        when(dispatcherRegistry.dispatch(any(), eq(byte[].class), any(CatalogRequestMessage.class)))
+                .thenReturn(completedFuture(toBytes(rootCatalog)))
+                .thenReturn(completedFuture(toBytes(nestedCatalog)));
+
+        assertThat(action.apply(request)).isCompletedWithValueMatching(updateResponse -> {
+            if (updateResponse instanceof CatalogUpdateResponse cr) {
+                return cr.getCatalog() != null &&
+                        cr.getCatalog().getId().equals("root-catalog-id") &&
+                        cr.getSource().equals("https://example.com/test-node-id") &&
+                        cr.getCatalog().getDatasets().stream().allMatch(dataset -> dataset.getId().equals("nested-catalog-id"));
+            }
+            return false;
+        }, "Contains nested catalog datasets");
+    }
+
+    @Test
+    void apply_withRootDatasets_andNestedCatalog() {
+        var request = new UpdateRequest("test-node-id", "https://example.com/test-node-id", DATASPACE_PROTOCOL_HTTP_V_2025_1);
+
+        var rootCatalog = createCatalog("root-catalog-id");
+        var nestedCatalog = createCatalog("nested-catalog-id");
+        rootCatalog.getDatasets().add(nestedCatalog);
+
+        when(dispatcherRegistry.dispatch(any(), eq(byte[].class), any(CatalogRequestMessage.class)))
+                .thenReturn(completedFuture(toBytes(rootCatalog)))
+                .thenReturn(completedFuture(toBytes(nestedCatalog)));
+
+        assertThat(action.apply(request)).isCompletedWithValueMatching(updateResponse -> {
+            if (updateResponse instanceof CatalogUpdateResponse cr) {
+                return cr.getCatalog() != null &&
+                        cr.getCatalog().getId().equals("root-catalog-id") &&
+                        cr.getSource().equals("https://example.com/test-node-id") &&
+                        cr.getCatalog().getDatasets().stream()
+                                .allMatch(dataset -> dataset.getId().equals("nested-catalog-id") ||
+                                        dataset.getId().equals("root-catalog-id-dataset"));
+            }
+            return false;
+        }, "Contains root catalog datasets plus nested catalog datasets");
+    }
+
+    private StatusResult<byte[]> toBytes(Catalog catalog) {
+        try {
+            var jo = typeTransformerRegistry.transform(catalog, JsonObject.class).getContent();
+            var expanded = jsonLdService.expand(jo).getContent();
+            var expandedStr = objectMapper.writeValueAsString(expanded);
+            return StatusResult.success(expandedStr.getBytes());
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/query/PagingCatalogFetcherTest.java
+++ b/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/query/PagingCatalogFetcherTest.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.query;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.catalog.cache.query.PagingCatalogFetcher;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.junit.annotations.ComponentTest;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.spi.message.Range;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.transform.TypeTransformerRegistryImpl;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.catalog.TestUtil.createCatalog;
+import static org.eclipse.edc.catalog.TestUtil.registerTransformers;
+import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ComponentTest
+class PagingCatalogFetcherTest {
+
+    private final RemoteMessageDispatcherRegistry dispatcherRegistryMock = mock();
+    private final ObjectMapper objectMapper = createObjectMapper();
+    private final TitaniumJsonLd jsonLdService = new TitaniumJsonLd(mock());
+    private final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(
+            ParticipantContext.Builder.newInstance().participantContextId("participantContext").identity("identity").build());
+    private final TypeTransformerRegistry typeTransformerRegistry = new TypeTransformerRegistryImpl();
+    private PagingCatalogFetcher fetcher;
+
+    @BeforeEach
+    void setup() {
+        registerTransformers(typeTransformerRegistry);
+
+        fetcher = new PagingCatalogFetcher(dispatcherRegistryMock, participantContextSupplier, mock(), objectMapper, typeTransformerRegistry, jsonLdService);
+    }
+
+    @Test
+    void fetchAll() throws JsonProcessingException {
+        var cat1 = createCatalog(5);
+        var cat2 = createCatalog(5);
+        var cat3 = createCatalog(3);
+        when(dispatcherRegistryMock.dispatch(any(), eq(byte[].class), any(CatalogRequestMessage.class)))
+                .thenReturn(completedFuture(toBytes(cat1)))
+                .thenReturn(completedFuture(toBytes(cat2)))
+                .thenReturn(completedFuture(toBytes(cat3)))
+                .thenReturn(completedFuture(toBytes(emptyCatalog())));
+
+        var request = createRequest();
+
+        var catalog = fetcher.fetch(request, 0, 5);
+        assertThat(catalog).isCompletedWithValueMatching(list -> list.getDatasets().size() == 13 &&
+                list.getDatasets().stream().allMatch(o -> o.getId().matches("(dataset-)\\d|1[0-3]")));
+
+
+        var captor = forClass(CatalogRequestMessage.class);
+        verify(dispatcherRegistryMock, times(3)).dispatch(any(), eq(byte[].class), captor.capture());
+
+        // verify the sequence of requests
+        assertThat(captor.getAllValues())
+                .extracting(l -> l.getQuerySpec().getRange())
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(new Range(0, 5), new Range(5, 10), new Range(10, 15));
+    }
+
+
+    private StatusResult<byte[]> toBytes(Catalog catalog) throws JsonProcessingException {
+        var jo = typeTransformerRegistry.transform(catalog, JsonObject.class).getContent();
+        var expanded = jsonLdService.expand(jo).getContent();
+        var expandedStr = objectMapper.writeValueAsString(expanded);
+        return StatusResult.success(expandedStr.getBytes());
+    }
+
+    private CatalogRequestMessage createRequest() {
+        return CatalogRequestMessage.Builder.newInstance()
+                .counterPartyAddress("test-address")
+                .protocol(DATASPACE_PROTOCOL_HTTP_V_2025_1)
+                .build();
+    }
+
+    private Catalog emptyCatalog() {
+        return Catalog.Builder.newInstance().id("id").participantId("test-participant").datasets(emptyList()).dataServices(emptyList()).build();
+    }
+
+}

--- a/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToCatalogTransformerTest.java
+++ b/core/federated-catalog-core-2025/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToCatalogTransformerTest.java
@@ -1,0 +1,215 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.catalog.test.TestInput.getExpanded;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_CATALOG_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_CATALOG_TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATASET_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATA_SERVICE_ATTRIBUTE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class JsonObjectToCatalogTransformerTest {
+
+    private static final String CATALOG_ID = "catalogId";
+
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
+
+    private JsonObjectToCatalogTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToCatalogTransformer();
+    }
+
+    @Test
+    void transform_emptyCatalog_returnCatalog() {
+        var catalog = jsonFactory.createObjectBuilder().add(ID, CATALOG_ID).add(TYPE, DCAT_CATALOG_TYPE).build();
+
+        var result = transformer.transform(getExpanded(catalog), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(CATALOG_ID);
+        assertThat(result.getDatasets()).isNotNull();
+        assertThat(result.getDataServices()).isNotNull().isEmpty();
+
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    void transform_catalogWithAdditionalProperty_returnCatalog() {
+        var propertyKey = "catalog:prop:key";
+        var propertyValue = "value";
+
+        when(context.transform(any(JsonValue.class), eq(Object.class))).thenReturn(propertyValue);
+
+        var catalog = jsonFactory.createObjectBuilder()
+                .add(ID, CATALOG_ID)
+                .add(TYPE, DCAT_CATALOG_TYPE)
+                .add(propertyKey, propertyValue)
+                .build();
+
+        var result = transformer.transform(getExpanded(catalog), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(CATALOG_ID);
+        assertThat(result.getProperties()).hasSize(1);
+        assertThat(result.getProperties()).containsEntry(propertyKey, propertyValue);
+
+        verify(context, never()).reportProblem(anyString());
+        verify(context, times(1)).transform(any(JsonValue.class), eq(Object.class));
+    }
+
+    @Test
+    void transform_filledCatalog_returnCatalog() {
+        var datasetJson = getJsonObject("dataset");
+        var dataServiceJson = getJsonObject("dataService");
+
+        var dataset = Dataset.Builder.newInstance()
+                .offer("offerId", Policy.Builder.newInstance().build())
+                .distribution(Distribution.Builder.newInstance()
+                        .format("format")
+                        .dataService(DataService.Builder.newInstance().build())
+                        .build())
+                .build();
+        var dataService = DataService.Builder.newInstance().build();
+
+        when(context.transform(any(JsonObject.class), eq(Dataset.class)))
+                .thenReturn(dataset);
+        when(context.transform(any(JsonObject.class), eq(DataService.class)))
+                .thenReturn(dataService);
+
+        var catalog = jsonFactory.createObjectBuilder()
+                .add(ID, CATALOG_ID)
+                .add(TYPE, DCAT_CATALOG_TYPE)
+                .add(DCAT_DATASET_ATTRIBUTE, datasetJson)
+                .add(DCAT_DATA_SERVICE_ATTRIBUTE, dataServiceJson)
+                .build();
+
+        var result = transformer.transform(getExpanded(catalog), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(CATALOG_ID);
+        assertThat(result.getDatasets()).hasSize(1);
+        assertThat(result.getDatasets().get(0)).isEqualTo(dataset);
+        assertThat(result.getDataServices()).hasSize(1);
+        assertThat(result.getDataServices().get(0)).isEqualTo(dataService);
+
+        verify(context, never()).reportProblem(anyString());
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Dataset.class));
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(DataService.class));
+    }
+
+    @Test
+    void transform_subCatalog_returnCatalog() {
+        var datasetJson = getJsonObject("dataset");
+        var dataServiceJson = getJsonObject("dataService");
+
+        var dataset = Dataset.Builder.newInstance()
+                .offer("offerId", Policy.Builder.newInstance().build())
+                .distribution(Distribution.Builder.newInstance()
+                        .format("format")
+                        .dataService(DataService.Builder.newInstance().build())
+                        .build())
+                .build();
+        var dataService = DataService.Builder.newInstance().build();
+
+
+        var subCatalog = Catalog.Builder.newInstance()
+                .id(CATALOG_ID + "-sub")
+                .dataService(dataService)
+                .dataset(dataset)
+                .build();
+
+        var subCatalogJson = jsonFactory.createObjectBuilder()
+                .add(ID, CATALOG_ID + "-sub")
+                .add(TYPE, DCAT_CATALOG_TYPE)
+                .add(DCAT_DATASET_ATTRIBUTE, datasetJson)
+                .add(DCAT_DATA_SERVICE_ATTRIBUTE, dataServiceJson)
+                .build();
+
+        when(context.transform(any(JsonObject.class), eq(Dataset.class)))
+                .thenReturn(dataset);
+        when(context.transform(any(JsonObject.class), eq(DataService.class)))
+                .thenReturn(dataService);
+
+        when(context.transform(any(JsonObject.class), eq(Catalog.class)))
+                .thenAnswer(args -> transformer.transform(args.getArgument(0), context));
+
+        var catalog = jsonFactory.createObjectBuilder()
+                .add(ID, CATALOG_ID)
+                .add(TYPE, DCAT_CATALOG_TYPE)
+                .add(DCAT_DATASET_ATTRIBUTE, datasetJson)
+                .add(DCAT_CATALOG_ATTRIBUTE, subCatalogJson)
+                .add(DCAT_DATA_SERVICE_ATTRIBUTE, dataServiceJson)
+                .build();
+
+        var result = transformer.transform(getExpanded(catalog), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(CATALOG_ID);
+        assertThat(result.getDatasets()).hasSize(2);
+        assertThat(result.getDatasets()).contains(dataset);
+        assertThat(result.getDatasets()).usingRecursiveFieldByFieldElementComparator().contains(subCatalog);
+        assertThat(result.getDataServices()).hasSize(1);
+        assertThat(result.getDataServices().get(0)).isEqualTo(dataService);
+
+        verify(context, never()).reportProblem(anyString());
+        verify(context, times(2)).transform(isA(JsonObject.class), eq(Dataset.class));
+        verify(context, times(2)).transform(isA(JsonObject.class), eq(DataService.class));
+    }
+
+    @Test
+    void transform_invalidType_reportProblem() {
+        var catalog = jsonFactory.createObjectBuilder().add(TYPE, "not-a-catalog").build();
+
+        transformer.transform(getExpanded(catalog), context);
+
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    private JsonObject getJsonObject(String type) {
+        return jsonFactory.createObjectBuilder().add(TYPE, type).build();
+    }
+
+}

--- a/core/federated-catalog-core/README.md
+++ b/core/federated-catalog-core/README.md
@@ -1,0 +1,6 @@
+This module contains implementations for the Federated Catalog Cache, which is a database that contains a snapshot of
+all the catalogs offered by all the connectors in a dataspace.
+
+It collects those catalogs using `Crawler` objects that run periodically.
+
+**This module is currently under development and should not be considered stable!**

--- a/core/federated-catalog-core/build.gradle.kts
+++ b/core/federated-catalog-core/build.gradle.kts
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `java-test-fixtures`
+}
+
+dependencies {
+    api(project(":spi:common:core-spi"))
+    api(project(":spi:common:web-spi"))
+    api(project(":spi:control-plane:catalog-spi"))
+    api(project(":data-protocols:dsp:dsp-spi"))
+    api(project(":spi:common:participant-context-single-spi"))
+    api(project(":core:crawler-core"))
+    api(project(":spi:federated-catalog-spi"))
+    api(project(":core:common:lib:catalog-util-lib"))
+    api(project(":data-protocols:dsp:dsp-lib:dsp-catalog-lib:dsp-catalog-transform-lib"))
+    api(project(":core:control-plane:control-plane-transform"))
+    api(project(":core:common:lib:transform-lib"))
+    api(project(":core:common:lib:query-lib"))
+
+    implementation(project(":core:common:lib:util-lib"))
+    implementation(project(":data-protocols:dsp:dsp-core:dsp-http-api-base-configuration"))
+    implementation(project(":spi:common:json-ld-spi"))
+    implementation(project(":core:common:lib:json-ld-lib"))
+    implementation(project(":core:common:lib:store-lib"))
+
+    testImplementation(project(":core:common:junit"))
+    testImplementation(project(":extensions:common:http"))
+    testImplementation(libs.awaitility)
+
+    testImplementation(testFixtures(project(":spi:federated-catalog-spi")))
+    testImplementation(testFixtures(project(":spi:crawler-spi")))
+
+    testFixturesImplementation(project(":core:common:lib:json-lib"))
+    testFixturesImplementation(project(":core:common:lib:json-ld-lib"))
+    testFixturesImplementation(project(":core:control-plane:control-plane-transform"))
+    testFixturesImplementation(project(":data-protocols:dsp:dsp-lib:dsp-catalog-lib:dsp-catalog-transform-lib"))
+    testFixturesImplementation(project(":data-protocols:dsp:dsp-2025:dsp-catalog-2025:dsp-catalog-transform-2025"))
+}

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogCoreServicesExtension.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogCoreServicesExtension.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache;
+
+import org.eclipse.edc.catalog.spi.CatalogConstants;
+import org.eclipse.edc.catalog.spi.CatalogCrawlerConfiguration;
+import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
+import org.eclipse.edc.catalog.spi.model.CatalogUpdateResponse;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.crawler.spi.CrawlerActionRegistry;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
+import org.eclipse.edc.crawler.spi.TargetNodeFilter;
+import org.eclipse.edc.crawler.spi.model.ExecutionPlan;
+import org.eclipse.edc.crawler.spi.model.UpdateResponse;
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.health.HealthCheckResult;
+import org.eclipse.edc.spi.system.health.HealthCheckService;
+
+import static java.util.Optional.ofNullable;
+
+@Extension(value = FederatedCatalogCoreServicesExtension.NAME)
+public class FederatedCatalogCoreServicesExtension implements ServiceExtension {
+
+    public static final String NAME = "Federated Catalog Core";
+
+    @Configuration
+    private CatalogCrawlerConfiguration catalogCrawlerConfiguration;
+
+    @Inject(required = false)
+    private ExecutionPlan executionPlan;
+    @Inject
+    private FederatedCatalogCache store;
+    @Inject
+    private CrawlerActionRegistry crawlerActionRegistry;
+    @Inject
+    private TargetNodeDirectory directory;
+    @Inject(required = false)
+    private TargetNodeFilter nodeFilter;
+    @Inject(required = false)
+    private HealthCheckService healthCheckService;
+
+    private Monitor monitor;
+    private ExecutionManager executionManager;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        monitor = context.getMonitor();
+
+        if (healthCheckService != null) {
+            healthCheckService.addReadinessProvider(() -> HealthCheckResult.Builder.newInstance().component("Crawler Subsystem").build());
+        }
+
+        nodeFilter = ofNullable(nodeFilter).orElse(node -> !node.name().equals(context.getRuntimeId()));
+
+        executionManager = ExecutionManager.Builder.newInstance()
+                .monitor(context.getMonitor().withPrefix("ExecutionManager"))
+                .configuration(catalogCrawlerConfiguration)
+                .preExecutionTask(() -> {
+                    store.deleteExpired();
+                    store.expireAll();
+                })
+                .nodeQueryAdapterRegistry(crawlerActionRegistry)
+                .onSuccess(this::persist)
+                .nodeDirectory(directory)
+                .nodeFilterFunction(nodeFilter)
+                .build();
+    }
+
+    @Override
+    public void start() {
+        executionManager.executePlan(executionPlan);
+    }
+
+    @Override
+    public void shutdown() {
+        executionManager.shutdownPlan(executionPlan);
+    }
+
+    /**
+     * inserts a particular {@link Catalog} in the {@link FederatedCatalogCache}
+     *
+     * @param updateResponse The response that contains the catalog
+     */
+    private void persist(UpdateResponse updateResponse) {
+        if (updateResponse instanceof CatalogUpdateResponse catalogUpdateResponse) {
+            var catalog = catalogUpdateResponse.getCatalog();
+            catalog.getProperties().put(CatalogConstants.PROPERTY_ORIGINATOR, updateResponse.getSource());
+            store.save(catalog);
+        } else {
+            monitor.warning("Expected a response of type %s but got %s. Will discard".formatted(CatalogUpdateResponse.class, updateResponse.getClass()));
+        }
+    }
+}

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogDefaultServicesExtension.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/FederatedCatalogDefaultServicesExtension.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache;
+
+import org.eclipse.edc.catalog.cache.crawler.CrawlerActionRegistryImpl;
+import org.eclipse.edc.catalog.cache.query.QueryServiceImpl;
+import org.eclipse.edc.catalog.crawler.RecurringExecutionPlan;
+import org.eclipse.edc.catalog.directory.InMemoryNodeDirectory;
+import org.eclipse.edc.catalog.spi.CatalogCrawlerConfiguration;
+import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
+import org.eclipse.edc.catalog.spi.QueryService;
+import org.eclipse.edc.catalog.store.InMemoryFederatedCatalogCache;
+import org.eclipse.edc.crawler.spi.CrawlerActionRegistry;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
+import org.eclipse.edc.crawler.spi.model.ExecutionPlan;
+import org.eclipse.edc.query.CriterionOperatorRegistryImpl;
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.util.concurrency.LockManager;
+
+import java.time.Duration;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Provides default service implementations for fallback
+ * Omitted {@link org.eclipse.edc.runtime.metamodel.annotation.Extension since there this module already contains {@code FederatedCatalogCacheExtension} }
+ */
+public class FederatedCatalogDefaultServicesExtension implements ServiceExtension {
+
+    public static final String NAME = "Federated Catalog Default Services";
+
+    @Configuration
+    private CatalogCrawlerConfiguration catalogCrawlerConfiguration;
+
+    @Inject
+    private FederatedCatalogCache store;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider(isDefault = true)
+    public FederatedCatalogCache defaultCacheStore() {
+        return new InMemoryFederatedCatalogCache(new LockManager(new ReentrantReadWriteLock()), CriterionOperatorRegistryImpl.ofDefaults());
+    }
+
+    @Provider(isDefault = true)
+    public TargetNodeDirectory defaultNodeDirectory() {
+        return new InMemoryNodeDirectory();
+    }
+
+    @Provider
+    public QueryService defaultQueryEngine() {
+        return new QueryServiceImpl(store);
+    }
+
+    @Provider
+    public CrawlerActionRegistry crawlerActionRegistry() {
+        return new CrawlerActionRegistryImpl();
+    }
+
+    @Provider(isDefault = true)
+    public ExecutionPlan createRecurringExecutionPlan(ServiceExtensionContext context) {
+        var monitor = context.getMonitor();
+        catalogCrawlerConfiguration.checkPeriodSeconds().ifPresent(monitor::warning);
+        return new RecurringExecutionPlan(
+                Duration.ofSeconds(catalogCrawlerConfiguration.periodSeconds()),
+                Duration.ofSeconds(catalogCrawlerConfiguration.delaySeconds()),
+                monitor);
+    }
+}

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestAction.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/DspCatalogRequestAction.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache.query;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.catalog.spi.model.CatalogUpdateResponse;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.crawler.spi.CrawlerAction;
+import org.eclipse.edc.crawler.spi.model.UpdateRequest;
+import org.eclipse.edc.crawler.spi.model.UpdateResponse;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static java.util.Optional.ofNullable;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.eclipse.edc.federatedcatalog.util.FederatedCatalogUtil.copy;
+
+public class DspCatalogRequestAction implements CrawlerAction {
+    private static final int INITIAL_OFFSET = 0;
+    private static final int BATCH_SIZE = 100;
+    private final PagingCatalogFetcher fetcher;
+
+    public DspCatalogRequestAction(RemoteMessageDispatcherRegistry dispatcherRegistry, SingleParticipantContextSupplier participantContextSupplier,
+                                   Monitor monitor, ObjectMapper objectMapper, TypeTransformerRegistry transformerRegistry, JsonLd jsonLdService
+    ) {
+        fetcher = new PagingCatalogFetcher(dispatcherRegistry, participantContextSupplier, monitor,  objectMapper, transformerRegistry, jsonLdService);
+    }
+
+    @Override
+    public CompletableFuture<UpdateResponse> apply(UpdateRequest request) {
+        var catalogRequest = CatalogRequestMessage.Builder.newInstance()
+                .protocol(request.protocol())
+                .counterPartyAddress(request.nodeUrl())
+                .counterPartyId(request.nodeId())
+                .build();
+
+        var catalogFuture = fetcher.fetch(catalogRequest, INITIAL_OFFSET, BATCH_SIZE);
+
+        return catalogFuture
+                .thenCompose(rootCatalog -> expandCatalog(rootCatalog, request.protocol()))
+                .thenApply(catalog -> new CatalogUpdateResponse(request.nodeUrl(), catalog));
+    }
+
+    /**
+     * This will go through the root catalog, and for every {@link Dataset}, that is in fact a {@link Catalog}, it will recurse down
+     * and fetch that {@link Catalog} as well.
+     * Note that this method will preserve hierarchy, so there could be catalogs within catalogs withing catalogs...
+     *
+     * @param rootCatalog the root catalog, e.g. of a catalog server
+     * @param protocol the protocol
+     * @return a {@link Catalog} that contains expanded subcatalogs
+     */
+    private CompletableFuture<Catalog> expandCatalog(Catalog rootCatalog, String protocol) {
+        var partitions = rootCatalog.getDatasets().stream().collect(Collectors.groupingBy(Dataset::getClass));
+
+        var subCatalogs = partitions.get(Catalog.class);
+
+        if (subCatalogs == null || subCatalogs.isEmpty()) {
+            return completedFuture(rootCatalog);
+        }
+
+        var expandedSubCatalogs = subCatalogs.stream()
+                .map(ds -> (Catalog) ds)
+                .map(subCatalog -> subCatalog.getDataServices().stream()
+                        .map(DataService::getEndpointUrl)
+                        .filter(Objects::nonNull)
+                        .findFirst()
+                        .map(url -> {
+                            var id = ofNullable(subCatalog.getParticipantId()).orElseGet(rootCatalog::getParticipantId);
+                            return new UpdateRequest(id, url, protocol);
+                        })
+                        .orElse(null))
+                .filter(Objects::nonNull)
+                .map(this) //recursively call this.apply()
+                .map(CompletableFuture::join)
+                .map(ur -> (CatalogUpdateResponse) ur)
+                .map(CatalogUpdateResponse::getCatalog);
+
+        var datasets = ofNullable(partitions.get(Dataset.class))
+                .map(ArrayList::new)
+                .orElseGet(ArrayList::new);
+        expandedSubCatalogs.forEach(datasets::add);
+        return completedFuture(copy(rootCatalog, datasets).build());
+
+    }
+
+}

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/PagingCatalogFetcher.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/PagingCatalogFetcher.java
@@ -1,0 +1,124 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache.query;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.message.Range;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.result.Failure;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+
+import static java.lang.String.format;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+import static org.eclipse.edc.federatedcatalog.util.FederatedCatalogUtil.copy;
+import static org.eclipse.edc.federatedcatalog.util.FederatedCatalogUtil.merge;
+
+/**
+ * Helper class that runs through a loop and sends {@link CatalogRequestMessage}s until no more {@link ContractOffer}s are
+ * received. This is useful to avoid overloading the provider connector by chunking the resulting response payload
+ * size.
+ */
+public class PagingCatalogFetcher {
+    private final RemoteMessageDispatcherRegistry dispatcherRegistry;
+    private final SingleParticipantContextSupplier participantContextSupplier;
+    private final Monitor monitor;
+    private final ObjectMapper objectMapper;
+    private final TypeTransformerRegistry transformerRegistry;
+    private final JsonLd jsonLdService;
+
+    public PagingCatalogFetcher(RemoteMessageDispatcherRegistry dispatcherRegistry, SingleParticipantContextSupplier participantContextSupplier,
+                                Monitor monitor, ObjectMapper objectMapper, TypeTransformerRegistry transformerRegistry, JsonLd jsonLdService) {
+        this.dispatcherRegistry = dispatcherRegistry;
+        this.participantContextSupplier = participantContextSupplier;
+        this.monitor = monitor;
+        this.objectMapper = objectMapper;
+        this.transformerRegistry = transformerRegistry;
+        this.jsonLdService = jsonLdService;
+    }
+
+    /**
+     * Gets all contract offers. Requests are split in digestible chunks to match {@code batchSize} until no more offers
+     * can be obtained.
+     *
+     * @param catalogRequest The catalog request. This will be copied for every request.
+     * @param from           The (zero-based) index of the first item
+     * @param batchSize      The size of one batch
+     * @return A list of {@link ContractOffer} objects
+     */
+    public @NotNull CompletableFuture<Catalog> fetch(CatalogRequestMessage catalogRequest, int from, int batchSize) {
+
+        var range = new Range(from, from + batchSize);
+        var rangedRequest = CatalogRequestMessage.Builder.newInstance()
+                .counterPartyAddress(catalogRequest.getCounterPartyAddress())
+                .counterPartyId(catalogRequest.getCounterPartyId())
+                .protocol(catalogRequest.getProtocol())
+                .querySpec(QuerySpec.Builder.newInstance().range(range).build())
+                .build();
+
+        var participantResult  = participantContextSupplier.get().map(ParticipantContext::getParticipantContextId);
+        if (participantResult.failed()) {
+            return failedFuture(new EdcException(participantResult.getFailureDetail()));
+        }
+
+        return dispatcherRegistry.dispatch(participantResult.getContent(), byte[].class, rangedRequest)
+                .thenCompose(this::readCatalogFrom)
+                .thenApply(catalog -> copy(catalog).build())
+                .thenCompose(catalog -> {
+
+                    var datasets = catalog.getDatasets();
+                    if (datasets.size() >= batchSize) {
+                        monitor.debug(format("Fetching next batch from %s to %s", from, from + batchSize));
+                        return fetch(rangedRequest, range.getFrom() + batchSize, batchSize)
+                                .thenApply(catalogChunk -> merge(catalog, catalogChunk));
+                    } else {
+                        return completedFuture(catalog);
+                    }
+                });
+    }
+
+    private CompletableFuture<Catalog> readCatalogFrom(StatusResult<byte[]> bytes) {
+        if (bytes.failed()) {
+            return CompletableFuture.failedFuture(new EdcException(bytes.getFailureDetail()));
+        }
+        try {
+            var json = new String(bytes.getContent());
+            var catalogJsonObject = objectMapper.readValue(json, JsonObject.class);
+            return jsonLdService.expand(catalogJsonObject)
+                    .compose(expandedJson -> transformerRegistry.transform(expandedJson, Catalog.class))
+                    .map(CompletableFuture::completedFuture)
+                    .orElse((Failure f) -> failedFuture(new EdcException(f.getFailureDetail())));
+        } catch (JsonProcessingException e) {
+            monitor.severe(() -> "Error parsing Catalog from byes", e);
+            return failedFuture(e);
+        }
+    }
+
+}

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/QueryServiceImpl.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/cache/query/QueryServiceImpl.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache.query;
+
+import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
+import org.eclipse.edc.catalog.spi.QueryService;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+import java.util.Collection;
+
+public class QueryServiceImpl implements QueryService {
+
+    private final FederatedCatalogCache cache;
+
+    public QueryServiceImpl(FederatedCatalogCache cache) {
+        this.cache = cache;
+    }
+
+    @Override
+    public ServiceResult<Collection<Catalog>> getCatalog(QuerySpec query) {
+
+        return ServiceResult.from(Result.ofThrowable(() -> cache.query(query)));
+    }
+}

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/crawler/RecurringExecutionPlan.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/crawler/RecurringExecutionPlan.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *       Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. - Add stop method
+ *
+ */
+
+package org.eclipse.edc.catalog.crawler;
+
+import org.eclipse.edc.crawler.spi.model.ExecutionPlan;
+import org.eclipse.edc.spi.monitor.Monitor;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An ExecutionPlan that executes periodically according to a given schedule.
+ */
+public class RecurringExecutionPlan implements ExecutionPlan {
+
+    private static final Integer EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 60;
+
+    private final Duration schedule;
+    private final Duration withInitialDelay;
+    private final Monitor monitor;
+    private ScheduledExecutorService ses;
+
+    /**
+     * Instantiates the {@code RecurringExecutionPlan}.
+     *
+     * @param schedule     A time span used for initial delay and for the period.
+     * @param initialDelay Specifies whether the execution plan should run right away or after an initial delay passes.
+     */
+    public RecurringExecutionPlan(Duration schedule, Duration initialDelay, Monitor monitor) {
+        this.schedule = schedule;
+        withInitialDelay = initialDelay;
+        this.monitor = monitor;
+    }
+
+    @Override
+    public void run(Runnable task) {
+        ses = Executors.newSingleThreadScheduledExecutor();
+        ses.scheduleAtFixedRate(catchExceptions(task), withInitialDelay.toMillis(), schedule.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void stop() {
+        if (ses != null && !ses.isShutdown()) {
+            ses.shutdown();
+            try {
+                if (!ses.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    ses.shutdownNow();
+
+                    if (!ses.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                        monitor.warning("The execution plan did not shutdown");
+                    }
+                }
+            } catch (InterruptedException ie) {
+                monitor.severe("Unexpected error during execution plan shutdown", ie);
+                ses.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private Runnable catchExceptions(Runnable original) {
+        return () -> {
+            try {
+                original.run();
+            } catch (Throwable thr) {
+                monitor.severe("Unexpected error during plan execution", thr);
+            }
+        };
+    }
+}

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/directory/InMemoryNodeDirectory.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/directory/InMemoryNodeDirectory.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.directory;
+
+import org.eclipse.edc.crawler.spi.TargetNode;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class InMemoryNodeDirectory implements TargetNodeDirectory {
+    private final Map<String, TargetNode> cache = new ConcurrentHashMap<>();
+
+    @Override
+    public List<TargetNode> getAll() {
+        return List.copyOf(cache.values()); //never return the internal copy
+    }
+
+    @Override
+    public void insert(TargetNode node) {
+        cache.put(node.id(), node);
+    }
+
+    @Override
+    public TargetNode remove(String id) {
+        return cache.remove(id);
+    }
+}

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/store/InMemoryFederatedCatalogCache.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/store/InMemoryFederatedCatalogCache.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.store;
+
+import org.eclipse.edc.catalog.spi.CatalogConstants;
+import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.spi.query.CriterionOperatorRegistry;
+import org.eclipse.edc.spi.query.QueryResolver;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.store.ReflectionBasedQueryResolver;
+import org.eclipse.edc.util.concurrency.LockManager;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.Optional.ofNullable;
+
+/**
+ * An ephemeral in-memory cache store.
+ */
+public class InMemoryFederatedCatalogCache implements FederatedCatalogCache {
+
+    private final Map<String, MarkableEntry<Catalog>> cache = new ConcurrentHashMap<>();
+    private final LockManager lockManager;
+    private final QueryResolver<Catalog> queryResolver;
+
+
+    public InMemoryFederatedCatalogCache(LockManager lockManager, CriterionOperatorRegistry criterionOperatorRegistry) {
+        this.lockManager = lockManager;
+        queryResolver = new ReflectionBasedQueryResolver<>(Catalog.class, criterionOperatorRegistry);
+    }
+
+    @Override
+    public void save(Catalog catalog) {
+        lockManager.writeLock(() -> {
+            var id = ofNullable(catalog.getProperties().get(CatalogConstants.PROPERTY_ORIGINATOR))
+                    .map(Object::toString)
+                    .orElse(catalog.getId());
+            return cache.put(id, new MarkableEntry<>(false, catalog));
+        });
+    }
+
+    @Override
+    public Collection<Catalog> query(QuerySpec query) {
+        var catalogs = cache.values().stream().map(me -> me.entry);
+        return lockManager.readLock(() -> queryResolver.query(catalogs, query)).toList();
+    }
+
+    @Override
+    public void deleteExpired() {
+        lockManager.writeLock(() -> {
+            cache.values().removeIf(MarkableEntry::isMarked);
+            return null;
+        });
+    }
+
+    @Override
+    public void expireAll() {
+        cache.replaceAll((k, v) -> new MarkableEntry<>(true, v.getEntry()));
+    }
+
+    private static class MarkableEntry<B> {
+        private final B entry;
+        private final boolean mark;
+
+        MarkableEntry(boolean isMarked, B catalog) {
+            entry = catalog;
+            mark = isMarked;
+        }
+
+        public boolean isMarked() {
+            return mark;
+        }
+
+        public B getEntry() {
+            return entry;
+        }
+
+    }
+}

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToDataServiceTransformer.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToDataServiceTransformer.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ENDPOINT_DESCRIPTION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ENDPOINT_URL_ATTRIBUTE;
+
+/**
+ * Converts from a DCAT data service as a {@link JsonObject} in JSON-LD expanded form to a {@link DataService}.
+ */
+public class JsonObjectToDataServiceTransformer extends AbstractJsonLdTransformer<JsonObject, DataService> {
+
+    public JsonObjectToDataServiceTransformer() {
+        super(JsonObject.class, DataService.class);
+    }
+
+    @Override
+    public @Nullable DataService transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
+        var builder = DataService.Builder.newInstance();
+
+        builder.id(nodeId(object));
+        visitProperties(object, (key, value) -> transformProperties(key, value, builder, context));
+
+        return builderResult(builder::build, context);
+    }
+
+    private void transformProperties(String key, JsonValue value, DataService.Builder builder, TransformerContext context) {
+        if (DCAT_ENDPOINT_URL_ATTRIBUTE.equals(key)) {
+            transformString(value, builder::endpointUrl, context);
+        } else if (DCAT_ENDPOINT_DESCRIPTION_ATTRIBUTE.equals(key)) {
+            transformString(value, builder::endpointDescription, context);
+        }
+    }
+}
+

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToDatasetTransformer.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToDatasetTransformer.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+
+import static jakarta.json.JsonValue.ValueType.ARRAY;
+import static jakarta.json.JsonValue.ValueType.OBJECT;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATASET_TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DISTRIBUTION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_ATTRIBUTE;
+
+/**
+ * Converts from a DCAT dataset as a {@link JsonObject} in JSON-LD expanded form to a {@link Dataset}.
+ */
+public class JsonObjectToDatasetTransformer extends AbstractJsonLdTransformer<JsonObject, Dataset> {
+
+    public JsonObjectToDatasetTransformer() {
+        super(JsonObject.class, Dataset.class);
+    }
+
+    @Override
+    public @Nullable Dataset transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
+        var builder = Dataset.Builder.newInstance();
+
+        builder.id(nodeId(object));
+        builder.distributions(new ArrayList<>());
+        visitProperties(object, (key, value) -> transformProperties(key, value, builder, context));
+
+        return builderResult(builder::build, context);
+    }
+
+    private void transformProperties(String key, JsonValue value, Dataset.Builder builder, TransformerContext context) {
+        switch (key) {
+            case ODRL_POLICY_ATTRIBUTE -> transformPolicies(value, builder, context);
+            case DCAT_DISTRIBUTION_ATTRIBUTE ->
+                    transformArrayOrObject(value, Distribution.class, builder::distribution, context);
+            default -> builder.property(key, transformGenericProperty(value, context));
+        }
+    }
+
+    private void transformPolicies(JsonValue value, Dataset.Builder builder, TransformerContext context) {
+        if (value instanceof JsonObject object) {
+            var id = nodeId(object);
+            var policy = context.transform(object, Policy.class);
+            builder.offer(id, policy);
+        } else if (value instanceof JsonArray array) {
+            array.forEach(entry -> transformPolicies(entry, builder, context));
+        } else {
+            context.problem()
+                    .unexpectedType()
+                    .type(DCAT_DATASET_TYPE)
+                    .property(ODRL_POLICY_ATTRIBUTE)
+                    .actual(value == null ? "null" : value.getValueType().toString())
+                    .expected(OBJECT)
+                    .expected(ARRAY)
+                    .report();
+        }
+    }
+}

--- a/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToDistributionTransformer.java
+++ b/core/federated-catalog-core/src/main/java/org/eclipse/edc/catalog/transform/JsonObjectToDistributionTransformer.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ACCESS_SERVICE_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
+
+/**
+ * Converts from a DCAT distribution as a {@link JsonObject} in JSON-LD expanded form to a {@link Distribution}.
+ */
+public class JsonObjectToDistributionTransformer extends AbstractJsonLdTransformer<JsonObject, Distribution> {
+
+    public JsonObjectToDistributionTransformer() {
+        super(JsonObject.class, Distribution.class);
+    }
+
+    @Override
+    public @Nullable Distribution transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
+        var builder = Distribution.Builder.newInstance();
+        visitProperties(object, (key, value) -> transformProperties(key, value, builder, context));
+        return builderResult(builder::build, context);
+    }
+
+    private void transformProperties(String key, JsonValue value, Distribution.Builder builder, TransformerContext context) {
+        if (DCAT_ACCESS_SERVICE_ATTRIBUTE.equals(key)) {
+            var dataServiceBuilder = DataService.Builder.newInstance();
+            transformString(value, dataServiceBuilder::id, context);
+            builder.dataService(dataServiceBuilder.build());
+        } else if (DCT_FORMAT_ATTRIBUTE.equals(key)) {
+            transformString(value, builder::format, context);
+        }
+    }
+}

--- a/core/federated-catalog-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/core/federated-catalog-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,2 @@
+org.eclipse.edc.catalog.cache.FederatedCatalogCoreServicesExtension
+org.eclipse.edc.catalog.cache.FederatedCatalogDefaultServicesExtension

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/cache/FederatedCatalogCoreServicesExtensionTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/cache/FederatedCatalogCoreServicesExtensionTest.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache;
+
+import org.eclipse.edc.boot.system.injection.ObjectFactory;
+import org.eclipse.edc.catalog.crawler.RecurringExecutionPlan;
+import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
+import org.eclipse.edc.crawler.spi.TargetNodeFilter;
+import org.eclipse.edc.crawler.spi.model.ExecutionPlan;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.spi.system.health.HealthCheckService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class FederatedCatalogCoreServicesExtensionTest {
+
+    private final FederatedCatalogCache store = mock();
+    private final TargetNodeDirectory nodeDirectory = mock();
+    private final HealthCheckService healthCheckService = mock();
+    private final ExecutionPlan executionPlan = mock();
+    private FederatedCatalogCoreServicesExtension extension;
+
+    @BeforeEach
+    void setUp(ServiceExtensionContext context, ObjectFactory factory) {
+        var monitorWithPrefix = mock(Monitor.class);
+        var monitor = mock(Monitor.class);
+        when(monitor.withPrefix(anyString())).thenReturn(monitorWithPrefix);
+
+        context.registerService(TargetNodeDirectory.class, nodeDirectory);
+        context.registerService(FederatedCatalogCache.class, store);
+        context.registerService(TargetNodeFilter.class, null);
+        context.registerService(ExecutionPlan.class, new RecurringExecutionPlan(Duration.ofSeconds(1), Duration.ofSeconds(0), mock()));
+        context.registerService(Monitor.class, monitor);
+        context.registerService(HealthCheckService.class, healthCheckService);
+        context.registerService(ExecutionPlan.class, executionPlan);
+
+        extension = factory.constructInstance(FederatedCatalogCoreServicesExtension.class);
+    }
+
+    @Test
+    void initialize(ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(context, atLeastOnce()).getMonitor();
+    }
+
+    @Test
+    void initialize_withHealthCheck(ServiceExtensionContext context, FederatedCatalogCoreServicesExtension extension) {
+        extension.initialize(context);
+
+        verify(healthCheckService).addReadinessProvider(any());
+    }
+
+    @Test
+    void initialize_withDisabledExecution(ServiceExtensionContext context, ObjectFactory objectFactory) {
+        var mockedConfig = ConfigFactory.fromMap(Map.of("edc.catalog.cache.execution.enabled", Boolean.FALSE.toString()));
+        when(context.getConfig()).thenReturn(mockedConfig);
+
+        var extension = objectFactory.constructInstance(FederatedCatalogCoreServicesExtension.class);
+
+        extension.initialize(context);
+        extension.start();
+
+        verifyNoInteractions(executionPlan);
+    }
+
+    @Test
+    void start(ServiceExtensionContext context) {
+        extension.initialize(context);
+    }
+
+
+}

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/cache/query/QueryServiceImplTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/cache/query/QueryServiceImplTest.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache.query;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.eclipse.edc.catalog.test.TestUtil.createCatalog;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class QueryServiceImplTest {
+
+    private static final Catalog CATALOG_ABC = createCatalog("ABC");
+    private static final Catalog CATALOG_DEF = createCatalog("DEF");
+    private static final Catalog CATALOG_XYZ = createCatalog("XYZ");
+
+    private final FederatedCatalogCache storeMock = mock();
+    private final QueryServiceImpl queryService = new QueryServiceImpl(storeMock);
+
+    @Test
+    void getCatalog() {
+
+        when(storeMock.query(any())).thenReturn(List.of(CATALOG_ABC, CATALOG_DEF, CATALOG_XYZ));
+
+        var catalog = queryService.getCatalog(QuerySpec.none());
+        assertThat(catalog).isSucceeded();
+        Assertions.assertThat(catalog.getContent()).containsExactlyInAnyOrder(CATALOG_ABC, CATALOG_DEF, CATALOG_XYZ);
+        verify(storeMock).query(any());
+    }
+
+    @Test
+    void getCatalog_storeThrowsException() {
+        when(storeMock.query(any())).thenThrow(new RuntimeException("test exception"));
+
+        var catalog = queryService.getCatalog(QuerySpec.none());
+        assertThat(catalog).isFailed()
+                .detail().isEqualTo("test exception");
+        verify(storeMock).query(any());
+    }
+
+    @Test
+    void getCatalog_empty() {
+        when(storeMock.query(any())).thenReturn(Collections.emptyList());
+
+        var catalog = queryService.getCatalog(QuerySpec.none());
+        assertThat(catalog).isSucceeded();
+        Assertions.assertThat(catalog.getContent()).isEmpty();
+        verify(storeMock).query(any());
+    }
+}

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/crawler/RecurringExecutionPlanTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/crawler/RecurringExecutionPlanTest.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (c) 2024 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. - initial implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.crawler;
+
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class RecurringExecutionPlanTest {
+    private static final Integer POLL_DELAY = 10;
+    private final Monitor monitor = mock(Monitor.class);
+    private RecurringExecutionPlan recurringExecutionPlan;
+
+    @BeforeEach
+    public void setUp() {
+        var schedule = Duration.ofMillis(5);
+        var initialDelay = Duration.ofMillis(1);
+        recurringExecutionPlan = new RecurringExecutionPlan(schedule, initialDelay, monitor);
+    }
+
+    @Test
+    public void runPlan_shouldExecuteAtLeastOnce() {
+        AtomicInteger counter = new AtomicInteger();
+        Runnable task = counter::incrementAndGet;
+
+        recurringExecutionPlan.run(task);
+
+        await().pollDelay(Duration.ofMillis(POLL_DELAY))
+                .untilAsserted(() -> {
+                    recurringExecutionPlan.stop();
+                    assertThat(counter).hasPositiveValue();
+                });
+    }
+
+    @Test
+    public void stopPlanWithoutRun_shouldNotLogWarningsOrErrors() {
+        recurringExecutionPlan.stop();
+
+        verify(monitor, never()).warning(anyString());
+        verify(monitor, never()).severe(anyString(), any(Throwable.class));
+    }
+
+    @Test
+    public void runPlaneWithException_shouldLogError() {
+        Runnable task = () -> {
+            throw new RuntimeException("Test Exception");
+        };
+
+        recurringExecutionPlan.run(task);
+
+        await().pollDelay(Duration.ofMillis(POLL_DELAY))
+                .untilAsserted(() -> {
+                    recurringExecutionPlan.stop();
+                    verify(monitor, atLeastOnce())
+                            .severe(anyString(), any(Throwable.class));
+                });
+    }
+
+    @Test
+    public void stopPlan_shouldPreventFurtherPlanExecution() {
+        AtomicInteger counter = new AtomicInteger();
+        Runnable task = counter::incrementAndGet;
+
+        recurringExecutionPlan.run(task);
+
+        await().pollDelay(Duration.ofMillis(POLL_DELAY))
+                .until(() -> counter.get() > 0);
+
+        recurringExecutionPlan.stop();
+
+        int countAfterStop = counter.get();
+
+        await().pollDelay(POLL_DELAY, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> assertThat(counter.get()).isEqualTo(countAfterStop));
+    }
+
+}

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/defaults/store/InMemoryFederatedCatalogCacheTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/defaults/store/InMemoryFederatedCatalogCacheTest.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2020 - 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.defaults.store;
+
+
+import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
+import org.eclipse.edc.catalog.spi.testfixtures.FederatedCatalogCacheTestBase;
+import org.eclipse.edc.catalog.store.InMemoryFederatedCatalogCache;
+import org.eclipse.edc.query.CriterionOperatorRegistryImpl;
+import org.eclipse.edc.util.concurrency.LockManager;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+class InMemoryFederatedCatalogCacheTest extends FederatedCatalogCacheTestBase {
+
+    private final InMemoryFederatedCatalogCache store = new InMemoryFederatedCatalogCache(new LockManager(new ReentrantReadWriteLock()), CriterionOperatorRegistryImpl.ofDefaults());
+    
+    @Override
+    protected FederatedCatalogCache getStore() {
+        return store;
+    }
+}

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/directory/InMemoryNodeDirectoryTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/directory/InMemoryNodeDirectoryTest.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2024 Amadeus IT Group
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus IT Group - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.directory;
+
+import org.eclipse.edc.catalog.spi.testfixtures.TargetNodeDirectoryTestBase;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
+
+class InMemoryNodeDirectoryTest extends TargetNodeDirectoryTestBase {
+
+    private final InMemoryNodeDirectory store = new InMemoryNodeDirectory();
+
+    @Override
+    protected TargetNodeDirectory getStore() {
+        return store;
+    }
+
+}

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToDataServiceTransformerTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToDataServiceTransformerTest.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.catalog.test.TestInput.getExpanded;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATA_SERVICE_TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ENDPOINT_DESCRIPTION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ENDPOINT_URL_ATTRIBUTE;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+
+class JsonObjectToDataServiceTransformerTest {
+
+    private static final String DATA_SERVICE_ID = "dataServiceId";
+
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
+
+    private JsonObjectToDataServiceTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToDataServiceTransformer();
+    }
+
+    @Test
+    void transform_returnDataService() {
+        var terms = "terms";
+        var url = "url";
+
+        var dataService = jsonFactory.createObjectBuilder()
+                .add(ID, DATA_SERVICE_ID)
+                .add(TYPE, DCAT_DATA_SERVICE_TYPE)
+                .add(DCAT_ENDPOINT_DESCRIPTION_ATTRIBUTE, terms)
+                .add(DCAT_ENDPOINT_URL_ATTRIBUTE, url)
+                .build();
+
+        var result = transformer.transform(getExpanded(dataService), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(DATA_SERVICE_ID);
+        assertThat(result.getEndpointDescription()).isEqualTo(terms);
+        assertThat(result.getEndpointUrl()).isEqualTo(url);
+
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    void transform_invalidType_reportProblem() {
+        var dataService = jsonFactory.createObjectBuilder().add(TYPE, "not-a-data-service").build();
+
+        transformer.transform(getExpanded(dataService), context);
+
+        verify(context, never()).reportProblem(anyString());
+    }
+}

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToDatasetTransformerTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToDatasetTransformerTest.java
@@ -1,0 +1,161 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.catalog.test.TestInput.getExpanded;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DATASET_TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DISTRIBUTION_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_ATTRIBUTE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class JsonObjectToDatasetTransformerTest {
+
+    private static final String DATASET_ID = "datasetId";
+
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock();
+
+    private JsonObjectToDatasetTransformer transformer;
+
+    private Policy policy;
+    private Distribution distribution;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToDatasetTransformer();
+
+        policy = Policy.Builder.newInstance().build();
+        distribution = Distribution.Builder.newInstance()
+                .format("format")
+                .dataService(DataService.Builder.newInstance().build())
+                .build();
+
+        when(context.transform(any(JsonObject.class), eq(Policy.class)))
+                .thenReturn(policy);
+        when(context.transform(any(JsonObject.class), eq(Distribution.class)))
+                .thenReturn(distribution);
+    }
+
+    @Test
+    void transform_returnDataset() {
+        var policyId = "policy-id";
+        var policyJson = getJsonObject(policyId, "policy");
+        var distributionJson = getJsonObject("data-service-id", "dataService");
+
+        var dataset = jsonFactory.createObjectBuilder()
+                .add(ID, DATASET_ID)
+                .add(TYPE, DCAT_DATASET_TYPE)
+                .add(ODRL_POLICY_ATTRIBUTE, policyJson)
+                .add(DCAT_DISTRIBUTION_ATTRIBUTE, distributionJson)
+                .build();
+
+        var result = transformer.transform(getExpanded(dataset), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(DATASET_ID);
+        assertThat(result.getOffers()).hasSize(1);
+        assertThat(result.getOffers()).containsEntry(policyId, policy);
+        assertThat(result.getDistributions()).hasSize(1);
+        assertThat(result.getDistributions().get(0)).isEqualTo(distribution);
+
+        verify(context, never()).reportProblem(anyString());
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Policy.class));
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Distribution.class));
+    }
+
+    @Test
+    void transform_datasetWithAdditionalProperty_returnDataset() {
+        var propertyKey = "dataset:prop:key";
+        var propertyValue = "value";
+
+        when(context.transform(any(JsonValue.class), eq(Object.class))).thenReturn(propertyValue);
+
+        var dataset = jsonFactory.createObjectBuilder()
+                .add(ID, DATASET_ID)
+                .add(TYPE, DCAT_DATASET_TYPE)
+                .add(ODRL_POLICY_ATTRIBUTE, jsonFactory.createObjectBuilder().build())
+                .add(DCAT_DISTRIBUTION_ATTRIBUTE, jsonFactory.createObjectBuilder().build())
+                .add(propertyKey, propertyValue)
+                .build();
+
+        var result = transformer.transform(getExpanded(dataset), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(DATASET_ID);
+        assertThat(result.getProperties()).hasSize(1);
+        assertThat(result.getProperties()).containsEntry(propertyKey, propertyValue);
+
+        verify(context, never()).reportProblem(anyString());
+        verify(context, times(1)).transform(any(JsonValue.class), eq(Object.class));
+    }
+
+    @Test
+    void transform_dataset_withoutDistribution() {
+        var policyId = "policy-id";
+        var policyJson = getJsonObject(policyId, "policy");
+        var distributionJson = jsonFactory.createArrayBuilder().build();
+
+        var dataset = jsonFactory.createObjectBuilder()
+                .add(ID, DATASET_ID)
+                .add(TYPE, DCAT_DATASET_TYPE)
+                .add(ODRL_POLICY_ATTRIBUTE, policyJson)
+                .add(DCAT_DISTRIBUTION_ATTRIBUTE, distributionJson)
+                .build();
+
+        var result = transformer.transform(getExpanded(dataset), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(DATASET_ID);
+        assertThat(result.getOffers()).hasSize(1);
+        assertThat(result.getOffers()).containsEntry(policyId, policy);
+        assertThat(result.getDistributions()).isNotNull().isEmpty();
+
+        verify(context, never()).reportProblem(anyString());
+        verify(context, times(1)).transform(isA(JsonObject.class), eq(Policy.class));
+        verify(context, never()).transform(isA(JsonObject.class), eq(Distribution.class));
+    }
+
+    private JsonObject getJsonObject(String id, String type) {
+        return jsonFactory.createObjectBuilder()
+                .add(ID, id)
+                .add(TYPE, type)
+                .build();
+    }
+
+}

--- a/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToDistributionTransformerTest.java
+++ b/core/federated-catalog-core/src/test/java/org/eclipse/edc/catalog/transform/JsonObjectToDistributionTransformerTest.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.transform;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.catalog.test.TestInput.getExpanded;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_ACCESS_SERVICE_ATTRIBUTE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCAT_DISTRIBUTION_TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_FORMAT_ATTRIBUTE;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class JsonObjectToDistributionTransformerTest {
+
+    private final JsonBuilderFactory jsonFactory = Json.createBuilderFactory(Map.of());
+    private final TransformerContext context = mock(TransformerContext.class);
+
+    private JsonObjectToDistributionTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new JsonObjectToDistributionTransformer();
+    }
+
+    @Test
+    void transform_returnDistribution() {
+        var format = "format";
+        var dataServiceId = "dataServiceId";
+
+        var distribution = jsonFactory.createObjectBuilder()
+                .add(TYPE, DCAT_DISTRIBUTION_TYPE)
+                .add(DCT_FORMAT_ATTRIBUTE, format)
+                .add(DCAT_ACCESS_SERVICE_ATTRIBUTE, dataServiceId)
+                .build();
+
+        var result = transformer.transform(getExpanded(distribution), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getFormat()).isEqualTo(format);
+        assertThat(result.getDataService()).isNotNull()
+                .matches(ds -> ds.getId().equals(dataServiceId) && ds.getEndpointDescription() == null && ds.getEndpointUrl() == null);
+
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    void transform_invalidType_reportProblem() {
+        var distribution = jsonFactory.createObjectBuilder()
+                .add(TYPE, "not-a-distribution")
+                .build();
+
+        transformer.transform(getExpanded(distribution), context);
+
+        verify(context, times(1)).reportProblem(anyString());
+    }
+
+    @Test
+    void transform_requiredAttributesMissing_reportProblem() {
+        var distribution = jsonFactory.createObjectBuilder()
+                .add(TYPE, DCAT_DISTRIBUTION_TYPE)
+                .build();
+
+        var result = transformer.transform(getExpanded(distribution), context);
+
+        assertThat(result).isNull();
+        verify(context, times(1)).reportProblem(anyString());
+    }
+}

--- a/core/federated-catalog-core/src/testFixtures/java/org/eclipse/edc/catalog/test/TestInput.java
+++ b/core/federated-catalog-core/src/testFixtures/java/org/eclipse/edc/catalog/test/TestInput.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.test;
+
+import com.apicatalog.jsonld.document.JsonDocument;
+import jakarta.json.JsonObject;
+
+import static com.apicatalog.jsonld.JsonLd.expand;
+
+/**
+ * Functions for shaping test input.
+ */
+public class TestInput {
+
+    private TestInput() {
+    }
+
+    /**
+     * Expands test input as Json-ld is required to be in this form
+     */
+    public static JsonObject getExpanded(JsonObject message) {
+        try {
+            return expand(JsonDocument.of(message)).get().asJsonArray().getJsonObject(0);
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/core/federated-catalog-core/src/testFixtures/java/org/eclipse/edc/catalog/test/TestUtil.java
+++ b/core/federated-catalog-core/src/testFixtures/java/org/eclipse/edc/catalog/test/TestUtil.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - Initial implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.test;
+
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
+import org.eclipse.edc.crawler.spi.TargetNode;
+import org.eclipse.edc.participant.spi.ParticipantIdMapper;
+import org.eclipse.edc.policy.model.Policy;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class TestUtil {
+
+    public static final String TEST_PROTOCOL = "test-protocol";
+
+    public static Catalog createCatalog(String id) {
+        var dataService = DataService.Builder.newInstance()
+                .endpointUrl("https://test-dataservice.endpoint.url")
+                .endpointDescription("test endpoint description")
+                .build();
+        return buildCatalog(id)
+                .datasets(List.of(Dataset.Builder.newInstance()
+                        .id(id + "-dataset")
+                        .distributions(List.of(Distribution.Builder.newInstance()
+                                .dataService(dataService)
+                                .format("test-format").build()))
+                        .build()))
+                .dataServices(List.of(dataService))
+                .build();
+    }
+
+    public static Catalog.Builder buildCatalog(String id) {
+        return Catalog.Builder.newInstance()
+                .participantId("test-participant")
+                .id(id)
+                .properties(new HashMap<>());
+    }
+
+    @NotNull
+    public static TargetNode createNode() {
+        return new TargetNode("testnode" + UUID.randomUUID(), "did:web:" + UUID.randomUUID(), "http://test.com", List.of(TEST_PROTOCOL));
+    }
+
+    public static Catalog createCatalog(int howManyOffers) {
+        var datasets = IntStream.range(0, howManyOffers)
+                .mapToObj(i -> createDataset("dataset-" + i))
+                .collect(Collectors.toList());
+
+        var build = List.of(DataService.Builder.newInstance().build());
+        return Catalog.Builder.newInstance().participantId("test-participant").id("catalog").datasets(datasets).dataServices(build).build();
+    }
+
+    public static Dataset createDataset(String id) {
+        return Dataset.Builder.newInstance()
+                .offer("test-offer", Policy.Builder.newInstance().build())
+                .distribution(Distribution.Builder.newInstance().format("test-format").dataService(DataService.Builder.newInstance().build()).build())
+                .id(id)
+                .build();
+    }
+
+    public static class NoOpParticipantIdMapper implements ParticipantIdMapper {
+        @Override
+        public String toIri(String id) {
+            return id;
+        }
+
+        @Override
+        public String fromIri(String id) {
+            return id;
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,6 +43,7 @@ include(":core:common:cel-core")
 
 include(":core:common:lib:api-lib")
 include(":core:common:lib:boot-lib")
+include(":core:common:lib:catalog-util-lib")
 include(":core:common:lib:crypto-common-lib")
 include(":core:common:lib:http-lib")
 include(":core:common:lib:json-ld-lib")
@@ -59,6 +60,10 @@ include(":core:common:lib:transform-lib")
 include(":core:common:lib:util-lib")
 include(":core:common:lib:validator-lib")
 include(":core:common:lib:encryption-lib")
+
+include(":core:crawler-core")
+include(":core:federated-catalog-core")
+include(":core:federated-catalog-core-2025")
 
 include(":core:control-plane:control-plane-catalog")
 include(":core:control-plane:control-plane-contract")


### PR DESCRIPTION
## What this PR changes/adds

Move the federated catalog core to the Connector repo. This is the second step out of 5 steps to completely move all federated catalog components. This is related to this [decision record](https://github.com/eclipse-edc/eclipse-edc.github.io/tree/ef760eeabaf0b0baa2a74580b87c2071d4419217/developer/decision-records/2026-03-02-catalog-crawler).

- [ ]  Move the federated catalog SPIs
- [ ]  Move the core components
- [ ]  Move the extensions
- [ ]  move/modify the Boms
- [ ] move end to end tests

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5530

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
