### PR TITLE
refactor: move federated catalog extensions to Connector repo

### DIFF
--- a/core/federated-catalog-core/build.gradle.kts
+++ b/core/federated-catalog-core/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     api(project(":core:common:lib:query-lib"))
 
     implementation(project(":core:common:lib:util-lib"))
-    implementation(project(":data-protocols:dsp:dsp-core:dsp-http-api-base-configuration"))
+    implementation(project(":data-protocols:dsp:dsp-2025:dsp-http-api-configuration-2025"))
     implementation(project(":spi:common:json-ld-spi"))
     implementation(project(":core:common:lib:json-ld-lib"))
     implementation(project(":core:common:lib:store-lib"))

--- a/extensions/federated-catalog/api/federated-catalog-api/build.gradle.kts
+++ b/extensions/federated-catalog/api/federated-catalog-api/build.gradle.kts
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    id(libs.plugins.swagger.get().pluginId)
+}
+
+dependencies {
+    api(project(":spi:federated-catalog-spi"))
+    api(project(":spi:common:core-spi"))
+    api(project(":spi:control-plane:contract-spi"))
+    api(project(":data-protocols:dsp:dsp-2025:dsp-spi-2025"))
+
+    implementation(project(":spi:common:boot-spi"))
+    implementation(project(":core:common:lib:api-lib"))
+    implementation(project(":core:common:lib:catalog-util-lib"))
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
+    implementation(project(":spi:common:transform-spi"))
+    implementation(project(":spi:common:web-spi"))
+
+
+    runtimeOnly(project(":spi:common:json-ld-spi"))
+    runtimeOnly(project(":core:common:lib:json-ld-lib"))
+
+    // required for integration test
+    testImplementation(project(":data-protocols:dsp:dsp-http-spi"))
+    testImplementation(project(":core:common:lib:boot-lib"))
+    testImplementation(testFixtures(project(":core:federated-catalog-core")))
+    testImplementation(project(":core:common:junit"))
+    testImplementation(project(":core:common:lib:json-lib"))
+    testImplementation(project(":extensions:common:http"))
+    testImplementation(libs.restAssured)
+    testImplementation(project(":extensions:common:iam:iam-mock"))
+    testImplementation(project(":core:common:lib:json-ld-lib"))
+    testImplementation(project(":data-protocols:dsp:dsp-lib:dsp-catalog-lib:dsp-catalog-transform-lib"))
+    testImplementation(project(":data-protocols:dsp:dsp-2025:dsp-catalog-2025:dsp-catalog-transform-2025"))
+    testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
+    testImplementation(project(":core:common:lib:transform-lib"))
+    testImplementation(project(":core:common:lib:query-lib"))
+}
+
+edcBuild {
+    swagger {
+        apiGroup.set("catalog-api")
+    }
+}

--- a/extensions/federated-catalog/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApi.java
+++ b/extensions/federated-catalog/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApi.java
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.api.query;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.model.ApiCoreSchema;
+
+@OpenAPIDefinition(
+        info = @Info(description = "This represents the Federated Catalog API. It serves the cached Catalogs fetched from the data providers.",
+                title = "Federated Catalog API", version = "v1"))
+@Tag(name = "Federated Catalog")
+public interface FederatedCatalogApi {
+    @Operation(description = "Obtains all Catalog currently held by this cache instance",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ApiCoreSchema.QuerySpecSchema.class))),
+            parameters = @Parameter(name = "flatten", description = "Whether the resulting root catalog should be 'flattened' or contain a hierarchy of catalogs"),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "A list of Catalog is returned, potentially empty",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = CatalogSchema.class)))),
+                    @ApiResponse(responseCode = "500", description = "A Query could not be completed due to an internal error")
+            }
+
+    )
+    JsonArray getCachedCatalog(JsonObject querySpec, boolean flatten);
+
+    @Schema(name = "Catalog", description = "DCAT catalog", example = CatalogSchema.CATALOG_EXAMPLE)
+    record CatalogSchema(
+    ) {
+        public static final String CATALOG_EXAMPLE = """
+                {
+                    "@id": "7df65569-8c59-4013-b1c0-fa14f6641bf2",
+                    "@type": "dcat:Catalog",
+                    "dcat:dataset": {
+                        "@id": "bcca61be-e82e-4da6-bfec-9716a56cef35",
+                        "@type": "dcat:Dataset",
+                        "odrl:hasPolicy": {
+                            "@id": "OGU0ZTMzMGMtODQ2ZS00ZWMxLThmOGQtNWQxNWM0NmI2NmY4:YmNjYTYxYmUtZTgyZS00ZGE2LWJmZWMtOTcxNmE1NmNlZjM1:NDY2ZTZhMmEtNjQ1Yy00ZGQ0LWFlZDktMjdjNGJkZTU4MDNj",
+                            "@type": "odrl:Set",
+                            "odrl:permission": {
+                                "odrl:target": "bcca61be-e82e-4da6-bfec-9716a56cef35",
+                                "odrl:action": {
+                                    "odrl:type": "http://www.w3.org/ns/odrl/2/use"
+                                },
+                                "odrl:constraint": {
+                                    "odrl:and": [
+                                        {
+                                            "odrl:leftOperand": "https://w3id.org/edc/v0.0.1/ns/inForceDate",
+                                            "odrl:operator": {
+                                                "@id": "odrl:gteq"
+                                            },
+                                            "odrl:rightOperand": "2023-07-07T07:19:58.585601395Z"
+                                        },
+                                        {
+                                            "odrl:leftOperand": "https://w3id.org/edc/v0.0.1/ns/inForceDate",
+                                            "odrl:operator": {
+                                                "@id": "odrl:lteq"
+                                            },
+                                            "odrl:rightOperand": "2023-07-12T07:19:58.585601395Z"
+                                        }
+                                    ]
+                                }
+                            },
+                            "odrl:prohibition": [],
+                            "odrl:obligation": []
+                        },
+                        "dcat:distribution": [
+                            {
+                                "@type": "dcat:Distribution",
+                                "dct:format": {
+                                    "@id": "HttpData"
+                                },
+                                "dcat:accessService": "5e839777-d93e-4785-8972-1005f51cf367"
+                            }
+                        ],
+                        "description": "description",
+                        "id": "bcca61be-e82e-4da6-bfec-9716a56cef35"
+                    },
+                    "dcat:service": {
+                        "@id": "5e839777-d93e-4785-8972-1005f51cf367",
+                        "@type": "dcat:DataService",
+                        "dct:terms": "connector",
+                        "dcat:endpointURL": "http://localhost:16806/protocol"
+                    },
+                    "dspace:participantId": "urn:connector:provider",
+                    "@context": {
+                        "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+                        "dct": "http://purl.org/dc/terms/",
+                        "edc": "https://w3id.org/edc/v0.0.1/ns/",
+                        "dcat": "http://www.w3.org/ns/dcat#",
+                        "odrl": "http://www.w3.org/ns/odrl/2/",
+                        "dspace": "https://w3id.org/dspace/2025/1/"
+                    }
+                }
+                """;
+    }
+}
+

--- a/extensions/federated-catalog/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiController.java
+++ b/extensions/federated-catalog/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiController.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.api.query;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import org.eclipse.edc.catalog.spi.QueryService;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.federatedcatalog.util.FederatedCatalogUtil;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.AbstractResult;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
+
+import static jakarta.json.stream.JsonCollectors.toJsonArray;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v1alpha/catalog/query")
+public class FederatedCatalogApiController implements FederatedCatalogApi {
+
+    private final QueryService queryService;
+    private final TypeTransformerRegistry transformerRegistry;
+
+    public FederatedCatalogApiController(QueryService queryService, TypeTransformerRegistry transformerRegistry) {
+        this.queryService = queryService;
+        this.transformerRegistry = transformerRegistry;
+    }
+
+    @Override
+    @POST
+    public JsonArray getCachedCatalog(JsonObject querySpecJson, @DefaultValue("false") @QueryParam("flatten") boolean flatten) {
+        var querySpec = querySpecJson == null
+                ? QuerySpec.none()
+                : transformerRegistry.transform(querySpecJson, QuerySpec.class)
+                        .orElseThrow(InvalidRequestException::new);
+
+        return queryService.getCatalog(querySpec)
+                .orElseThrow(exceptionMapper(Catalog.class))
+                .stream()
+                .map(catalog -> flatten ? FederatedCatalogUtil.flatten(catalog) : catalog)
+                .map(catalog -> transformerRegistry.transform(catalog, JsonObject.class))
+                .filter(Result::succeeded)
+                .map(AbstractResult::getContent)
+                .collect(toJsonArray());
+    }
+}

--- a/extensions/federated-catalog/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiExtension.java
+++ b/extensions/federated-catalog/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiExtension.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.api.query;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import org.eclipse.edc.catalog.spi.QueryService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.apiversion.ApiVersionService;
+import org.eclipse.edc.spi.system.apiversion.VersionRecord;
+import org.eclipse.edc.spi.system.health.HealthCheckResult;
+import org.eclipse.edc.spi.system.health.HealthCheckService;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
+import org.eclipse.edc.web.jersey.providers.jsonld.ObjectMapperProvider;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.PortMapping;
+import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import static org.eclipse.edc.catalog.spi.FccApiContexts.CATALOG_QUERY;
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_CONTEXT_2025_1;
+import static org.eclipse.edc.jsonld.spi.Namespaces.EDC_DSPACE_CONTEXT;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+@Extension(value = FederatedCatalogApiExtension.NAME)
+public class FederatedCatalogApiExtension implements ServiceExtension {
+
+    public static final String NAME = "Cache Query API Extension";
+    static final String CATALOG_QUERY_SCOPE = "CATALOG_QUERY_API";
+    private static final String API_VERSION_JSON_FILE = "catalog-version.json";
+
+    @Configuration
+    private CatalogApiConfiguration apiConfiguration;
+
+    @Inject
+    private WebService webService;
+    @Inject
+    private QueryService queryService;
+    @Inject
+    private JsonLd jsonLd;
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private TypeTransformerRegistry transformerRegistry;
+    @Inject
+    private ApiVersionService apiVersionService;
+    @Inject
+    private PortMappingRegistry portMappingRegistry;
+    @Inject(required = false)
+    private HealthCheckService healthCheckService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        portMappingRegistry.register(new PortMapping(CATALOG_QUERY, apiConfiguration.port(), apiConfiguration.path()));
+
+        jsonLd.registerContext(DSPACE_CONTEXT_2025_1, CATALOG_QUERY_SCOPE);
+        jsonLd.registerContext(EDC_DSPACE_CONTEXT, CATALOG_QUERY_SCOPE);
+
+        webService.registerResource(CATALOG_QUERY, new FederatedCatalogApiController(queryService, transformerRegistry));
+        webService.registerResource(CATALOG_QUERY, new ObjectMapperProvider(typeManager, JSON_LD));
+        webService.registerResource(CATALOG_QUERY, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, CATALOG_QUERY_SCOPE));
+
+        if (healthCheckService != null) {
+            var successResult = HealthCheckResult.Builder.newInstance().component("FCC Query API").build();
+            healthCheckService.addReadinessProvider(() -> successResult);
+            healthCheckService.addLivenessProvider(() -> successResult);
+        }
+
+        registerVersionInfo(getClass().getClassLoader());
+    }
+
+    private void registerVersionInfo(ClassLoader resourceClassLoader) {
+        try (var versionContent = resourceClassLoader.getResourceAsStream(API_VERSION_JSON_FILE)) {
+            if (versionContent == null) {
+                throw new EdcException("Version file not found or not readable.");
+            }
+            Stream.of(typeManager.getMapper()
+                            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+                            .readValue(versionContent, VersionRecord[].class))
+                    .forEach(versionRecord -> apiVersionService.addRecord(CATALOG_QUERY, versionRecord));
+        } catch (IOException e) {
+            throw new EdcException(e);
+        }
+    }
+
+    @Settings
+    record CatalogApiConfiguration(
+            @Setting(key = "web.http." + CATALOG_QUERY + ".port", description = "Port for " + CATALOG_QUERY + " api context", defaultValue = 17171 + "")
+            int port,
+            @Setting(key = "web.http." + CATALOG_QUERY + ".path", description = "Path for " + CATALOG_QUERY + " api context", defaultValue = "/api/catalog")
+            String path
+    ) {
+    }
+}

--- a/extensions/federated-catalog/api/federated-catalog-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/federated-catalog/api/federated-catalog-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2022 Microsoft Corporation
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Microsoft Corporation - initial API and implementation
+#
+#
+
+org.eclipse.edc.catalog.api.query.FederatedCatalogApiExtension

--- a/extensions/federated-catalog/api/federated-catalog-api/src/main/resources/catalog-version.json
+++ b/extensions/federated-catalog/api/federated-catalog-api/src/main/resources/catalog-version.json
@@ -1,0 +1,7 @@
+[
+  {
+    "version": "1.0.0-alpha",
+    "urlPath": "/v1alpha",
+    "lastUpdated": "2026-02-06T11:00:00Z"
+  }
+]

--- a/extensions/federated-catalog/api/federated-catalog-api/src/test/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiControllerTest.java
+++ b/extensions/federated-catalog/api/federated-catalog-api/src/test/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiControllerTest.java
@@ -1,0 +1,170 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.api.query;
+
+import io.restassured.specification.RequestSpecification;
+import jakarta.json.Json;
+import org.eclipse.edc.catalog.spi.QueryService;
+import org.eclipse.edc.catalog.test.TestUtil;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.json.JacksonTypeManager;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDataServiceTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDatasetTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDistributionTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.v2025.from.JsonObjectFromCatalogV2025Transformer;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.transform.TypeTransformerRegistryImpl;
+import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToQuerySpecTransformer;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static java.util.Collections.emptyList;
+import static java.util.stream.IntStream.range;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.catalog.test.TestUtil.buildCatalog;
+import static org.eclipse.edc.catalog.test.TestUtil.createCatalog;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ApiTest
+class FederatedCatalogApiControllerTest extends RestControllerTestBase {
+
+    private static final String PATH = "/v1alpha/catalog/query";
+    private final QueryService queryService = mock();
+
+    @Test
+    void queryApi_whenEmptyResult() {
+        when(queryService.getCatalog(any())).thenReturn(ServiceResult.success(emptyList()));
+
+        baseRequest()
+                .contentType(JSON)
+                .body("{}")
+                .post(PATH)
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(0));
+    }
+
+    @Test
+    void queryApi_whenResultsReturned() {
+        var catalogs = range(0, 3).mapToObj(i -> createCatalog("catalog-" + i)).toList();
+        when(queryService.getCatalog(any())).thenReturn(ServiceResult.success(catalogs));
+
+        baseRequest()
+                .contentType(JSON)
+                .body("{}")
+                .post(PATH)
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(3));
+    }
+
+    @Test
+    void queryApi_whenQueryUnsuccessful() {
+        when(queryService.getCatalog(any())).thenThrow(new RuntimeException("test exception"));
+
+        baseRequest()
+                .contentType(JSON)
+                .body("{}")
+                .post(PATH)
+                .then()
+                .statusCode(500);
+    }
+
+    @Test
+    void queryApi_whenFlattened() {
+        var catalogs = range(0, 2).mapToObj(i ->
+                buildCatalog("catalog-" + i)
+                        .dataset(createCatalog("sub1-" + i))
+                        .dataset(buildCatalog("sub2-" + i)
+                                .dataset(createCatalog("subsub1-" + i))
+                                .dataset(Dataset.Builder.newInstance().id("sub2-normal-asset-" + i).build())
+                                .build())
+                        .build()).toList();
+        when(queryService.getCatalog(any())).thenReturn(ServiceResult.success(catalogs));
+
+        var response = baseRequest()
+                .contentType(JSON)
+                .body("{}")
+                .post(PATH + "?flatten=true")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(2))
+                .body("[0].'http://www.w3.org/ns/dcat#dataset'", hasSize(3))
+                .body("[1].'http://www.w3.org/ns/dcat#dataset'", hasSize(3));
+
+        var jsonPath = response.extract().body().jsonPath();
+        List<String> types1 = jsonPath.get("[0].'http://www.w3.org/ns/dcat#dataset'.'@type'");
+        assertThat(types1).containsOnly("http://www.w3.org/ns/dcat#Dataset");
+
+        List<String> types2 = jsonPath.get("[1].'http://www.w3.org/ns/dcat#dataset'.'@type'");
+        assertThat(types2).containsOnly("http://www.w3.org/ns/dcat#Dataset");
+    }
+
+    @Test
+    void queryApi_shouldUseEmptyQuerySpec_whenRequestBodyIsNull() {
+        when(queryService.getCatalog(any())).thenReturn(ServiceResult.success(emptyList()));
+
+        baseRequest()
+                .contentType(JSON)
+                .post(PATH)
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(0));
+
+        verify(queryService).getCatalog(QuerySpec.none());
+    }
+
+    @Override
+    protected Object controller() {
+        var typeTransformerRegistry = new TypeTransformerRegistryImpl();
+        var factory = Json.createBuilderFactory(Map.of());
+        var mapper = new JacksonTypeManager();
+        var participantIdMapper = new TestUtil.NoOpParticipantIdMapper();
+        typeTransformerRegistry.register(new JsonObjectFromCatalogV2025Transformer(factory, new JacksonTypeManager(), JSON_LD, participantIdMapper, DSP_NAMESPACE_V_2025_1));
+        typeTransformerRegistry.register(new JsonObjectFromDatasetTransformer(factory, mapper, JSON_LD));
+        typeTransformerRegistry.register(new JsonObjectFromDistributionTransformer(factory));
+        typeTransformerRegistry.register(new JsonObjectFromDataServiceTransformer(factory));
+        typeTransformerRegistry.register(new JsonObjectToQuerySpecTransformer());
+        return new FederatedCatalogApiController(queryService, typeTransformerRegistry);
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port)
+                .when();
+    }
+}

--- a/extensions/federated-catalog/api/federated-catalog-api/src/test/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiExtensionTest.java
+++ b/extensions/federated-catalog/api/federated-catalog-api/src/test/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiExtensionTest.java
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.api.query;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.catalog.spi.QueryService;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.apiversion.ApiVersionService;
+import org.eclipse.edc.spi.system.apiversion.VersionRecord;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
+import org.eclipse.edc.web.jersey.providers.jsonld.ObjectMapperProvider;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.eclipse.edc.catalog.api.query.FederatedCatalogApiExtension.CATALOG_QUERY_SCOPE;
+import static org.eclipse.edc.catalog.spi.FccApiContexts.CATALOG_QUERY;
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_CONTEXT_2025_1;
+import static org.eclipse.edc.jsonld.spi.Namespaces.EDC_DSPACE_CONTEXT;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class FederatedCatalogApiExtensionTest {
+
+    private final WebService webService = mock();
+    private final TypeTransformerRegistry transformerRegistry = mock();
+    private final JsonLd jsonLd = mock();
+    private final TypeManager typeManager = mock();
+    private final QueryService queryService = mock();
+    private final ApiVersionService apiVersionService = mock();
+    private final PortMappingRegistry portMappingRegistry = mock();
+    private final ObjectMapper mapper = JacksonJsonLd.createObjectMapper();
+
+    @BeforeEach
+    void setUp(ServiceExtensionContext context) {
+        context.registerService(WebService.class, webService);
+        context.registerService(TypeTransformerRegistry.class, transformerRegistry);
+        context.registerService(JsonLd.class, jsonLd);
+        context.registerService(TypeManager.class, typeManager);
+        context.registerService(QueryService.class, queryService);
+        context.registerService(ApiVersionService.class, apiVersionService);
+        context.registerService(PortMappingRegistry.class, portMappingRegistry);
+        when(typeManager.getMapper()).thenReturn(mapper);
+    }
+
+    @Test
+    void initialize_shouldRegisterStandaloneCatalogApiResources(FederatedCatalogApiExtension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(portMappingRegistry).register(argThat(mapping ->
+                mapping.name().equals(CATALOG_QUERY) && mapping.port() == 17171 && mapping.path().equals("/api/catalog")));
+        verify(webService).registerResource(eq(CATALOG_QUERY), isA(FederatedCatalogApiController.class));
+        verify(webService).registerResource(eq(CATALOG_QUERY), isA(ObjectMapperProvider.class));
+        verify(webService).registerResource(eq(CATALOG_QUERY), isA(JerseyJsonLdInterceptor.class));
+        verify(apiVersionService).addRecord(eq(CATALOG_QUERY), argThat(this::isCatalogApiVersion));
+        verifyNoInteractions(transformerRegistry);
+    }
+
+    @Test
+    void initialize_shouldRegisterNamespaces(FederatedCatalogApiExtension extension, ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(jsonLd).registerContext(DSPACE_CONTEXT_2025_1, CATALOG_QUERY_SCOPE);
+        verify(jsonLd).registerContext(EDC_DSPACE_CONTEXT, CATALOG_QUERY_SCOPE);
+    }
+
+    private boolean isCatalogApiVersion(VersionRecord versionRecord) {
+        return versionRecord != null &&
+                "1.0.0-alpha".equals(versionRecord.version()) &&
+                "/v1alpha".equals(versionRecord.urlPath()) &&
+                versionRecord.maturity() == null;
+    }
+}

--- a/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/build.gradle.kts
+++ b/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/build.gradle.kts
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:federated-catalog-spi"))
+    implementation(project(":core:common:lib:sql-lib"))
+    implementation(project(":core:common:lib:util-lib"))
+    implementation(project(":extensions:common:sql:sql-bootstrapper"))
+    implementation(project(":spi:common:transaction-datasource-spi"))
+
+    testImplementation(project(":core:common:junit"))
+    testImplementation(testFixtures(project(":extensions:common:sql:sql-test-fixtures")))
+    testImplementation(testFixtures(project(":spi:federated-catalog-spi")))
+}

--- a/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/BaseSqlDialectStatements.java
+++ b/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/BaseSqlDialectStatements.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache.sql;
+
+import org.eclipse.edc.catalog.cache.sql.schema.postgres.FederatedCatalogMapping;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.translation.SqlOperatorTranslator;
+import org.eclipse.edc.sql.translation.SqlQueryStatement;
+
+import static java.lang.String.format;
+
+public abstract class BaseSqlDialectStatements implements FederatedCatalogCacheStatements {
+
+    protected final SqlOperatorTranslator operatorTranslator;
+
+    protected BaseSqlDialectStatements(SqlOperatorTranslator operatorTranslator) {
+        this.operatorTranslator = operatorTranslator;
+    }
+
+    @Override
+    public String getFindByIdTemplate() {
+        return format("SELECT * FROM %s WHERE %s = ?", getFederatedCatalogTable(), getIdColumn());
+    }
+
+    @Override
+    public String getUpdateAsMarkedTemplate() {
+        return format("UPDATE %s SET %s = ?", getFederatedCatalogTable(), getMarkedColumn());
+    }
+
+    @Override
+    public String getDeleteByMarkedTemplate() {
+        return executeStatement()
+                .delete(getFederatedCatalogTable(), getMarkedColumn());
+    }
+
+    @Override
+    public String getInsertTemplate() {
+        return executeStatement()
+                .column(getIdColumn())
+                .jsonColumn(getCatalogColumn())
+                .column(getMarkedColumn())
+                .insertInto(getFederatedCatalogTable());
+    }
+
+    @Override
+    public String getUpdateTemplate() {
+        return executeStatement()
+                .jsonColumn(getCatalogColumn())
+                .column(getMarkedColumn())
+                .update(getFederatedCatalogTable(), getIdColumn());
+    }
+
+    @Override
+    public SqlQueryStatement createQuery(QuerySpec querySpec) {
+        var select = getSelectStatement();
+        return new SqlQueryStatement(select, querySpec, new FederatedCatalogMapping(this), operatorTranslator);
+    }
+
+    @Override
+    public String getSelectStatement() {
+        return format("SELECT * FROM %s", getFederatedCatalogTable());
+    }
+}

--- a/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/FederatedCatalogCacheStatements.java
+++ b/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/FederatedCatalogCacheStatements.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache.sql;
+
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.statement.SqlStatements;
+import org.eclipse.edc.sql.translation.SqlQueryStatement;
+
+public interface FederatedCatalogCacheStatements extends SqlStatements {
+
+    default String getFederatedCatalogTable() {
+        return "edc_federated_catalog";
+    }
+
+    default String getIdColumn() {
+        return "id";
+    }
+
+    default String getCatalogColumn() {
+        return "catalog";
+    }
+
+    default String getMarkedColumn() {
+        return "marked";
+    }
+
+    String getFindByIdTemplate();
+
+    String getUpdateAsMarkedTemplate();
+
+    String getDeleteByMarkedTemplate();
+
+
+    String getInsertTemplate();
+
+    String getUpdateTemplate();
+
+    SqlQueryStatement createQuery(QuerySpec query);
+
+    String getSelectStatement();
+}

--- a/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/SqlFederatedCatalogCache.java
+++ b/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/SqlFederatedCatalogCache.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache.sql;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.catalog.spi.CatalogConstants;
+import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.spi.persistence.EdcPersistenceException;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.sql.store.AbstractSqlStore;
+import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+
+import static java.util.Optional.ofNullable;
+
+public class SqlFederatedCatalogCache extends AbstractSqlStore implements FederatedCatalogCache {
+
+    private final FederatedCatalogCacheStatements statements;
+
+    public SqlFederatedCatalogCache(DataSourceRegistry dataSourceRegistry, String dataSourceName, TransactionContext transactionContext,
+                                    ObjectMapper objectMapper, QueryExecutor queryExecutor, FederatedCatalogCacheStatements statements) {
+        super(dataSourceRegistry, dataSourceName, transactionContext, objectMapper, queryExecutor);
+        this.statements = statements;
+    }
+
+    @Override
+    public void save(Catalog catalog) {
+
+        transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                var id = ofNullable(catalog.getProperties().get(CatalogConstants.PROPERTY_ORIGINATOR))
+                        .map(Object::toString)
+                        .orElse(catalog.getId());
+
+                if (findByIdInternal(connection, id) == null) {
+                    insertInternal(connection, id, catalog);
+                } else {
+                    updateInternal(connection, id, catalog);
+                }
+
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    @Override
+    public Collection<Catalog> query(QuerySpec querySpec) {
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                var query = statements.createQuery(querySpec);
+                return queryExecutor.query(connection, true, this::mapResultSet, query.getQueryAsString(), query.getParameters()).toList();
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    @Override
+    public void deleteExpired() {
+        transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                var stmt = statements.getDeleteByMarkedTemplate();
+                queryExecutor.execute(connection, stmt, true);
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    @Override
+    public void expireAll() {
+        transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                var stmt = statements.getUpdateAsMarkedTemplate();
+                queryExecutor.execute(connection, stmt, true);
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+
+    }
+
+    private Catalog findByIdInternal(Connection connection, String id) {
+        var stmt = statements.getFindByIdTemplate();
+        return queryExecutor.single(connection, false, this::mapResultSet, stmt, id);
+    }
+
+    private void insertInternal(Connection connection, String id, Catalog catalog) {
+        var stmt = statements.getInsertTemplate();
+        queryExecutor.execute(connection, stmt, id, toJson(catalog), false);
+    }
+
+    private void updateInternal(Connection connection, String id, Catalog catalog) {
+        var stmt = statements.getUpdateTemplate();
+        queryExecutor.execute(connection, stmt, toJson(catalog), false, id);
+    }
+
+    private Catalog mapResultSet(ResultSet resultSet) throws Exception {
+        var json = resultSet.getString(statements.getCatalogColumn());
+        return fromJson(json, Catalog.class);
+    }
+}

--- a/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/SqlFederatedCatalogCacheExtension.java
+++ b/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/SqlFederatedCatalogCacheExtension.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache.sql;
+
+import org.eclipse.edc.catalog.cache.sql.schema.postgres.PostgresDialectStatements;
+import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provides;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
+import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+
+@Provides(FederatedCatalogCache.class)
+@Extension(value = "SQL federated catalog cache")
+public class SqlFederatedCatalogCacheExtension implements ServiceExtension {
+
+    @Setting(description = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE, key = "edc.sql.store.federatedcatalog.datasource")
+    private String dataSourceName;
+
+    @Inject
+    private DataSourceRegistry dataSourceRegistry;
+    @Inject
+    private TransactionContext trxContext;
+    @Inject(required = false)
+    private FederatedCatalogCacheStatements statements;
+    @Inject
+    private TypeManager typeManager;
+
+    @Inject
+    private QueryExecutor queryExecutor;
+
+    @Inject
+    private SqlSchemaBootstrapper sqlSchemaBootstrapper;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        typeManager.registerTypes(Catalog.class, Dataset.class);
+        var store = new SqlFederatedCatalogCache(dataSourceRegistry, dataSourceName, trxContext,
+                typeManager.getMapper(), queryExecutor, getStatementImpl());
+        context.registerService(FederatedCatalogCache.class, store);
+        sqlSchemaBootstrapper.addStatementFromResource(dataSourceName, "cache-schema.sql");
+    }
+
+    /**
+     * returns an externally-provided sql statement dialect, or postgres as a default
+     */
+    private FederatedCatalogCacheStatements getStatementImpl() {
+        return statements != null ? statements : new PostgresDialectStatements();
+    }
+
+}

--- a/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/schema/postgres/FederatedCatalogMapping.java
+++ b/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/schema/postgres/FederatedCatalogMapping.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache.sql.schema.postgres;
+
+import org.eclipse.edc.catalog.cache.sql.FederatedCatalogCacheStatements;
+import org.eclipse.edc.sql.translation.JsonFieldTranslator;
+import org.eclipse.edc.sql.translation.TranslationMapping;
+
+public class FederatedCatalogMapping extends TranslationMapping {
+
+    public FederatedCatalogMapping(FederatedCatalogCacheStatements statements) {
+        add("id", statements.getIdColumn());
+        add("participantId", new JsonFieldTranslator(statements.getCatalogColumn()));
+        add("properties", new PrefixedJsonFieldTranslator(statements.getCatalogColumn(), "properties"));
+        add("datasets", new JsonFieldTranslator("datasets"));
+        add("dataServices", new JsonFieldTranslator("dataServices"));
+    }
+}

--- a/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/schema/postgres/PostgresDialectStatements.java
+++ b/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/schema/postgres/PostgresDialectStatements.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache.sql.schema.postgres;
+
+import org.eclipse.edc.catalog.cache.sql.BaseSqlDialectStatements;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.dialect.PostgresDialect;
+import org.eclipse.edc.sql.translation.PostgresqlOperatorTranslator;
+import org.eclipse.edc.sql.translation.SqlQueryStatement;
+
+import static java.lang.String.format;
+import static org.eclipse.edc.sql.dialect.PostgresDialect.getSelectFromJsonArrayTemplate;
+
+public class PostgresDialectStatements extends BaseSqlDialectStatements {
+
+    public static final String DATASETS_ALIAS = "datasets";
+    public static final String DATA_SERVICES_ALIAS = "dataServices";
+
+    public PostgresDialectStatements() {
+        super(new PostgresqlOperatorTranslator());
+    }
+
+    @Override
+    public String getFormatAsJsonOperator() {
+        return PostgresDialect.getJsonCastOperator();
+    }
+
+
+    @Override
+    public SqlQueryStatement createQuery(QuerySpec querySpec) {
+        if (querySpec.containsAnyLeftOperand("datasets")) {
+            var select = getSelectFromJsonArrayTemplate(getSelectStatement(), format("%s -> '%s'", getCatalogColumn(), "datasets"), DATASETS_ALIAS);
+            return new SqlQueryStatement(select, querySpec, new FederatedCatalogMapping(this), operatorTranslator);
+        } else if (querySpec.containsAnyLeftOperand("dataServices")) {
+            var select = getSelectFromJsonArrayTemplate(getSelectStatement(), format("%s -> '%s'", getCatalogColumn(), "dataServices"), DATA_SERVICES_ALIAS);
+            return new SqlQueryStatement(select, querySpec, new FederatedCatalogMapping(this), operatorTranslator);
+        } else {
+            return super.createQuery(querySpec);
+        }
+    }
+}

--- a/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/schema/postgres/PrefixedJsonFieldTranslator.java
+++ b/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/java/org/eclipse/edc/catalog/cache/sql/schema/postgres/PrefixedJsonFieldTranslator.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache.sql.schema.postgres;
+
+import org.eclipse.edc.sql.translation.JsonFieldTranslator;
+import org.eclipse.edc.util.reflection.PathItem;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * An extension of {@link JsonFieldTranslator} where the list of path is prefixed with
+ * the provided prefix value. This is useful for mapping field that are stored in a single json column
+ * without exposing the column/path name directly. For example, we store the catalog DTO as JSON inside the `catalog` column.
+ * and we want to expose the catalog fields directly without using the prefix `catalog`. For query like
+ * properties.name = 'name' where the `properties` field is stored inside the json column `catalog` and thus
+ * the path `catalog.properties` the final JSON filter should be `catalog -> properties ->> name. With only {@link JsonFieldTranslator}
+ * we would get `catalog ->> name`.
+ */
+public class PrefixedJsonFieldTranslator extends JsonFieldTranslator {
+
+    private final String prefix;
+
+    public PrefixedJsonFieldTranslator(String columnName, String prefix) {
+        super(columnName);
+        this.prefix = prefix;
+    }
+
+    @Override
+    public String getLeftOperand(List<PathItem> path, Class<?> type) {
+        return super.getLeftOperand(Stream.concat(PathItem.parse(prefix).stream(), path.stream()).toList(), type);
+    }
+}

--- a/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+#
+#
+
+org.eclipse.edc.catalog.cache.sql.SqlFederatedCatalogCacheExtension

--- a/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/resources/cache-schema.sql
+++ b/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/main/resources/cache-schema.sql
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+-- only intended for and tested with Postgres!
+CREATE TABLE IF NOT EXISTS edc_federated_catalog
+(
+    id                    VARCHAR PRIMARY KEY NOT NULL,
+    catalog               JSON,
+    marked                BOOLEAN DEFAULT FALSE
+);

--- a/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/test/java/org/eclipse/edc/catalog/cache/sql/SqlFederatedCatalogCacheExtensionTest.java
+++ b/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/test/java/org/eclipse/edc/catalog/cache/sql/SqlFederatedCatalogCacheExtensionTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache.sql;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+public class SqlFederatedCatalogCacheExtensionTest {
+
+    private final TypeManager typeManager = mock();
+
+    @BeforeEach
+    void setUp(ServiceExtensionContext context) {
+        context.registerService(TypeManager.class, typeManager);
+        when(typeManager.getMapper()).thenReturn(new ObjectMapper());
+    }
+
+    @Test
+    void shouldInitializeTheStore(SqlFederatedCatalogCacheExtension extension, ServiceExtensionContext context) {
+        var config = mock(Config.class);
+        when(context.getConfig()).thenReturn(config);
+        when(config.getString(any(), any())).thenReturn("test");
+
+        extension.initialize(context);
+
+        var service = context.getService(FederatedCatalogCache.class);
+        assertThat(service).isInstanceOf(SqlFederatedCatalogCache.class);
+
+        verify(typeManager).registerTypes(Catalog.class, Dataset.class);
+    }
+}

--- a/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/test/java/org/eclipse/edc/catalog/cache/sql/SqlFederatedCatalogCacheTest.java
+++ b/extensions/federated-catalog/store/sql/federated-catalog-cache-sql/src/test/java/org/eclipse/edc/catalog/cache/sql/SqlFederatedCatalogCacheTest.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.cache.sql;
+
+import org.eclipse.edc.catalog.cache.sql.schema.postgres.PostgresDialectStatements;
+import org.eclipse.edc.catalog.spi.FederatedCatalogCache;
+import org.eclipse.edc.catalog.spi.testfixtures.FederatedCatalogCacheTestBase;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.json.JacksonTypeManager;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+
+@PostgresqlIntegrationTest
+@ExtendWith(PostgresqlStoreSetupExtension.class)
+public class SqlFederatedCatalogCacheTest extends FederatedCatalogCacheTestBase {
+
+    private final FederatedCatalogCacheStatements statements = new PostgresDialectStatements();
+
+    private FederatedCatalogCache store;
+
+    @BeforeEach
+    void setup(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) throws IOException {
+        var typeManager = new JacksonTypeManager();
+        typeManager.registerTypes(Catalog.class, Dataset.class);
+        store = new SqlFederatedCatalogCache(extension.getDataSourceRegistry(), extension.getDatasourceName(),
+                extension.getTransactionContext(), typeManager.getMapper(), queryExecutor, statements);
+
+        var schema = TestUtils.getResourceFileContentAsString("cache-schema.sql");
+        extension.runQuery(schema);
+    }
+
+    @AfterEach
+    void tearDown(PostgresqlStoreSetupExtension extension) {
+        extension.runQuery("DROP TABLE " + statements.getFederatedCatalogTable());
+    }
+
+    @Override
+    protected FederatedCatalogCache getStore() {
+        return store;
+    }
+}

--- a/extensions/federated-catalog/store/sql/target-node-directory-sql/build.gradle.kts
+++ b/extensions/federated-catalog/store/sql/target-node-directory-sql/build.gradle.kts
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2024 Amadeus IT Group
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus IT Group - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:crawler-spi"))
+    implementation(project(":core:common:lib:sql-lib"))
+    implementation(project(":core:common:lib:util-lib"))
+    implementation(project(":extensions:common:sql:sql-bootstrapper"))
+    implementation(project(":spi:common:transaction-datasource-spi"))
+
+    testImplementation(project(":core:common:junit"))
+    testImplementation(testFixtures(project(":extensions:common:sql:sql-test-fixtures")))
+    testImplementation(testFixtures(project(":spi:crawler-spi")))
+}

--- a/extensions/federated-catalog/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/BaseSqlDialectStatements.java
+++ b/extensions/federated-catalog/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/BaseSqlDialectStatements.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2024 Amadeus IT Group
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus IT Group - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.directory.sql;
+
+import org.eclipse.edc.catalog.directory.sql.schema.postgres.TargetNodeMapping;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.translation.PostgresqlOperatorTranslator;
+import org.eclipse.edc.sql.translation.SqlQueryStatement;
+
+import static java.lang.String.format;
+
+public abstract class BaseSqlDialectStatements implements TargetNodeStatements {
+
+    @Override
+    public String getFindByIdTemplate() {
+        return format("SELECT * FROM %s WHERE %s = ?", getTargetNodeDirectoryTable(), getIdColumn());
+    }
+
+    @Override
+    public String getUpdateTemplate() {
+        return executeStatement()
+                .column(getNameColumn())
+                .column(getTargetUrlColumn())
+                .jsonColumn(getSupportedProtocolsColumn())
+                .update(getTargetNodeDirectoryTable(), getIdColumn());
+    }
+
+    @Override
+    public String getInsertTemplate() {
+        return executeStatement()
+                .column(getIdColumn())
+                .column(getNameColumn())
+                .column(getTargetUrlColumn())
+                .jsonColumn(getSupportedProtocolsColumn())
+                .insertInto(getTargetNodeDirectoryTable());
+    }
+
+    @Override
+    public String getDeleteTemplate() {
+        return executeStatement()
+                .delete(getTargetNodeDirectoryTable(), getIdColumn());
+    }
+
+    @Override
+    public SqlQueryStatement createQuery(QuerySpec querySpec) {
+        var select = getSelectStatement();
+        return new SqlQueryStatement(select, querySpec, new TargetNodeMapping(this), new PostgresqlOperatorTranslator());
+    }
+
+    @Override
+    public String getSelectStatement() {
+        return format("SELECT * FROM %s", getTargetNodeDirectoryTable());
+    }
+}

--- a/extensions/federated-catalog/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/SqlTargetNodeDirectory.java
+++ b/extensions/federated-catalog/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/SqlTargetNodeDirectory.java
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (c) 2024 Amadeus IT Group
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus IT Group - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.directory.sql;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.crawler.spi.TargetNode;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
+import org.eclipse.edc.spi.persistence.EdcPersistenceException;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.sql.store.AbstractSqlStore;
+import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+public class SqlTargetNodeDirectory extends AbstractSqlStore implements TargetNodeDirectory {
+
+    private final TargetNodeStatements statements;
+
+    public SqlTargetNodeDirectory(DataSourceRegistry dataSourceRegistry, String dataSourceName, TransactionContext transactionContext,
+                                  ObjectMapper objectMapper, QueryExecutor queryExecutor, TargetNodeStatements statements) {
+        super(dataSourceRegistry, dataSourceName, transactionContext, objectMapper, queryExecutor);
+        this.statements = statements;
+    }
+
+    @Override
+    public List<TargetNode> getAll() {
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                var query = statements.createQuery(QuerySpec.max());
+                return queryExecutor.query(connection, true, this::mapResultSet, query.getQueryAsString(), query.getParameters()).toList();
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    @Override
+    public void insert(TargetNode node) {
+        transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                var id = node.id();
+
+                if (findByIdInternal(connection, id) == null) {
+                    insertInternal(connection, id, node);
+                } else {
+                    updateInternal(connection, id, node);
+                }
+
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    @Override
+    public TargetNode remove(String id) {
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                var existing = findByIdInternal(connection, id);
+                if (existing == null) {
+                    return null;
+                }
+
+                var stmt = statements.getDeleteTemplate();
+                queryExecutor.execute(connection, stmt, id);
+                return existing;
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    private TargetNode findByIdInternal(Connection connection, String id) {
+        var stmt = statements.getFindByIdTemplate();
+        return queryExecutor.single(connection, false, this::mapResultSet, stmt, id);
+    }
+
+    private void insertInternal(Connection connection, String id, TargetNode targetNode) {
+        var stmt = statements.getInsertTemplate();
+        queryExecutor.execute(connection,
+                stmt,
+                id,
+                targetNode.name(),
+                targetNode.targetUrl(),
+                toJson(targetNode.supportedProtocols())
+        );
+    }
+
+    private void updateInternal(Connection connection, String id, TargetNode targetNode) {
+        var stmt = statements.getUpdateTemplate();
+        queryExecutor.execute(connection,
+                stmt,
+                targetNode.name(),
+                targetNode.targetUrl(),
+                toJson(targetNode.supportedProtocols()),
+                id
+        );
+    }
+
+    private TargetNode mapResultSet(ResultSet resultSet) throws Exception {
+        return new TargetNode(
+                resultSet.getString(statements.getNameColumn()),
+                resultSet.getString(statements.getIdColumn()),
+                resultSet.getString(statements.getTargetUrlColumn()),
+                fromJson(resultSet.getString(statements.getSupportedProtocolsColumn()), new TypeReference<>() {
+                })
+        );
+    }
+
+}

--- a/extensions/federated-catalog/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/SqlTargetNodeDirectoryExtension.java
+++ b/extensions/federated-catalog/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/SqlTargetNodeDirectoryExtension.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2024 Amadeus IT Group
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus IT Group - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.directory.sql;
+
+import org.eclipse.edc.catalog.directory.sql.schema.postgres.PostgresDialectStatements;
+import org.eclipse.edc.crawler.spi.TargetNode;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provides;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.sql.bootstrapper.SqlSchemaBootstrapper;
+import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+
+@Provides(TargetNodeDirectory.class)
+@Extension(value = "SQL target node directory")
+public class SqlTargetNodeDirectoryExtension implements ServiceExtension {
+
+    @Setting(description = "The datasource to be used", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE, key = "edc.sql.store.targetnodedirectory.datasource")
+    private String dataSourceName;
+
+    @Inject
+    private DataSourceRegistry dataSourceRegistry;
+    @Inject
+    private TransactionContext trxContext;
+    @Inject(required = false)
+    private TargetNodeStatements statements;
+    @Inject
+    private TypeManager typeManager;
+
+    @Inject
+    private QueryExecutor queryExecutor;
+
+    @Inject
+    private SqlSchemaBootstrapper sqlSchemaBootstrapper;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        typeManager.registerTypes(TargetNode.class);
+        var targetNodeDirectory = new SqlTargetNodeDirectory(dataSourceRegistry, dataSourceName, trxContext,
+                typeManager.getMapper(), queryExecutor, getStatementImpl());
+        context.registerService(TargetNodeDirectory.class, targetNodeDirectory);
+        sqlSchemaBootstrapper.addStatementFromResource(dataSourceName, "target-node-directory-schema.sql");
+    }
+
+    /**
+     * returns an externally-provided sql statement dialect, or postgres as a default
+     */
+    private TargetNodeStatements getStatementImpl() {
+        return statements != null ? statements : new PostgresDialectStatements();
+    }
+
+}

--- a/extensions/federated-catalog/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/TargetNodeStatements.java
+++ b/extensions/federated-catalog/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/TargetNodeStatements.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2024 Amadeus IT Group
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus IT Group - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.directory.sql;
+
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.sql.statement.SqlStatements;
+import org.eclipse.edc.sql.translation.SqlQueryStatement;
+
+public interface TargetNodeStatements extends SqlStatements {
+
+    default String getTargetNodeDirectoryTable() {
+        return "edc_target_node_directory";
+    }
+
+    default String getIdColumn() {
+        return "id";
+    }
+
+    default String getNameColumn() {
+        return "name";
+    }
+
+    default String getTargetUrlColumn() {
+        return "target_url";
+    }
+
+    default String getSupportedProtocolsColumn() {
+        return "supported_protocols";
+    }
+
+    String getInsertTemplate();
+
+    String getFindByIdTemplate();
+
+    String getUpdateTemplate();
+
+    String getDeleteTemplate();
+
+    SqlQueryStatement createQuery(QuerySpec query);
+
+    String getSelectStatement();
+}

--- a/extensions/federated-catalog/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/schema/postgres/PostgresDialectStatements.java
+++ b/extensions/federated-catalog/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/schema/postgres/PostgresDialectStatements.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2024 Amadeus IT Group
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus IT Group - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.directory.sql.schema.postgres;
+
+import org.eclipse.edc.catalog.directory.sql.BaseSqlDialectStatements;
+import org.eclipse.edc.sql.dialect.PostgresDialect;
+
+public class PostgresDialectStatements extends BaseSqlDialectStatements {
+
+    @Override
+    public String getFormatAsJsonOperator() {
+        return PostgresDialect.getJsonCastOperator();
+    }
+}

--- a/extensions/federated-catalog/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/schema/postgres/TargetNodeMapping.java
+++ b/extensions/federated-catalog/store/sql/target-node-directory-sql/src/main/java/org/eclipse/edc/catalog/directory/sql/schema/postgres/TargetNodeMapping.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2024 Amadeus IT Group
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus IT Group - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.directory.sql.schema.postgres;
+
+import org.eclipse.edc.catalog.directory.sql.TargetNodeStatements;
+import org.eclipse.edc.sql.translation.JsonFieldTranslator;
+import org.eclipse.edc.sql.translation.TranslationMapping;
+
+public class TargetNodeMapping extends TranslationMapping {
+
+    public TargetNodeMapping(TargetNodeStatements statements) {
+        add("id", statements.getIdColumn());
+        add("name", statements.getNameColumn());
+        add("targetUrl", statements.getTargetUrlColumn());
+        add("supportedProtocols", new JsonFieldTranslator(statements.getSupportedProtocolsColumn()));
+    }
+}

--- a/extensions/federated-catalog/store/sql/target-node-directory-sql/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/federated-catalog/store/sql/target-node-directory-sql/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2024 Amadeus IT Group
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Amadeus IT Group - initial API and implementation
+#
+#
+
+org.eclipse.edc.catalog.directory.sql.SqlTargetNodeDirectoryExtension

--- a/extensions/federated-catalog/store/sql/target-node-directory-sql/src/main/resources/target-node-directory-schema.sql
+++ b/extensions/federated-catalog/store/sql/target-node-directory-sql/src/main/resources/target-node-directory-schema.sql
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2024 Amadeus IT Group
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus IT Group - initial API and implementation
+ *
+ */
+
+-- only intended for and tested with Postgres!
+CREATE TABLE IF NOT EXISTS edc_target_node_directory
+(
+    id                      VARCHAR PRIMARY KEY NOT NULL,
+    name                    VARCHAR NOT NULL,
+    target_url              VARCHAR NOT NULL,
+    supported_protocols     JSON
+);
+
+COMMENT ON COLUMN edc_target_node_directory.supported_protocols IS 'List<String> serialized as JSON';

--- a/extensions/federated-catalog/store/sql/target-node-directory-sql/src/test/java/org/eclipse/edc/catalog/directory/sql/SqlTargetNodeDirectoryExtensionTest.java
+++ b/extensions/federated-catalog/store/sql/target-node-directory-sql/src/test/java/org/eclipse/edc/catalog/directory/sql/SqlTargetNodeDirectoryExtensionTest.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2024 Amadeus IT Group
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus IT Group - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.directory.sql;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.crawler.spi.TargetNode;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+public class SqlTargetNodeDirectoryExtensionTest {
+
+    private final TypeManager typeManager = mock();
+
+    @BeforeEach
+    void setUp(ServiceExtensionContext context) {
+        context.registerService(TypeManager.class, typeManager);
+        when(typeManager.getMapper()).thenReturn(new ObjectMapper());
+    }
+
+    @Test
+    void shouldInitializeTheStore(SqlTargetNodeDirectoryExtension extension, ServiceExtensionContext context) {
+        var config = mock(Config.class);
+        when(context.getConfig()).thenReturn(config);
+        when(config.getString(any(), any())).thenReturn("test");
+
+        extension.initialize(context);
+
+        var service = context.getService(TargetNodeDirectory.class);
+        assertThat(service).isInstanceOf(SqlTargetNodeDirectory.class);
+
+        verify(typeManager).registerTypes(TargetNode.class);
+    }
+}

--- a/extensions/federated-catalog/store/sql/target-node-directory-sql/src/test/java/org/eclipse/edc/catalog/directory/sql/SqlTargetNodeDirectoryTest.java
+++ b/extensions/federated-catalog/store/sql/target-node-directory-sql/src/test/java/org/eclipse/edc/catalog/directory/sql/SqlTargetNodeDirectoryTest.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2024 Amadeus IT Group
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus IT Group - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.directory.sql;
+
+import org.eclipse.edc.catalog.directory.sql.schema.postgres.PostgresDialectStatements;
+import org.eclipse.edc.catalog.spi.testfixtures.TargetNodeDirectoryTestBase;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
+import org.eclipse.edc.json.JacksonTypeManager;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.IOException;
+
+@PostgresqlIntegrationTest
+@ExtendWith(PostgresqlStoreSetupExtension.class)
+public class SqlTargetNodeDirectoryTest extends TargetNodeDirectoryTestBase {
+
+    private final TargetNodeStatements statements = new PostgresDialectStatements();
+
+    private TargetNodeDirectory store;
+
+    @BeforeEach
+    void setup(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) throws IOException {
+        var typeManager = new JacksonTypeManager();
+        typeManager.registerTypes(Catalog.class, Dataset.class);
+        store = new SqlTargetNodeDirectory(extension.getDataSourceRegistry(), extension.getDatasourceName(),
+                extension.getTransactionContext(), typeManager.getMapper(), queryExecutor, statements);
+
+        var schema = TestUtils.getResourceFileContentAsString("target-node-directory-schema.sql");
+        extension.runQuery(schema);
+    }
+
+    @AfterEach
+    void tearDown(PostgresqlStoreSetupExtension extension) {
+        extension.runQuery("DROP TABLE " + statements.getTargetNodeDirectoryTable());
+    }
+
+    @Override
+    protected TargetNodeDirectory getStore() {
+        return store;
+    }
+}

--- a/resources/openapi/catalog-api.version
+++ b/resources/openapi/catalog-api.version
@@ -1,0 +1,1 @@
+extensions/federated-catalog/api/federated-catalog-api/src/main/resources/catalog-version.json

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -188,10 +188,13 @@ include(":extensions:common:store:sql:edr-index-sql")
 include(":extensions:common:store:sql:jti-validation-store-sql")
 include(":extensions:common:store:sql:cel-store-sql")
 include(":extensions:common:encryption:aes-encryption")
+include(":extensions:federated-catalog:store:sql:federated-catalog-cache-sql")
+include(":extensions:federated-catalog:store:sql:target-node-directory-sql")
 
 include(":extensions:common:api:control-api-configuration")
 include(":extensions:common:api:management-api-configuration")
 include(":extensions:common:api:management-api-schema-validator")
+include(":extensions:federated-catalog:api:federated-catalog-api")
 
 include(":extensions:control-plane:api:control-plane-api")
 include(":extensions:control-plane:api:control-plane-api-client")


### PR DESCRIPTION
## What this PR changes/adds

Move the federated catalog extensions to the Connector repo. This is the third step out of 5 steps to completely move all federated catalog components. This is related to this [decision record](https://github.com/eclipse-edc/eclipse-edc.github.io/tree/ef760eeabaf0b0baa2a74580b87c2071d4419217/developer/decision-records/2026-03-02-catalog-crawler).

- [x] Move the federated catalog SPIs
- [x]  Move the core components
- [x]  Move the extensions
- [ ]  Move/Modify the Boms
- [ ] Move end to end tests

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5530

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
