### PR TITLE
refactor: move federated catalog end-to-end tests to connector repo

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -316,6 +316,10 @@ include(":system-tests:telemetry:telemetry-test-runner")
 include(":system-tests:telemetry:telemetry-test-runtime")
 include(":system-tests:version-api:version-api-test-runner")
 include(":system-tests:version-api:version-api-test-runtime")
+include(":system-tests:e2e-federatedcatalog-tests:component-tests")
+include(":system-tests:e2e-federatedcatalog-tests:end2end-test:catalog-runtime")
+include(":system-tests:e2e-federatedcatalog-tests:end2end-test:connector-runtime")
+include(":system-tests:e2e-federatedcatalog-tests:end2end-test:e2e-junit-runner")
 
 // BOM modules ----------------------------------------------------------------
 include(":dist:bom:controlplane-base-bom")

--- a/system-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
+++ b/system-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
@@ -81,6 +81,33 @@ public class BomSmokeTests {
 
     @Nested
     @EndToEndTest
+    class FederatedCatalogDcp extends SmokeTest {
+
+        @RegisterExtension
+        protected RuntimeExtension runtime =
+                new RuntimePerMethodExtension(new EmbeddedRuntime("fc-dcp-bom", ":dist:bom:federatedcatalog-dcp-bom")
+                        .configurationProvider(() -> ConfigFactory.fromMap(new HashMap<>() {
+                            {
+                                put("edc.iam.sts.oauth.token.url", "https://sts.com/token");
+                                put("edc.iam.sts.oauth.client.id", "test-clientid");
+                                put("edc.iam.sts.oauth.client.secret.alias", "test-alias");
+                                put("web.http.port", DEFAULT_PORT);
+                                put("web.http.path", DEFAULT_PATH);
+                                put("web.http.catalog.port", "8081");
+                                put("web.http.catalog.path", "/api/catalog");
+                                put("web.http.version.port", String.valueOf(getFreePort()));
+                                put("edc.catalog.cache.execution.period.seconds", "5");
+                                put("edc.iam.issuer.id", "did:web:testparticipant");
+                                put("edc.iam.sts.privatekey.alias", "private-alias");
+                                put("edc.iam.sts.publickey.id", "public-key-id");
+                                put("edc.catalog.cache.execution.delay.seconds", "0");
+                            }
+                        }))
+                );
+    }
+
+    @Nested
+    @EndToEndTest
     public class DataPlaneBase extends SmokeTest {
 
         @RegisterExtension

--- a/system-tests/e2e-federatedcatalog-tests/component-tests/build.gradle.kts
+++ b/system-tests/e2e-federatedcatalog-tests/component-tests/build.gradle.kts
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    testImplementation(project(":core:federated-catalog-core-2025"))
+    testImplementation(project(":extensions:federated-catalog:api:federated-catalog-api"))
+
+    testImplementation(project(":spi:common:json-ld-spi"))
+    testImplementation(project(":spi:control-plane:catalog-spi"))
+    testImplementation(project(":data-protocols:dsp"))
+    testImplementation(project(":core:common:lib:json-ld-lib"))
+    testImplementation(project(":extensions:common:http:jetty-core"))
+    testImplementation(project(":core:common:junit"))
+    testImplementation(project(":spi:data-plane-selector:data-plane-selector-spi"))
+
+    testImplementation(project(":data-protocols:dsp:dsp-http-spi"))
+    testImplementation(project(":data-protocols:dsp:dsp-2025:dsp-spi-2025"))
+    testImplementation(project(":spi:common:core-spi"))
+    testImplementation(project(":spi:common:policy-model"))
+    testImplementation(project(":spi:common:transform-spi"))
+    testImplementation(project(":spi:crawler-spi"))
+    testImplementation(project(":spi:federated-catalog-spi"))
+    testImplementation(project(":spi:common:protocol-spi"))
+
+    testImplementation(libs.restAssured)
+    testImplementation(libs.awaitility)
+
+    testRuntimeOnly(project(":extensions:common:iam:iam-mock"))
+}
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/java/org/eclipse/edc/catalog/CatalogRuntimeComponentTest.java
+++ b/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/java/org/eclipse/edc/catalog/CatalogRuntimeComponentTest.java
@@ -1,0 +1,379 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.crawler.spi.TargetNode;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.junit.annotations.ComponentTest;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
+import org.eclipse.edc.protocol.dsp.http.spi.dispatcher.DspHttpRemoteMessageDispatcher;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.lang.String.format;
+import static java.lang.String.valueOf;
+import static java.time.Duration.ofSeconds;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.stream.IntStream.range;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.catalog.TestFunctions.catalogBuilder;
+import static org.eclipse.edc.catalog.TestFunctions.catalogOf;
+import static org.eclipse.edc.catalog.TestFunctions.createDataset;
+import static org.eclipse.edc.catalog.TestFunctions.emptyCatalog;
+import static org.eclipse.edc.catalog.TestFunctions.queryCatalogApi;
+import static org.eclipse.edc.catalog.TestFunctions.randomCatalog;
+import static org.eclipse.edc.catalog.matchers.CatalogRequestMatcher.sentTo;
+import static org.eclipse.edc.catalog.spi.CatalogConstants.PROPERTY_ORIGINATOR;
+import static org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.eclipse.edc.util.io.Ports.getFreePort;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ComponentTest
+public class CatalogRuntimeComponentTest {
+
+    public static final String TEST_CATALOG_ID = "test-catalog-id";
+    private static final Duration TEST_TIMEOUT = ofSeconds(10);
+    private static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
+    private static final JsonLd JSON_LD_SERVICE = new TitaniumJsonLd(mock());
+
+    @RegisterExtension
+    protected static RuntimeExtension runtimePerClassExtension = new RuntimePerMethodExtension(
+            new EmbeddedRuntime("catalog", ":dist:bom:federatedcatalog-base-bom")
+                    .configurationProvider(() -> ConfigFactory.fromMap(Map.of(
+                        // make sure only one crawl-run is performed
+                        "edc.catalog.cache.execution.period.seconds", "2",
+                        // number of crawlers will be limited by the number of crawl-targets
+                        "edc.catalog.cache.partition.num.crawlers", "10",
+                        // give the runtime time to set up everything
+                        "edc.catalog.cache.execution.delay.seconds", "1",
+                        "web.http.catalog.port", valueOf(TestFunctions.CATALOG_QUERY_PORT),
+                        "web.http.catalog.path", TestFunctions.CATALOG_QUERY_BASE_PATH,
+                        "web.http.port", valueOf(getFreePort()),
+                        "web.http.path", "/api/v1",
+                        "web.http.protocol.port", valueOf(getFreePort()),
+                        "web.http.protocol.path", "/api/v1/dsp",
+                        "edc.participant.id", "test-participant"
+                    )))
+    );
+    private final DspHttpRemoteMessageDispatcher dispatcher = mock();
+
+    @Test
+    @DisplayName("Crawl a single target, yields no results")
+    void crawlSingle_noResults(RemoteMessageDispatcherRegistry reg, TypeTransformerRegistry ttr, TargetNodeDirectory directory, JsonLd jsonLd) {
+        // prepare node directory
+        directory.insert(targetNode());
+        // intercept request egress
+        reg.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, dispatcher);
+        when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
+                .thenReturn(emptyCatalog(catalog -> toBytes(ttr, catalog)));
+
+        await().pollDelay(ofSeconds(1))
+                .atMost(TEST_TIMEOUT)
+                .untilAsserted(() -> {
+                    var response = queryCatalogApi(jsonLd, jsonObject -> ttr.transform(jsonObject, Catalog.class).orElseThrow(AssertionError::new));
+                    assertThat(response).hasSize(1);
+                    assertThat(response).allSatisfy(c -> assertThat(c.getDatasets()).isNullOrEmpty());
+                });
+    }
+
+    @Test
+    @DisplayName("Crawl a single target, yields some results")
+    void crawlSingle_withResults(RemoteMessageDispatcherRegistry reg, TypeTransformerRegistry ttr, TargetNodeDirectory directory, JsonLd jsonLd) {
+        // prepare node directory
+        directory.insert(targetNode());
+        // intercept request egress
+        reg.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, dispatcher);
+        when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
+                .thenReturn(randomCatalog(catalog -> toBytes(ttr, catalog), TEST_CATALOG_ID, 5))
+                .thenReturn(emptyCatalog(catalog -> toBytes(ttr, catalog))); // this is important, otherwise there is an endless loop!
+
+        await().pollDelay(ofSeconds(1))
+                .atMost(TEST_TIMEOUT)
+                .untilAsserted(() -> {
+                    var catalogs = queryCatalogApi(jsonLd, jsonObject -> ttr.transform(jsonObject, Catalog.class).orElseThrow(AssertionError::new));
+                    assertThat(catalogs).allSatisfy(c -> assertThat(c.getDatasets()).hasSize(5));
+                });
+    }
+
+    @Test
+    @DisplayName("Crawl a single target, returns a catalog of catalogs")
+    void crawlSingle_withCatalogOfCatalogs(RemoteMessageDispatcherRegistry reg, TypeTransformerRegistry ttr, TargetNodeDirectory directory, JsonLd jsonLd) {
+        // prepare node directory
+        directory.insert(targetNode());
+        // intercept request egress
+        reg.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, dispatcher);
+        when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
+                .thenReturn(randomCatalog(catalog -> StatusResult.success(TestUtils.getResourceFileContentAsString("catalog_of_catalogs.json").getBytes()), "root-catalog-id", 5))
+                .thenReturn(randomCatalog(catalog -> StatusResult.success(TestUtils.getResourceFileContentAsString("catalog.json").getBytes()), "sub-catalog-id", 5));
+
+        await().pollDelay(ofSeconds(1))
+                .atMost(TEST_TIMEOUT)
+                .untilAsserted(() -> {
+                    var catalogs = queryCatalogApi(jsonLd, jsonObject -> ttr.transform(jsonObject, Catalog.class).orElseThrow(AssertionError::new));
+                    assertThat(catalogs).isNotEmpty().allSatisfy(c -> {
+                        assertThat(c.getDatasets()).hasSize(2);
+                        assertThat(c.getDatasets()).anySatisfy(ds -> assertThat(ds).isInstanceOf(Catalog.class));
+                    });
+                });
+    }
+
+    @Test
+    @DisplayName("Crawl a single targets, > 100 results, needs paging")
+    void crawlSingle_withPagedResults(RemoteMessageDispatcherRegistry reg, TypeTransformerRegistry ttr, TargetNodeDirectory directory, JsonLd jsonLd) {
+        // prepare node directory
+        directory.insert(targetNode());
+
+        // intercept request egress
+        reg.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, dispatcher);
+        when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
+                .thenReturn(randomCatalog(catalog -> toBytes(ttr, catalog), TEST_CATALOG_ID, 100))
+                .thenReturn(randomCatalog(catalog -> toBytes(ttr, catalog), TEST_CATALOG_ID, 100))
+                .thenReturn(randomCatalog(catalog -> toBytes(ttr, catalog), TEST_CATALOG_ID, 50));
+
+        await().pollDelay(ofSeconds(1))
+                .atMost(TEST_TIMEOUT)
+                .untilAsserted(() -> {
+                    var catalogs = queryCatalogApi(jsonLd, jsonObject -> ttr.transform(jsonObject, Catalog.class).orElseThrow(AssertionError::new));
+                    assertThat(catalogs.size()).isEqualTo(1);
+                    assertThat(catalogs.get(0).getDatasets()).hasSize(250);
+                });
+        verify(dispatcher, atLeast(3)).dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class));
+
+    }
+
+    @Test
+    @DisplayName("Crawl a single target twice, emulate deletion of assets")
+    void crawlSingle_withDeletions_shouldRemove(RemoteMessageDispatcherRegistry reg, TypeTransformerRegistry ttr, TargetNodeDirectory directory, JsonLd jsonLd) {
+        // prepare node directory
+        directory.insert(targetNode());
+
+        // intercept request egress
+        reg.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, dispatcher);
+        when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
+                .thenReturn(completedFuture(toBytes(ttr, catalogBuilder().id(TEST_CATALOG_ID).datasets(new ArrayList<>(List.of(
+                        createDataset("offer1"), createDataset("offer2"), createDataset("offer3")
+                ))).build())))
+                .thenReturn(emptyCatalog(catalog -> toBytes(ttr, catalog), TEST_CATALOG_ID))
+                .thenReturn(completedFuture(toBytes(ttr, catalogBuilder().id(TEST_CATALOG_ID).datasets(new ArrayList<>(List.of(
+                        createDataset("offer1"), createDataset("offer2")/* this one is "deleted": createDataset("offer3") */
+                ))).build())));
+
+        await().pollDelay(ofSeconds(1))
+                .atMost(TEST_TIMEOUT)
+                .untilAsserted(() -> {
+                    var catalogs = queryCatalogApi(jsonLd, jsonObject -> ttr.transform(jsonObject, Catalog.class).orElseThrow(AssertionError::new));
+                    assertThat(catalogs).hasSize(1);
+                    assertThat(catalogs.get(0).getDatasets()).hasSize(2)
+                            .noneMatch(offer -> offer.getId().equals("offer3"));
+                    verify(dispatcher, atLeast(4)).dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class));
+                });
+
+    }
+
+    @Test
+    @DisplayName("Crawl a single target twice, emulate deleting and re-adding of assets with same ID")
+    void crawlSingle_withUpdates_shouldReplace(RemoteMessageDispatcherRegistry reg, TypeTransformerRegistry ttr, TargetNodeDirectory directory, JsonLd jsonLd) {
+        // prepare node directory
+        directory.insert(targetNode());
+
+        // intercept request egress
+        reg.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, dispatcher);
+        when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
+                .thenReturn(completedFuture(toBytes(ttr, catalogBuilder().id(TEST_CATALOG_ID).datasets(new ArrayList<>(List.of(
+                        createDataset("offer1"), createDataset("offer2"), createDataset("offer3")
+                ))).build())))
+                .thenReturn(emptyCatalog(catalog -> toBytes(ttr, catalog), TEST_CATALOG_ID))
+                .thenReturn(completedFuture(toBytes(ttr, catalogBuilder().id(TEST_CATALOG_ID).datasets(new ArrayList<>(List.of(
+                        createDataset("offer1"), createDataset("offer2"), createDataset("offer3")
+                ))).build())));
+
+        await().pollDelay(ofSeconds(1))
+                .atMost(TEST_TIMEOUT)
+                .untilAsserted(() -> {
+                    var catalogs = queryCatalogApi(jsonLd, jsonObject -> ttr.transform(jsonObject, Catalog.class).orElseThrow(AssertionError::new));
+                    assertThat(catalogs).hasSize(1);
+                    assertThat(catalogs.get(0).getDatasets()).hasSize(3);
+                    verify(dispatcher, atLeast(4)).dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class));
+                });
+
+    }
+
+    @Test
+    @DisplayName("Crawl a single target twice, emulate addition of assets")
+    void crawlSingle_withAdditions_shouldAdd(RemoteMessageDispatcherRegistry reg, TypeTransformerRegistry ttr, TargetNodeDirectory directory, JsonLd jsonLd) {
+        // prepare node directory
+        directory.insert(targetNode());
+
+        // intercept request egress
+        reg.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, dispatcher);
+        when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
+                .thenAnswer(a -> completedFuture(toBytes(ttr, catalogBuilder().id("test-cat")
+                        .datasets(List.of(createDataset("dataset1"), createDataset("dataset2"))).build())))
+                .thenAnswer(a -> completedFuture(toBytes(ttr, catalogBuilder().id("test-cat")
+                        .datasets(List.of(createDataset("dataset1"), createDataset("dataset2"),
+                                createDataset("dataset3"), createDataset("dataset4"))).build())));
+
+        await().pollDelay(ofSeconds(1))
+                .atMost(TEST_TIMEOUT)
+                .untilAsserted(() -> {
+                    var catalogs = queryCatalogApi(jsonLd, jsonObject -> ttr.transform(jsonObject, Catalog.class).orElseThrow(AssertionError::new));
+                    assertThat(catalogs).hasSize(1);
+                    assertThat(catalogs)
+                            .allSatisfy(cat -> assertThat(cat.getDatasets()).hasSize(4))
+                            .allSatisfy(co -> assertThat(co.getDatasets().stream().map(Dataset::getId).map(id -> id.replace("dataset", "")))
+                                    .containsExactlyInAnyOrder("1", "2", "3", "4"));
+                    verify(dispatcher, atLeast(2)).dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class));
+                });
+
+    }
+
+    @Test
+    @DisplayName("Crawl a single target, verify that the originator information is properly inserted")
+    void crawlSingle_verifyCorrectOriginator(RemoteMessageDispatcherRegistry reg, TypeTransformerRegistry ttr, TargetNodeDirectory directory, JsonLd jsonLd) {
+        // prepare node directory
+        directory.insert(targetNode());
+        // intercept request egress
+        reg.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, dispatcher);
+        when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
+                .thenReturn(randomCatalog(catalog -> toBytes(ttr, catalog), TEST_CATALOG_ID, 5))
+                .thenReturn(emptyCatalog(catalog -> toBytes(ttr, catalog))); // this is important, otherwise there is an endless loop!
+
+        await().pollDelay(ofSeconds(1))
+                .atMost(TEST_TIMEOUT)
+                .untilAsserted(() -> {
+                    var catalogs = queryCatalogApi(jsonLd, jsonObject -> ttr.transform(jsonObject, Catalog.class).orElseThrow(AssertionError::new));
+                    assertThat(catalogs).hasSize(1);
+                    assertThat(catalogs.get(0).getDatasets()).hasSize(5);
+                    assertThat(catalogs).extracting(Catalog::getProperties).allSatisfy(a -> assertThat(a).containsEntry(PROPERTY_ORIGINATOR, "http://test-node.com"));
+                });
+    }
+
+    @Test
+    @DisplayName("Crawl 1000 targets, verify that all offers are collected")
+    void crawlMany_shouldCollectAll(RemoteMessageDispatcherRegistry reg, TypeTransformerRegistry ttr, TargetNodeDirectory directory, JsonLd jsonLd) {
+
+        var numTotalAssets = new AtomicInteger();
+        var rnd = new SecureRandom();
+
+        // create 1000 crawl targets, setup dispatcher mocks for them
+        reg.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, dispatcher);
+        var numTargets = 50;
+        range(0, numTargets)
+                .forEach(i -> {
+                    var nodeId = "did:web:" + UUID.randomUUID();
+                    var nodeUrl = format("http://test-node%s.com", i);
+                    var node = new TargetNode("test-node-" + i, nodeId, nodeUrl, singletonList(DATASPACE_PROTOCOL_HTTP_V_2025_1));
+                    directory.insert(node);
+
+                    var numAssets = 1 + rnd.nextInt(10);
+                    when(dispatcher.dispatch(any(), eq(byte[].class), argThat(sentTo(nodeId, nodeUrl))))
+                            .thenReturn(randomCatalog(catalog -> toBytes(ttr, catalog), "catalog-" + nodeUrl, numAssets));
+                    numTotalAssets.addAndGet(numAssets);
+                });
+
+        await().pollDelay(ofSeconds(1))
+                .atMost(TEST_TIMEOUT.plus(TEST_TIMEOUT))
+                .untilAsserted(() -> {
+                    var catalogs = queryCatalogApi(jsonLd, jsonObject -> ttr.transform(jsonObject, Catalog.class).orElseThrow(AssertionError::new));
+                    assertThat(catalogs).hasSize(numTargets);
+                    //assert that the total number of offers across all catalogs is corrects
+                    assertThat(catalogs.stream().mapToLong(c -> c.getDatasets().size()).sum()).isEqualTo(numTotalAssets.get());
+                });
+    }
+
+    @Test
+    @DisplayName("Crawl multiple targets with conflicting asset IDs")
+    void crawlMultiple_whenConflictingAssetIds_shouldOverwrite(RemoteMessageDispatcherRegistry reg, TypeTransformerRegistry ttr, TargetNodeDirectory directory, JsonLd jsonLd) {
+        var node1 = new TargetNode("test-node1", "did:web:" + UUID.randomUUID(), "http://test-node1.com", singletonList(DATASPACE_PROTOCOL_HTTP_V_2025_1));
+        var node2 = new TargetNode("test-node2", "did:web:" + UUID.randomUUID(), "http://test-node2.com", singletonList(DATASPACE_PROTOCOL_HTTP_V_2025_1));
+
+        directory.insert(node1);
+        directory.insert(node2);
+        reg.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, dispatcher);
+
+        when(dispatcher.dispatch(any(), eq(byte[].class), argThat(sentTo(node1.id(), node1.targetUrl()))))
+                .thenReturn(catalogOf(catalog -> toBytes(ttr, catalog), "catalog-" + node1.targetUrl(), createDataset("offer1"), createDataset("offer2"), createDataset("offer3")))
+                .thenReturn(emptyCatalog(catalog -> toBytes(ttr, catalog)));
+
+        when(dispatcher.dispatch(any(), eq(byte[].class), argThat(sentTo(node2.id(), node2.targetUrl()))))
+                .thenReturn(catalogOf(catalog -> toBytes(ttr, catalog), "catalog-" + node2.targetUrl(), createDataset("offer14"), createDataset("offer32"), /*this one is conflicting:*/createDataset("offer3")))
+                .thenReturn(emptyCatalog(catalog -> toBytes(ttr, catalog)));
+
+        await().pollDelay(ofSeconds(1))
+                .atMost(TEST_TIMEOUT)
+                .untilAsserted(() -> {
+                    var catalogs = queryCatalogApi(jsonLd, jsonObject -> ttr.transform(jsonObject, Catalog.class).orElseThrow(AssertionError::new));
+                    assertThat(catalogs).hasSize(2);
+                    assertThat(catalogs).anySatisfy(c -> assertThat(c.getProperties().get(PROPERTY_ORIGINATOR).toString()).startsWith("http://test-node1.com"));
+                    assertThat(catalogs).anySatisfy(c -> assertThat(c.getProperties().get(PROPERTY_ORIGINATOR).toString()).startsWith("http://test-node2.com"));
+                    assertThat(catalogs.stream().mapToLong(c -> c.getDatasets().size()).sum()).isEqualTo(6);
+                    assertThat(catalogs.stream().flatMap(c -> c.getDatasets().stream()).map(Dataset::getId))
+                            .containsExactlyInAnyOrder("offer1", "offer2", "offer3", "offer14", "offer32", "offer3");
+                });
+
+
+    }
+
+    private StatusResult<byte[]> toBytes(TypeTransformerRegistry transformerRegistry, Catalog cat1) {
+        try {
+            var jo = transformerRegistry.transform(cat1, JsonObject.class).orElseThrow(AssertionError::new);
+            var expanded = JSON_LD_SERVICE.expand(jo).orElseThrow(AssertionError::new);
+            var expandedStr = OBJECT_MAPPER.writeValueAsString(expanded);
+            return StatusResult.success(expandedStr.getBytes());
+        } catch (JsonProcessingException ex) {
+            throw new AssertionError(ex);
+        }
+    }
+
+    private @NotNull TargetNode targetNode() {
+        return new TargetNode("test-node", "did:web:" + UUID.randomUUID(), "http://test-node.com", singletonList(DATASPACE_PROTOCOL_HTTP_V_2025_1));
+    }
+
+}

--- a/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/java/org/eclipse/edc/catalog/TestFunctions.java
+++ b/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/java/org/eclipse/edc/catalog/TestFunctions.java
@@ -1,0 +1,127 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.result.Result;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+import static io.restassured.RestAssured.given;
+import static java.util.Arrays.asList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.stream.Collectors.toList;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.util.io.Ports.getFreePort;
+
+public class TestFunctions {
+    public static final String CATALOG_QUERY_BASE_PATH = "/catalog";
+    public static final int CATALOG_QUERY_PORT = getFreePort();
+    private static final String PATH = "/v1alpha/catalog/query";
+    private static final TypeReference<List<Map<String, Object>>> MAP_TYPE = new TypeReference<>() {
+    };
+
+    private static RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + CATALOG_QUERY_PORT)
+                .basePath(CATALOG_QUERY_BASE_PATH)
+                .contentType(ContentType.JSON)
+                .when();
+    }
+
+    public static CompletableFuture<StatusResult<byte[]>> emptyCatalog(Function<Catalog, StatusResult<byte[]>> transformationFunction) {
+        return completedFuture(transformationFunction.apply(catalogBuilder().build()));
+    }
+
+    public static CompletableFuture<StatusResult<byte[]>> emptyCatalog(Function<Catalog, StatusResult<byte[]>> transformationFunction, String catalogId) {
+        return completedFuture(transformationFunction.apply(catalogBuilder().id(catalogId).build()));
+    }
+
+    public static Catalog.Builder catalogBuilder() {
+        return Catalog.Builder.newInstance()
+                .participantId("test-participant")
+                .id(UUID.randomUUID().toString())
+                .properties(new HashMap<>())
+                .dataServices(new ArrayList<>())
+                .datasets(new ArrayList<>());
+    }
+
+    public static CompletableFuture<StatusResult<byte[]>> catalogOf(Function<Catalog, StatusResult<byte[]>> transformationFunction, String catId, Dataset... datasets) {
+        return completedFuture(transformationFunction.apply(catalogBuilder().id(catId).datasets(asList(datasets)).build()));
+    }
+
+    public static CompletableFuture<StatusResult<byte[]>> randomCatalog(Function<Catalog, StatusResult<byte[]>> transformationFunction, String id, int howManyDatasets) {
+        return completedFuture(transformationFunction.apply(catalogBuilder()
+                .id(id)
+                .datasets(IntStream.range(0, howManyDatasets).mapToObj(i -> createDataset("DataSet_" + UUID.randomUUID())).collect(toList()))
+                .build()));
+    }
+
+    public static List<Catalog> queryCatalogApi(JsonLd jsonLd, Function<JsonObject, Catalog> transformerFunction) {
+        var objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        var body = baseRequest()
+                .body(TestFunctions.createEmptyQuery())
+                .post(PATH)
+                .body();
+
+        try {
+            var maps = objectMapper.readValue(body.asString(), MAP_TYPE);
+            return maps.stream().map(map -> Json.createObjectBuilder(map).build())
+                    .map(jsonLd::expand)
+                    .map(Result::getContent)
+                    .map(transformerFunction)
+                    .toList();
+        } catch (JsonProcessingException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public static JsonObject createEmptyQuery() {
+        return Json.createObjectBuilder()
+                .add(TYPE, QuerySpec.EDC_QUERY_SPEC_TYPE)
+                .build();
+    }
+
+    public static Dataset createDataset(String dataset1) {
+        return Dataset.Builder.newInstance()
+                .offer("test-offer", Policy.Builder.newInstance().build())
+                .distribution(Distribution.Builder.newInstance().format("test-format").dataService(DataService.Builder.newInstance().build()).build())
+                .id(dataset1)
+                .build();
+    }
+}

--- a/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/java/org/eclipse/edc/catalog/instrumentation/MockInjectionExtension.java
+++ b/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/java/org/eclipse/edc/catalog/instrumentation/MockInjectionExtension.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.instrumentation;
+
+import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClientFactory;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcher;
+import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.mockito.Mockito.mock;
+
+public class MockInjectionExtension implements ServiceExtension {
+
+    @Inject
+    private RemoteMessageDispatcherRegistry registry;
+    private RemoteMessageDispatcher dispatcher;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        registry.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, createDispatcher());
+    }
+
+    @Provider
+    public RemoteMessageDispatcher createDispatcher() {
+        if (dispatcher == null) {
+            dispatcher = mock(RemoteMessageDispatcher.class);
+        }
+
+        return dispatcher;
+    }
+
+    @Provider
+    public DataPlaneClientFactory createDataPlaneClientFactory() {
+        return mock();
+    }
+}

--- a/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/java/org/eclipse/edc/catalog/matchers/CatalogRequestMatcher.java
+++ b/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/java/org/eclipse/edc/catalog/matchers/CatalogRequestMatcher.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.catalog.matchers;
+
+import org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequestMessage;
+import org.mockito.ArgumentMatcher;
+
+public abstract class CatalogRequestMatcher implements ArgumentMatcher<CatalogRequestMessage> {
+
+    public static CatalogRequestMatcher sentTo(String recipientId, String recipientUrl) {
+        return new CatalogRequestMatcher() {
+            @Override
+            public boolean matches(CatalogRequestMessage argument) {
+                return argument.getCounterPartyId().equals(recipientId) &&
+                        argument.getCounterPartyAddress().equals(recipientUrl);
+            }
+        };
+    }
+}

--- a/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,1 @@
+org.eclipse.edc.catalog.instrumentation.MockInjectionExtension

--- a/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/resources/catalog.json
+++ b/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/resources/catalog.json
@@ -1,0 +1,43 @@
+{
+  "@id": "sub-catalog-id",
+  "@type": "dcat:Catalog",
+  "dcat:dataset": [
+    {
+      "@id": "subcatalog-asset-a873f2be-295e-4d03-af1c-0e15c1363627",
+      "@type": "dcat:Dataset",
+      "odrl:hasPolicy": {
+        "@id": "ODkzNGY3MzEtYzdmMy00N2NiLTlmM2UtNGU1ZDljOGNjNzU3:bm9ybWFsLWFzc2V0LWE4NzNmMmJlLTI5NWUtNGQwMy1hZjFjLTBlMTVjMTM2MzYyNw==:OGZhMzc3ODktOTZlYS00ZGQ1LWIyZjktNjYzNTQwOWZlNTUw",
+        "@type": "odrl:Offer",
+        "odrl:permission": [
+        ],
+        "odrl:prohibition": [
+        ],
+        "odrl:obligation": [
+        ]
+      },
+      "dcat:distribution": [
+      ],
+      "id": "normal-asset-a873f2be-295e-4d03-af1c-0e15c1363627"
+    }
+  ],
+  "dcat:distribution": [
+  ],
+  "dcat:service": {
+    "@id": "5cc832e4-9b77-412b-a21e-7d5b49516f2c",
+    "@type": "dcat:DataService",
+    "dcat:endpointDescription": "dspace:connector",
+    "dcat:endpointURL": "http://localhost:55229/protocol",
+    "dct:terms": "dspace:connector",
+    "dct:endpointUrl": "http://localhost:55229/protocol"
+  },
+  "dspace:participantId": "anonymous",
+  "participantId": "anonymous",
+  "@context": {
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/2025/1/"
+  }
+}

--- a/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/resources/catalog_of_catalogs.json
+++ b/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/resources/catalog_of_catalogs.json
@@ -1,0 +1,69 @@
+{
+  "@id": "root-catalog-id",
+  "@type": "dcat:Catalog",
+  "dcat:dataset": [
+    {
+      "@id": "normal-asset-a873f2be-295e-4d03-af1c-0e15c1363627",
+      "@type": "dcat:Dataset",
+      "odrl:hasPolicy": {
+        "@id": "ODkzNGY3MzEtYzdmMy00N2NiLTlmM2UtNGU1ZDljOGNjNzU3:bm9ybWFsLWFzc2V0LWE4NzNmMmJlLTI5NWUtNGQwMy1hZjFjLTBlMTVjMTM2MzYyNw==:OGZhMzc3ODktOTZlYS00ZGQ1LWIyZjktNjYzNTQwOWZlNTUw",
+        "@type": "odrl:Offer",
+        "odrl:permission": [
+        ],
+        "odrl:prohibition": [
+        ],
+        "odrl:obligation": [
+        ]
+      },
+      "dcat:distribution": [
+      ],
+      "id": "normal-asset-a873f2be-295e-4d03-af1c-0e15c1363627"
+    }
+  ],
+  "dcat:catalog": [
+    {
+      "@id": "catalog-asset-5a7482bd-a2a8-4248-a8fa-353cb1d14df7",
+      "@type": "dcat:Catalog",
+      "dcat:dataset": [
+      ],
+      "dcat:distribution": {
+        "@type": "dcat:Distribution",
+        "dct:format": {
+          "@id": "HttpData"
+        },
+        "dcat:accessService": {
+          "@id": "Y2F0YWxvZy1hc3NldC01YTc0ODJiZC1hMmE4LTQyNDgtYThmYS0zNTNjYjFkMTRkZjc=",
+          "@type": "dcat:DataService"
+        }
+      },
+      "dcat:service": {
+        "@id": "Y2F0YWxvZy1hc3NldC01YTc0ODJiZC1hMmE4LTQyNDgtYThmYS0zNTNjYjFkMTRkZjc=",
+        "@type": "dcat:DataService",
+        "dcat:endpointURL": "http://quizzqua.zz/buzz",
+        "dct:endpointUrl": "http://quizzqua.zz/buzz"
+      },
+      "isCatalog": true,
+      "id": "catalog-asset-5a7482bd-a2a8-4248-a8fa-353cb1d14df7"
+    }
+  ],
+  "dcat:distribution": [
+  ],
+  "dcat:service": {
+    "@id": "5cc832e4-9b77-412b-a21e-7d5b49516f2c",
+    "@type": "dcat:DataService",
+    "dcat:endpointDescription": "dspace:connector",
+    "dcat:endpointURL": "http://localhost:55229/protocol",
+    "dct:terms": "dspace:connector",
+    "dct:endpointUrl": "http://localhost:55229/protocol"
+  },
+  "dspace:participantId": "anonymous",
+  "participantId": "anonymous",
+  "@context": {
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/2025/1/"
+  }
+}

--- a/system-tests/e2e-federatedcatalog-tests/end2end-test/catalog-runtime/build.gradle.kts
+++ b/system-tests/e2e-federatedcatalog-tests/end2end-test/catalog-runtime/build.gradle.kts
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    id("application")
+    alias(libs.plugins.shadow)
+}
+
+dependencies {
+    runtimeOnly(project(":dist:bom:federatedcatalog-dcp-bom"))
+}
+
+application {
+    mainClass.set("org.eclipse.edc.boot.system.runtime.BaseRuntime")
+}
+
+tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
+    mergeServiceFiles()
+    archiveFileName.set("fc.jar")
+}
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/e2e-federatedcatalog-tests/end2end-test/connector-runtime/build.gradle.kts
+++ b/system-tests/e2e-federatedcatalog-tests/end2end-test/connector-runtime/build.gradle.kts
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    implementation(project(":dist:bom:controlplane-base-bom"))
+    implementation(project(":extensions:common:iam:iam-mock"))
+}
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/e2e-federatedcatalog-tests/end2end-test/connector-runtime/src/main/java/org/eclipse/edc/federatedcatalog/end2end/DataplaneInstanceRegistrationExtension.java
+++ b/system-tests/e2e-federatedcatalog-tests/end2end-test/connector-runtime/src/main/java/org/eclipse/edc/federatedcatalog/end2end/DataplaneInstanceRegistrationExtension.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.federatedcatalog.end2end;
+
+
+import org.eclipse.edc.connector.dataplane.selector.spi.client.DataPlaneClientFactory;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+public class DataplaneInstanceRegistrationExtension implements ServiceExtension {
+
+    @Inject
+    private DataPlaneInstanceStore dataPlaneInstanceStore;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var dpi = DataPlaneInstance.Builder.newInstance()
+                .id("test-instance")
+                .allowedDestType("test-dest-type")
+                .allowedSourceType("test-src-type")
+                .url("http://test.local")
+                .build();
+        dataPlaneInstanceStore.save(dpi);
+    }
+
+    @Provider
+    public DataPlaneClientFactory createDataPlaneClientFactory() {
+        return dataPlaneInstance -> null;
+    }
+}

--- a/system-tests/e2e-federatedcatalog-tests/end2end-test/connector-runtime/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/system-tests/e2e-federatedcatalog-tests/end2end-test/connector-runtime/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,1 @@
+org.eclipse.edc.federatedcatalog.end2end.DataplaneInstanceRegistrationExtension

--- a/system-tests/e2e-federatedcatalog-tests/end2end-test/e2e-junit-runner/build.gradle.kts
+++ b/system-tests/e2e-federatedcatalog-tests/end2end-test/e2e-junit-runner/build.gradle.kts
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2020, 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    testImplementation(project(":spi:federated-catalog-spi"))
+    testImplementation(project(":core:federated-catalog-core"))
+    testImplementation(project(":core:federated-catalog-core-2025"))
+    testImplementation(project(":core:common:connector-core"))
+    testImplementation(project(":core:common:lib:transform-lib"))
+    testImplementation(project(":core:control-plane:control-plane-transform"))
+    testImplementation(libs.awaitility)
+    testImplementation(project(":extensions:control-plane:api:management-api"))
+    testImplementation(project(":data-protocols:dsp:dsp-lib:dsp-catalog-lib:dsp-catalog-transform-lib"))
+    testImplementation(project(":data-protocols:dsp:dsp-2025:dsp-catalog-2025:dsp-catalog-transform-2025"))
+    testImplementation(project(":core:common:junit"))
+    testImplementation(project(":core:common:lib:json-ld-lib"))
+    testImplementation(libs.jackson.datatype.jsr310)
+
+    testCompileOnly(project(":dist:bom:federatedcatalog-base-bom"))
+    testCompileOnly(project(":extensions:common:iam:iam-mock"))
+    testCompileOnly(project(":system-tests:e2e-federatedcatalog-tests:end2end-test:catalog-runtime"))
+    testCompileOnly(project(":system-tests:e2e-federatedcatalog-tests:end2end-test:connector-runtime"))
+}
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/e2e-federatedcatalog-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/CatalogApiClient.java
+++ b/system-tests/e2e-federatedcatalog-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/CatalogApiClient.java
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.end2end;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static java.lang.String.format;
+
+class CatalogApiClient {
+    private static final TypeReference<List<Map<String, Object>>> LIST_TYPE_REFERENCE = new TypeReference<>() {
+    };
+    private static final MediaType JSON = MediaType.parse("application/json");
+    private final String managementBaseUrl;
+    private final String catalogBaseUrl;
+    private final ObjectMapper mapper;
+    private final Supplier<JsonLd> jsonLdSupplier;
+    private final TypeTransformerRegistry typeTransformerRegistry;
+
+    CatalogApiClient(Endpoint catalogManagement, Endpoint connectorManagement,
+                     ObjectMapper mapper, Supplier<JsonLd> jsonLdSupplier,
+                     TypeTransformerRegistry typeTransformerRegistry) {
+        this.mapper = mapper;
+        this.jsonLdSupplier = jsonLdSupplier;
+        this.typeTransformerRegistry = typeTransformerRegistry;
+        managementBaseUrl = "http://localhost:%s%s".formatted(connectorManagement.port(), connectorManagement.path());
+        catalogBaseUrl = "http://localhost:%s%s".formatted(catalogManagement.port(), catalogManagement.path());
+    }
+
+    Result<String> postAsset(JsonObject entry) {
+        return postObjectWithId(createPostRequest(entry, managementBaseUrl + "/v3/assets"));
+    }
+
+    Result<String> postPolicy(String policyJsonLd) {
+        return postObjectWithId(createPostRequest(policyJsonLd, managementBaseUrl + "/v3/policydefinitions"));
+    }
+
+    Result<String> postContractDefinition(JsonObject definition) {
+        return postObjectWithId(createPostRequest(definition, managementBaseUrl + "/v3/contractdefinitions"));
+    }
+
+    public String queryCatalogs(JsonObject querySpec) {
+        var rq = createPostRequest(querySpec, catalog("/v1alpha/catalog/query"));
+
+        try (var response = getClient().newCall(rq).execute()) {
+            if (response.isSuccessful()) {
+                return response.body().string();
+            }
+            throw new RuntimeException(format("Error getting catalog: %s", response));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public List<Catalog> deserializeCatalogs(String json) {
+        try {
+            return mapper.readValue(json, LIST_TYPE_REFERENCE).stream()
+                    .map(m -> jsonLdSupplier.get().expand(Json.createObjectBuilder(m).build())
+                            .compose(jsonObject -> typeTransformerRegistry.transform(jsonObject, Catalog.class))
+                            .orElseThrow(f -> new EdcException(f.getFailureDetail()))
+                    )
+                    .toList();
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String catalog(String path) {
+        return catalogBaseUrl + path;
+    }
+
+    @NotNull
+    private Result<String> postObjectWithId(Request policy) {
+        try (var response = getClient()
+                .newCall(policy)
+                .execute()) {
+            var stringbody = response.body().string();
+            return response.isSuccessful() ?
+                    Result.success(fromJson(stringbody, JsonObject.class).getString("@id")) :
+                    Result.failure(response.message());
+
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private <T> T fromJson(String string, Class<T> clazz) {
+        try {
+            return mapper.readValue(string, clazz);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @NotNull
+    private Request createPostRequest(Object body, String path) {
+        return new Request.Builder().url(path).post(RequestBody.create(asJson(body), JSON)).build();
+    }
+
+    private String asJson(Object entry) {
+        try {
+            return entry instanceof String ? (String) entry : mapper.writeValueAsString(entry);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private OkHttpClient getClient() {
+        return new OkHttpClient();
+    }
+}

--- a/system-tests/e2e-federatedcatalog-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/Endpoint.java
+++ b/system-tests/e2e-federatedcatalog-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/Endpoint.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.end2end;
+
+public record Endpoint(String path, String port) {
+}

--- a/system-tests/e2e-federatedcatalog-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/FederatedCatalogTest.java
+++ b/system-tests/e2e-federatedcatalog-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/FederatedCatalogTest.java
@@ -1,0 +1,236 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.end2end;
+
+import jakarta.json.Json;
+import org.eclipse.edc.catalog.transform.JsonObjectToCatalogTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDataServiceTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDatasetTransformer;
+import org.eclipse.edc.catalog.transform.JsonObjectToDistributionTransformer;
+import org.eclipse.edc.connector.controlplane.catalog.spi.Catalog;
+import org.eclipse.edc.connector.controlplane.transform.odrl.from.JsonObjectFromPolicyTransformer;
+import org.eclipse.edc.connector.core.agent.NoOpParticipantIdMapper;
+import org.eclipse.edc.crawler.spi.TargetNode;
+import org.eclipse.edc.crawler.spi.TargetNodeDirectory;
+import org.eclipse.edc.json.JacksonTypeManager;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDataServiceTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDatasetTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.from.JsonObjectFromDistributionTransformer;
+import org.eclipse.edc.protocol.dsp.catalog.transform.v2025.from.JsonObjectFromCatalogV2025Transformer;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.TypeTransformerRegistryImpl;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.transform.transformer.edc.to.JsonValueToGenericTypeTransformer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static java.time.Duration.ofSeconds;
+import static java.util.Map.entry;
+import static java.util.Map.ofEntries;
+import static java.util.Optional.ofNullable;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.connector.controlplane.transform.odrl.OdrlTransformersFactory.jsonObjectToOdrlTransformers;
+import static org.eclipse.edc.end2end.TestFunctions.createContractDef;
+import static org.eclipse.edc.end2end.TestFunctions.createPolicy;
+import static org.eclipse.edc.jsonld.spi.Namespaces.DSPACE_CONTEXT_2025_1;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
+import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1_VERSION;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+import static org.eclipse.edc.util.io.Ports.getFreePort;
+
+@EndToEndTest
+class FederatedCatalogTest {
+
+    public static final Duration TIMEOUT = ofSeconds(30);
+    private static final Endpoint CONNECTOR_MANAGEMENT = new Endpoint("/management", "8081");
+    private static final Endpoint CONNECTOR_PROTOCOL = new Endpoint("/api/v1/dsp", "8082");
+    private static final Endpoint CONNECTOR_DEFAULT = new Endpoint("/api/v1/", "8080");
+    private static final Endpoint CONNECTOR_CONTROL = new Endpoint("/api/v1/control", "8083");
+
+    private static final Endpoint CATALOG_MANAGEMENT = new Endpoint("/management", "8091");
+    private static final Endpoint CATALOG_PROTOCOL = new Endpoint("/api/v1/dsp", "8092");
+    private static final Endpoint CATALOG_DEFAULT = new Endpoint("/api/v1/", "8090");
+    private static final Endpoint CATALOG_CATALOG = new Endpoint("/catalog", "8093");
+
+    @RegisterExtension
+    static RuntimeExtension connector = new RuntimePerClassExtension(
+            new EmbeddedRuntime("connector", ":system-tests:e2e-federatedcatalog-tests:end2end-test:connector-runtime")
+                    .configurationProvider(() -> ConfigFactory.fromMap(Map.ofEntries(
+                            entry("edc.connector.name", "connector1"),
+                            entry("edc.web.rest.cors.enabled", "true"),
+                            entry("web.http.port", CONNECTOR_DEFAULT.port()),
+                            entry("web.http.path", CONNECTOR_DEFAULT.path()),
+                            entry("web.http.protocol.port", CONNECTOR_PROTOCOL.port()),
+                            entry("web.http.protocol.path", CONNECTOR_PROTOCOL.path()),
+                            entry("web.http.control.port", CONNECTOR_CONTROL.port()),
+                            entry("web.http.control.path", CONNECTOR_CONTROL.path()),
+                            entry("web.http.management.port", CONNECTOR_MANAGEMENT.port()),
+                            entry("edc.participant.id", "test-connector"),
+                            entry("web.http.management.path", CONNECTOR_MANAGEMENT.path()),
+                            entry("edc.web.rest.cors.headers", "origin,content-type,accept,authorization,x-api-key"),
+                            entry("edc.dsp.callback.address", "http://localhost:%s%s".formatted(CONNECTOR_PROTOCOL.port(), CONNECTOR_PROTOCOL.path()))
+                    )))
+    );
+
+    @RegisterExtension
+    static RuntimeExtension catalog = new RuntimePerMethodExtension(
+            new EmbeddedRuntime("catalog", ":dist:bom:federatedcatalog-base-bom", ":extensions:common:iam:iam-mock")
+                    .configurationProvider(() -> ConfigFactory.fromMap(ofEntries(
+                            entry("edc.catalog.cache.execution.delay.seconds", "0"),
+                            entry("edc.catalog.cache.execution.period.seconds", "5"),
+                            entry("edc.catalog.cache.partition.num.crawlers", "3"),
+                            entry("edc.web.rest.cors.enabled", "true"),
+                            entry("edc.participant.id", "test-catalog"),
+                            entry("web.http.port", CATALOG_DEFAULT.port()),
+                            entry("web.http.path", CATALOG_DEFAULT.path()),
+                            entry("web.http.protocol.port", CATALOG_PROTOCOL.port()),
+                            entry("web.http.protocol.path", CATALOG_PROTOCOL.path()),
+                            entry("web.http.management.port", CATALOG_MANAGEMENT.port()),
+                            entry("web.http.management.path", CATALOG_MANAGEMENT.path()),
+                            entry("web.http.version.port", getFreePort() + ""),
+                            entry("web.http.version.path", "/.well-known/version"),
+                            entry("web.http.catalog.port", CATALOG_CATALOG.port()),
+                            entry("web.http.catalog.path", CATALOG_CATALOG.path()),
+                            entry("edc.web.rest.cors.headers", "origin,content-type,accept,authorization,x-api-key")
+                    )))
+    );
+
+    private final TypeTransformerRegistry typeTransformerRegistry = new TypeTransformerRegistryImpl();
+    private final TypeManager mapper = new JacksonTypeManager();
+    private final CatalogApiClient apiClient = new CatalogApiClient(CATALOG_CATALOG, CONNECTOR_MANAGEMENT,
+            JacksonJsonLd.createObjectMapper(), () -> catalog.getService(JsonLd.class), typeTransformerRegistry);
+
+    @BeforeEach
+    void setUp() {
+        var factory = Json.createBuilderFactory(Map.of());
+        var participantIdMapper = new NoOpParticipantIdMapper();
+        typeTransformerRegistry.register(new JsonObjectFromCatalogV2025Transformer(factory, new JacksonTypeManager(), JSON_LD, participantIdMapper, DSP_NAMESPACE_V_2025_1));
+        typeTransformerRegistry.register(new JsonObjectFromDatasetTransformer(factory, mapper, JSON_LD));
+        typeTransformerRegistry.register(new JsonObjectFromDataServiceTransformer(factory));
+        typeTransformerRegistry.register(new JsonObjectFromPolicyTransformer(factory, participantIdMapper));
+        typeTransformerRegistry.register(new JsonObjectFromDistributionTransformer(factory));
+        typeTransformerRegistry.register(new JsonObjectToCatalogTransformer());
+        typeTransformerRegistry.register(new JsonObjectToDatasetTransformer());
+        typeTransformerRegistry.register(new JsonObjectToDataServiceTransformer());
+        jsonObjectToOdrlTransformers(participantIdMapper).forEach(typeTransformerRegistry::register);
+        typeTransformerRegistry.register(new JsonObjectToDistributionTransformer());
+        typeTransformerRegistry.register(new JsonValueToGenericTypeTransformer(mapper, JSON_LD));
+
+        var node = new TargetNode(
+                "connector", "did:web:" + UUID.randomUUID(),
+                "http://localhost:%s%s".formatted(CONNECTOR_PROTOCOL.port(), CONNECTOR_PROTOCOL.path() + "/" + V_2025_1_VERSION),
+                List.of(DATASPACE_PROTOCOL_HTTP_V_2025_1)
+        );
+        catalog.registerSystemExtension(ServiceExtension.class, new SeedNodeExtension(node));
+    }
+
+    @Test
+    void crawl_whenOfferAvailable_shouldContainOffer(TestInfo testInfo) {
+        var id = testInfo.getDisplayName() + "-" + UUID.randomUUID();
+        var asset = TestFunctions.createAssetJson(id);
+        var r = apiClient.postAsset(asset);
+        assertThat(r).withFailMessage(getError(r)).isSucceeded();
+
+        var assetId = r.getContent();
+
+        var policy = createPolicy("policy-" + id, id);
+        var pr = apiClient.postPolicy(policy);
+        assertThat(r).withFailMessage(getError(pr)).isSucceeded();
+
+        var policyId = pr.getContent();
+
+        var request = createContractDef("def-" + id, policyId, policyId, assetId);
+
+        var dr = apiClient.postContractDefinition(request);
+        assertThat(dr).withFailMessage(getError(dr)).isSucceeded();
+
+        var assetIdBase64 = Base64.getEncoder().encodeToString(assetId.getBytes());
+
+        await().pollDelay(ofSeconds(1))
+                .pollInterval(ofSeconds(1))
+                .atMost(TIMEOUT)
+                .untilAsserted(() -> {
+                    var emptyQuery = TestFunctions.createEmptyQuery();
+                    var catalogsJson = apiClient.queryCatalogs(emptyQuery);
+                    assertThat(catalogsJson).contains(DSPACE_CONTEXT_2025_1);
+
+                    var catalogs = apiClient.deserializeCatalogs(catalogsJson);
+                    assertCatalogContainsOffer(assetIdBase64, catalogs);
+                });
+
+        await().pollDelay(ofSeconds(1))
+                .pollInterval(ofSeconds(1))
+                .atMost(TIMEOUT)
+                .untilAsserted(() -> {
+                    var queryWithExistingAssetId = TestFunctions.createQuerySpecWithFilterExpressionForAssetId(id);
+                    var catalogs = apiClient.deserializeCatalogs(apiClient.queryCatalogs(queryWithExistingAssetId));
+
+                    assertCatalogContainsOffer(assetIdBase64, catalogs);
+                });
+    }
+
+    private String getError(Result<String> r) {
+        return ofNullable(r.getFailureDetail()).orElse("No error");
+    }
+
+    private void assertCatalogContainsOffer(String assetIdBase64, List<Catalog> catalogs) {
+        assertThat(catalogs).hasSizeGreaterThanOrEqualTo(1);
+        assertThat(catalogs).anySatisfy(catalog -> assertThat(catalog.getDatasets())
+                .anySatisfy(dataset -> {
+                    assertThat(dataset.getOffers()).hasSizeGreaterThanOrEqualTo(1);
+                    assertThat(dataset.getOffers().keySet()).anyMatch(key -> key.contains(assetIdBase64));
+                }));
+    }
+
+    private static class SeedNodeExtension implements ServiceExtension {
+
+        private final TargetNode node;
+
+        @Inject
+        private TargetNodeDirectory targetNodeDirectory;
+
+        SeedNodeExtension(TargetNode node) {
+            this.node = node;
+        }
+
+        @Override
+        public void prepare() {
+            targetNodeDirectory.insert(node);
+        }
+
+    }
+}

--- a/system-tests/e2e-federatedcatalog-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/TestFunctions.java
+++ b/system-tests/e2e-federatedcatalog-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/TestFunctions.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.end2end;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.spi.query.QuerySpec;
+
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_DATA_ADDRESS;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_PROPERTIES;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_TYPE;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_ACCESSPOLICY_ID;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_ASSETS_SELECTOR;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_CONTRACTPOLICY_ID;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
+import static org.eclipse.edc.junit.testfixtures.TestUtils.getResourceFileContentAsString;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_PREFIX;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_FILTER_EXPRESSION;
+
+public class TestFunctions {
+
+    public static String createPolicy(String policyId, String assetId) {
+        return getResourceFileContentAsString("policy.json")
+                .replace("http://example.com/policy:1010", policyId)
+                .replace("http://example.com/asset:9898.movie", assetId);
+    }
+
+    public static JsonObject createAssetJson(String assetId) {
+        return Json.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder().build())
+                .add(TYPE, EDC_ASSET_TYPE)
+                .add(ID, assetId)
+                .add(EDC_ASSET_PROPERTIES, createPropertiesBuilder(assetId).build())
+                .add(EDC_ASSET_DATA_ADDRESS, createDataAddressJson())
+                .build();
+    }
+
+    public static JsonObject createContractDef(String id, String accessPolicyId, String contractPolicyId, String assetId) {
+        return Json.createObjectBuilder()
+                .add(TYPE, CONTRACT_DEFINITION_TYPE)
+                .add(ID, id)
+                .add(CONTRACT_DEFINITION_ACCESSPOLICY_ID, accessPolicyId)
+                .add(CONTRACT_DEFINITION_CONTRACTPOLICY_ID, contractPolicyId)
+                .add(CONTRACT_DEFINITION_ASSETS_SELECTOR, createCriterionBuilder(Asset.PROPERTY_ID, "=", assetId).build())
+                .build();
+    }
+
+    public static JsonObject createEmptyQuery() {
+        return Json.createObjectBuilder()
+                .add(TYPE, QuerySpec.EDC_QUERY_SPEC_TYPE)
+                .build();
+    }
+
+    public static JsonObject createQuerySpecWithFilterExpressionForAssetId(String id) {
+        return Json.createObjectBuilder()
+                .add(TYPE, QuerySpec.EDC_QUERY_SPEC_TYPE)
+                .add(EDC_QUERY_SPEC_FILTER_EXPRESSION, createCriterionBuilder("datasets.id", "=", id))
+                .build();
+    }
+
+
+    private static JsonArrayBuilder createCriterionBuilder(String operandLeft, String operator, String operandRight) {
+        return Json.createArrayBuilder()
+                .add(Json.createObjectBuilder()
+                        .add(TYPE, EDC_NAMESPACE + "Criterion")
+                        .add(EDC_NAMESPACE + "operandLeft", operandLeft)
+                        .add(EDC_NAMESPACE + "operator", operator)
+                        .add(EDC_NAMESPACE + "operandRight", operandRight)
+                );
+    }
+
+    private static JsonObjectBuilder createPropertiesBuilder(String id) {
+        return Json.createObjectBuilder()
+                .add(Asset.PROPERTY_NAME, "test-asset-" + id)
+                .add(Asset.PROPERTY_ID, id);
+    }
+
+    private static JsonObjectBuilder createContextBuilder() {
+        return Json.createObjectBuilder()
+                .add(VOCAB, EDC_NAMESPACE)
+                .add(EDC_PREFIX, EDC_NAMESPACE);
+    }
+
+    private static JsonObject createDataAddressJson() {
+        return Json.createObjectBuilder()
+                .add(TYPE, EDC_NAMESPACE + "DataAddress")
+                .add(EDC_NAMESPACE + "type", "test-src-type")
+                .build();
+    }
+}

--- a/system-tests/e2e-federatedcatalog-tests/end2end-test/e2e-junit-runner/src/test/resources/policy.json
+++ b/system-tests/e2e-federatedcatalog-tests/end2end-test/e2e-junit-runner/src/test/resources/policy.json
@@ -1,0 +1,30 @@
+{
+  "@context": {
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "uid": "@id",
+    "type": "@type",
+    "PolicyDefinition": "edc:PolicyDefinition",
+    "Policy": "odrl:Policy",
+    "Rule": "odrl:Rule",
+    "policy": {
+      "@type": "@id",
+      "@id": "edc:policy"
+    },
+    "createdAt": {
+      "@type": "@id",
+      "@id": "edc:createdAt"
+    }
+  },
+  "@type": "PolicyDefinition",
+  "policy": {
+    "@context": "http://www.w3.org/ns/odrl.jsonld",
+    "@type": "Set",
+    "uid": "http://example.com/policy:1010",
+    "permission": [
+      {
+        "target": "http://example.com/asset:9898.movie",
+        "action": "use"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What this PR changes/adds

Move the federated catalog end-to-end tests to the Connector repo. This is the last step out of 5 steps to completely move all federated catalog components. This is related to this [decision record](https://github.com/eclipse-edc/eclipse-edc.github.io/tree/ef760eeabaf0b0baa2a74580b87c2071d4419217/developer/decision-records/2026-03-02-catalog-crawler).

- [x] Move the federated catalog SPIs
- [x] Move the core components
- [x]  Move the extensions
- [x]  Move/Modify the Boms
- [x]  Move end to end tests

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #5530

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
