### PR TITLE
feat: make state machine processors return future

### DIFF
--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/ProcessorImpl.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/ProcessorImpl.java
@@ -14,8 +14,16 @@
 
 package org.eclipse.edc.statemachine;
 
+import org.eclipse.edc.spi.entity.StatefulEntity;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.statemachine.retry.EntityRetryProcessConfiguration;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Clock;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -36,50 +44,86 @@ import static java.util.function.Predicate.isEqual;
  *
  * @param <E> the entity that is processed
  */
-public class ProcessorImpl<E> implements Processor {
+public class ProcessorImpl<E extends StatefulEntity<E>> implements Processor {
 
     private final Supplier<Collection<E>> entities;
-    private Function<E, Boolean> process;
+    private final EntityRetryProcessConfiguration configuration;
+    private final Clock clock;
+    private final Monitor monitor;
+    private Function<E, CompletableFuture<StatusResult<Void>>> process;
     private Guard<E> guard = Guard.noop();
     private Consumer<E> onNotProcessed = e -> {};
 
-    private ProcessorImpl(Supplier<Collection<E>> entitiesSupplier) {
+    private ProcessorImpl(Supplier<Collection<E>> entitiesSupplier, EntityRetryProcessConfiguration entityRetryProcessConfiguration, Clock clock, Monitor monitor) {
         entities = entitiesSupplier;
+        configuration = entityRetryProcessConfiguration;
+        this.clock = clock;
+        this.monitor = monitor;
     }
 
     @Override
     public Long process() {
         return entities.get().stream()
-                .map(entity -> {
-                    var actualProcess = guard.predicate().test(entity) ? guard.process() : process;
-                    var hasBeenProcessed = actualProcess.apply(entity);
-                    if (!hasBeenProcessed) {
-                        onNotProcessed.accept(entity);
-                    }
-                    return hasBeenProcessed;
-                })
+                .map(this::process)
                 .filter(isEqual(true))
                 .count();
     }
 
-    public static class Builder<E> {
+    private @NotNull Boolean process(E entity) {
+        if (isRetry(entity)) {
+            var delay = delayMillis(entity);
+            if (delay > 0) {
+                monitor.debug(String.format("Entity %s %s retry #%d will not be attempted before %d ms.", entity.getId(), entity.getClass().getSimpleName(), entity.getStateCount() - 1, delay));
+                onNotProcessed.accept(entity);
+                return false;
+            } else {
+                monitor.debug(String.format("Entity %s %s retry #%d of %d.", entity.getId(), entity.getClass().getSimpleName(), entity.getStateCount() - 1, configuration.retryLimit()));
+            }
+        }
+
+        var actualProcess = guard.predicate().test(entity) ? guard.process() : process;
+        actualProcess.apply(entity);
+        return true;
+    }
+
+    private boolean isRetry(E entity) {
+        return entity.getStateCount() - 1 > 0;
+    }
+
+    private long delayMillis(E entity) {
+        var delayStrategy = configuration.delayStrategySupplier().get();
+
+        // Set the WaitStrategy to have observed <retryCount> previous failures.
+        // This is relevant for stateful strategies such as exponential wait.
+        delayStrategy.failures(entity.getStateCount() - 1);
+
+        // Get the delay time following the number of failures.
+        var waitMillis = delayStrategy.retryInMillis();
+
+        return entity.getStateTimestamp() + waitMillis - clock.millis();
+    }
+
+    public static class Builder<E extends StatefulEntity<E>> {
 
         private final ProcessorImpl<E> processor;
 
-        public Builder(Supplier<Collection<E>> entitiesSupplier) {
-            processor = new ProcessorImpl<>(entitiesSupplier);
+        private Builder(Supplier<Collection<E>> entitiesSupplier, EntityRetryProcessConfiguration entityRetryProcessConfiguration,
+                        Clock clock, Monitor monitor) {
+            processor = new ProcessorImpl<>(entitiesSupplier, entityRetryProcessConfiguration, clock, monitor);
         }
 
-        public static <E> Builder<E> newInstance(Supplier<Collection<E>> entitiesSupplier) {
-            return new Builder<>(entitiesSupplier);
+        public static <E extends StatefulEntity<E>> Builder<E> newInstance(Supplier<Collection<E>> entitiesSupplier,
+                                                                           EntityRetryProcessConfiguration entityRetryProcessConfiguration,
+                                                                           Clock clock, Monitor monitor) {
+            return new Builder<>(entitiesSupplier, entityRetryProcessConfiguration, clock, monitor);
         }
 
-        public Builder<E> process(Function<E, Boolean> process) {
+        public Builder<E> process(Function<E, CompletableFuture<StatusResult<Void>>> process) {
             processor.process = process;
             return this;
         }
 
-        public Builder<E> guard(Predicate<E> predicate, Function<E, Boolean> process) {
+        public Builder<E> guard(Predicate<E> predicate, Function<E, CompletableFuture<StatusResult<Void>>> process) {
             processor.guard = new Guard<>(predicate, process);
             return this;
         }
@@ -102,9 +146,9 @@ public class ProcessorImpl<E> implements Processor {
         }
     }
 
-    private record Guard<E>(Predicate<E> predicate, Function<E, Boolean> process) {
+    private record Guard<E>(Predicate<E> predicate, Function<E, CompletableFuture<StatusResult<Void>>> process) {
         static <E> Guard<E> noop() {
-            return new Guard<>(e -> false, e -> false);
+            return new Guard<>(e -> false, e -> CompletableFuture.completedFuture(StatusResult.success()));
         }
     }
 }

--- a/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/RetryProcessor.java
+++ b/core/common/lib/state-machine-lib/src/main/java/org/eclipse/edc/statemachine/retry/processor/RetryProcessor.java
@@ -16,6 +16,8 @@ package org.eclipse.edc.statemachine.retry.processor;
 
 import org.eclipse.edc.spi.entity.StatefulEntity;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.response.ResponseStatus;
+import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.statemachine.retry.EntityRetryProcessConfiguration;
 
 import java.time.Clock;
@@ -87,63 +89,39 @@ public class RetryProcessor<E extends StatefulEntity<E>, C> {
      * Execute the processes applying eventual retry policy
      * Will execute the onSuccess, onFailure, onFinalFailure handlers at need
      *
-     * @return true if the process has been run, false otherwise.
+     * @return success if the execution succeeded, failure otherwise.
      */
-    public boolean execute() {
-        if (isRetry(entity)) {
-            var delay = delayMillis(entity);
-            if (delay > 0) {
-                monitor.debug(String.format("Entity %s %s retry #%d will not be attempted before %d ms.", entity.getId(), entity.getClass().getSimpleName(), entity.getStateCount() - 1, delay));
-                return false;
-            } else {
-                monitor.debug(String.format("Entity %s %s retry #%d of %d.", entity.getId(), entity.getClass().getSimpleName(), entity.getStateCount() - 1, configuration.retryLimit()));
-            }
-        }
-
-        processChain.apply(null)
-                .whenComplete((content, throwable) -> {
+    public CompletableFuture<StatusResult<Void>> execute() {
+        return processChain.apply(null)
+                .handle((content, throwable) -> {
                     if (throwable == null) {
                         onSuccess.accept(content.entity(), content.content());
+                        return StatusResult.success();
                     } else {
                         var cause = throwable.getCause();
                         if (cause instanceof UnrecoverableEntityStateException unrecoverable) {
                             monitor.severe(unrecoverable.getUnrecoverableMessage());
                             onFinalFailure.accept(entity, unrecoverable);
+                            return StatusResult.failure(ResponseStatus.FATAL_ERROR, unrecoverable.getUnrecoverableMessage());
                         } else if (cause instanceof EntityStateException entityStateException) {
                             var exceptionEntity = entityStateException.getEntity();
                             if (exceptionEntity.getStateCount() > configuration.retryLimit()) {
                                 monitor.severe(entityStateException.getRetryLimitExceededMessage());
                                 onFinalFailure.accept(entity, entityStateException);
+                                return StatusResult.failure(ResponseStatus.FATAL_ERROR, entityStateException.getRetryLimitExceededMessage());
                             } else {
                                 monitor.debug(entityStateException.getRetryFailedMessage());
                                 onFailure.accept(entity, entityStateException);
+                                return StatusResult.failure(ResponseStatus.ERROR_RETRY, entityStateException.getRetryFailedMessage());
                             }
                         } else {
-                            monitor.severe("Runtime exception caught by retry processor: %s".formatted(cause.getMessage()), cause);
+                            var errorMessage = "Runtime exception caught by retry processor: %s".formatted(cause.getMessage());
+                            monitor.severe(errorMessage, cause);
                             onFinalFailure.accept(entity, cause);
+                            return StatusResult.failure(ResponseStatus.FATAL_ERROR, errorMessage);
                         }
                     }
                 });
-
-        return true;
-    }
-
-    private boolean isRetry(E entity) {
-        return entity.getStateCount() - 1 > 0;
-    }
-
-    private long delayMillis(E entity) {
-        // Get a new instance of WaitStrategy.
-        var delayStrategy = configuration.delayStrategySupplier().get();
-
-        // Set the WaitStrategy to have observed <retryCount> previous failures.
-        // This is relevant for stateful strategies such as exponential wait.
-        delayStrategy.failures(entity.getStateCount() - 1);
-
-        // Get the delay time following the number of failures.
-        var waitMillis = delayStrategy.retryInMillis();
-
-        return entity.getStateTimestamp() + waitMillis - clock.millis();
     }
 
 }

--- a/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/ProcessorImplTest.java
+++ b/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/ProcessorImplTest.java
@@ -14,15 +14,25 @@
 
 package org.eclipse.edc.statemachine;
 
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.retry.WaitStrategy;
+import org.eclipse.edc.statemachine.retry.EntityRetryProcessConfiguration;
 import org.eclipse.edc.statemachine.retry.TestEntity;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -30,11 +40,21 @@ import static org.mockito.Mockito.when;
 
 class ProcessorImplTest {
 
+    private static final long DELAY = 2L;
+    private final long millis = 123;
+    private final WaitStrategy fixedWaitStrategy = () -> DELAY;
+    private final long shouldDelayTime = millis - DELAY + 1;
+    private final long shouldNotDelayTime = millis - DELAY;
+    private final int retryLimit = 2;
+    private final Monitor monitor = mock();
+    private final Clock clock = Clock.fixed(Instant.ofEpochMilli(millis), UTC);
+    private final EntityRetryProcessConfiguration configuration = new EntityRetryProcessConfiguration(retryLimit, () -> fixedWaitStrategy);
+
     @Test
     void shouldReturnTheProcessedCount() {
         var entity = TestEntity.Builder.newInstance().id("id").build();
-        var processor = ProcessorImpl.Builder.newInstance(() -> List.of(entity))
-                .process(e -> true)
+        var processor = ProcessorImpl.Builder.newInstance(() -> List.of(entity), configuration, clock, monitor)
+                .process(e -> CompletableFuture.completedFuture(StatusResult.success()))
                 .build();
 
         var count = processor.process();
@@ -43,24 +63,44 @@ class ProcessorImplTest {
     }
 
     @Test
-    void shouldNotCountUnprocessedEntities() {
-        var entity = TestEntity.Builder.newInstance().id("id").build();
-        var processor = ProcessorImpl.Builder.newInstance(() -> List.of(entity))
-                .process(e -> false)
+    void shouldProcessAndLog_whenItShouldRetryButNotDelay() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).stateTimestamp(shouldNotDelayTime)
+                .stateCount(2).build();
+
+        var processor = ProcessorImpl.Builder.newInstance(() -> List.of(entity), configuration, clock, monitor)
+                .process(e -> CompletableFuture.completedFuture(StatusResult.success()))
+                .build();
+
+        var count = processor.process();
+
+        assertThat(count).isEqualTo(1);
+        verify(monitor).debug(contains("retry #1 of 2"));
+    }
+
+    @Test
+    void shouldNotProcessAndCallOnNotProcessed_whenItShouldDelay() {
+        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).stateTimestamp(shouldDelayTime).stateCount(2).build();
+        Consumer<TestEntity> onNotProcessed = mock();
+
+        var processor = ProcessorImpl.Builder.newInstance(() -> List.of(entity), configuration, clock, monitor)
+                .process(e -> CompletableFuture.completedFuture(StatusResult.success()))
+                .onNotProcessed(onNotProcessed)
                 .build();
 
         var count = processor.process();
 
         assertThat(count).isEqualTo(0);
+        verify(monitor).debug(contains("not be attempted before"));
+        verify(onNotProcessed).accept(entity);
     }
 
     @Test
     void shouldExecuteGuard_whenItsPredicateMatches() {
         var entity = TestEntity.Builder.newInstance().id("id").build();
-        Function<TestEntity, Boolean> process = mock();
-        Function<TestEntity, Boolean> guardProcess = mock();
-        when(guardProcess.apply(any())).thenReturn(true);
-        var processor = ProcessorImpl.Builder.newInstance(() -> List.of(entity))
+        Function<TestEntity, CompletableFuture<StatusResult<Void>>> process = mock();
+        Function<TestEntity, CompletableFuture<StatusResult<Void>>> guardProcess = mock();
+        when(guardProcess.apply(any())).thenReturn(CompletableFuture.completedFuture(StatusResult.success()));
+        var processor = ProcessorImpl.Builder.newInstance(() -> List.of(entity), configuration, clock, monitor)
                 .guard(e -> true, guardProcess)
                 .process(process)
                 .build();
@@ -75,10 +115,10 @@ class ProcessorImplTest {
     @Test
     void shouldExecuteDefaultProcessor_whenGuardPredicateDoesNotMatch() {
         var entity = TestEntity.Builder.newInstance().id("id").build();
-        Function<TestEntity, Boolean> process = mock();
-        Function<TestEntity, Boolean> guardProcess = mock();
-        when(process.apply(any())).thenReturn(true);
-        var processor = ProcessorImpl.Builder.newInstance(() -> List.of(entity))
+        Function<TestEntity, CompletableFuture<StatusResult<Void>>> process = mock();
+        Function<TestEntity, CompletableFuture<StatusResult<Void>>> guardProcess = mock();
+        when(process.apply(any())).thenReturn(CompletableFuture.completedFuture(StatusResult.success()));
+        var processor = ProcessorImpl.Builder.newInstance(() -> List.of(entity), configuration, clock, monitor)
                 .guard(e -> false, guardProcess)
                 .process(process)
                 .build();
@@ -91,25 +131,11 @@ class ProcessorImplTest {
     }
 
     @Test
-    void shouldExecuteOnNotProcessed_whenEntityProcessed() {
-        var entity = TestEntity.Builder.newInstance().id("id").build();
-        Consumer<TestEntity> onNotProcessed = mock();
-        var processor = ProcessorImpl.Builder.newInstance(() -> List.of(entity))
-                .process(e -> false)
-                .onNotProcessed(onNotProcessed)
-                .build();
-
-        processor.process();
-
-        verify(onNotProcessed).accept(entity);
-    }
-
-    @Test
     void shouldNotExecuteOnNotProcessed_whenEntityProcessed() {
         var entity = TestEntity.Builder.newInstance().id("id").build();
         Consumer<TestEntity> onNotProcessed = mock();
-        var processor = ProcessorImpl.Builder.newInstance(() -> List.of(entity))
-                .process(e -> true)
+        var processor = ProcessorImpl.Builder.newInstance(() -> List.of(entity), configuration, clock, monitor)
+                .process(e -> CompletableFuture.completedFuture(StatusResult.success()))
                 .onNotProcessed(onNotProcessed)
                 .build();
 
@@ -117,4 +143,5 @@ class ProcessorImplTest {
 
         verifyNoInteractions(onNotProcessed);
     }
+
 }

--- a/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/retry/processor/RetryProcessorTest.java
+++ b/core/common/lib/state-machine-lib/src/test/java/org/eclipse/edc/statemachine/retry/processor/RetryProcessorTest.java
@@ -25,6 +25,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
@@ -76,27 +77,14 @@ class RetryProcessorTest {
                 .onFinalFailure(finalFailure)
                 .execute();
 
-        assertThat(processed).isTrue();
+        assertThat(processed).succeedsWithin(1, TimeUnit.SECONDS).satisfies(status -> {
+            assertThat(status.succeeded()).isTrue();
+        });
         verify(success).accept(entity, "1 second");
         verifyNoInteractions(failure, finalFailure);
         var inOrder = inOrder(firstProcess, secondProcess);
         inOrder.verify(firstProcess).apply(any(), any());
         inOrder.verify(secondProcess).apply(any(), any());
-    }
-
-    @Test
-    void shouldNotProcess_whenItShouldDelay() {
-        var entity = TestEntity.Builder.newInstance().id(UUID.randomUUID().toString()).stateTimestamp(shouldDelayTime).stateCount(2).build();
-        BiFunction<TestEntity, Object, StatusResult<String>> process = mock();
-
-        var processed = new RetryProcessor<>(entity, monitor, clock, configuration)
-                .doProcess(result("mock", process))
-                .onSuccess(success).onFailure(failure).onFinalFailure(finalFailure)
-                .execute();
-
-        assertThat(processed).isFalse();
-        verify(monitor).debug(contains("not be attempted before"));
-        verifyNoInteractions(process, success, failure, finalFailure);
     }
 
     @Test
@@ -114,7 +102,9 @@ class RetryProcessorTest {
                 .onFinalFailure(finalFailure)
                 .execute();
 
-        assertThat(processed).isTrue();
+        assertThat(processed).succeedsWithin(1, TimeUnit.SECONDS).satisfies(status -> {
+            assertThat(status.failed()).isTrue();
+        });
         verify(failure).accept(same(entity), isA(Throwable.class));
         verifyNoInteractions(second, success, finalFailure);
     }
@@ -134,7 +124,9 @@ class RetryProcessorTest {
                 .onFinalFailure(finalFailure)
                 .execute();
 
-        assertThat(processed).isTrue();
+        assertThat(processed).succeedsWithin(1, TimeUnit.SECONDS).satisfies(status -> {
+            assertThat(status.failed()).isTrue();
+        });
         verify(failure).accept(same(entity), isA(Throwable.class));
         verify(monitor).debug(contains("failed to process. Cause: generic error"));
         verifyNoInteractions(success, finalFailure);
@@ -155,7 +147,9 @@ class RetryProcessorTest {
                 .onFinalFailure(finalFailure)
                 .execute();
 
-        assertThat(processed).isTrue();
+        assertThat(processed).succeedsWithin(1, TimeUnit.SECONDS).satisfies(status -> {
+            assertThat(status.fatalError()).isTrue();
+        });
         verify(monitor).severe(contains("failed to process. Retry limit exceeded. Cause: generic error"));
         verify(finalFailure).accept(same(entity), isA(Throwable.class));
         verifyNoInteractions(success, failure);
@@ -176,7 +170,9 @@ class RetryProcessorTest {
                 .onFinalFailure(finalFailure)
                 .execute();
 
-        assertThat(processed).isTrue();
+        assertThat(processed).succeedsWithin(1, TimeUnit.SECONDS).satisfies(status -> {
+            assertThat(status.fatalError()).isTrue();
+        });
         verify(monitor).severe(contains("failed to process. Fatal error occurred. Cause: fatal error"));
         verify(finalFailure).accept(same(entity), isA(Throwable.class));
         verifyNoInteractions(success, failure);
@@ -196,7 +192,9 @@ class RetryProcessorTest {
                 .onFinalFailure(finalFailure)
                 .execute();
 
-        assertThat(processed).isTrue();
+        assertThat(processed).succeedsWithin(1, TimeUnit.SECONDS).satisfies(status -> {
+            assertThat(status.fatalError()).isTrue();
+        });
         verify(monitor).severe(contains("generic exception"), same(runtimeException));
         verify(finalFailure).accept(same(entity), isA(Throwable.class));
         verifyNoInteractions(success, failure);

--- a/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/AbstractContractNegotiationManager.java
+++ b/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/AbstractContractNegotiationManager.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolv
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
 import org.eclipse.edc.statemachine.AbstractStateEntityManager;
 import org.eclipse.edc.statemachine.Processor;
@@ -37,6 +38,7 @@ import org.eclipse.edc.statemachine.retry.processor.RetryProcessor;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import static java.lang.String.format;
@@ -54,9 +56,9 @@ public abstract class AbstractContractNegotiationManager extends AbstractStateEn
 
     abstract ContractNegotiation.Type type();
 
-    protected Processor processNegotiationsInState(ContractNegotiationStates state, Function<ContractNegotiation, Boolean> function) {
+    protected Processor processNegotiationsInState(ContractNegotiationStates state, Function<ContractNegotiation, CompletableFuture<StatusResult<Void>>> function) {
         var filter = new Criterion[]{hasState(state.code()), isNotPending(), new Criterion("type", "=", type().name())};
-        return ProcessorImpl.Builder.newInstance(() -> store.nextNotLeased(batchSize, filter))
+        return ProcessorImpl.Builder.newInstance(() -> store.nextNotLeased(batchSize, filter), entityRetryProcessConfiguration, clock, monitor)
                 .process(telemetry.contextPropagationMiddleware(function))
                 .guard(pendingGuard, this::setPending)
                 .onNotProcessed(this::breakLease)
@@ -68,10 +70,10 @@ public abstract class AbstractContractNegotiationManager extends AbstractStateEn
      * If this succeeds, the ContractNegotiation is transitioned to state TERMINATED. Else, it is transitioned
      * to TERMINATING for a retry.
      *
-     * @return true if processed, false elsewhere
+     * @return success if succeeded, failure otherwise.
      */
     @WithSpan
-    protected boolean processTerminating(ContractNegotiation negotiation) {
+    protected CompletableFuture<StatusResult<Void>> processTerminating(ContractNegotiation negotiation) {
         var messageBuilder = ContractNegotiationTerminationMessage.Builder.newInstance()
                 .rejectionReason(negotiation.getErrorDetail())
                 .policy(negotiation.getLastContractOffer().getPolicy());
@@ -204,10 +206,10 @@ public abstract class AbstractContractNegotiationManager extends AbstractStateEn
         observable.invokeForEach(l -> l.terminated(negotiation));
     }
 
-    private boolean setPending(ContractNegotiation contractNegotiation) {
+    private CompletableFuture<StatusResult<Void>> setPending(ContractNegotiation contractNegotiation) {
         contractNegotiation.setPending(true);
         update(contractNegotiation);
-        return true;
+        return CompletableFuture.completedFuture(StatusResult.success());
     }
 
     public static class Builder<T extends AbstractContractNegotiationManager>

--- a/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -32,6 +32,7 @@ import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.statemachine.StateMachineManager;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import static java.lang.String.format;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractNegotiationEventMessage.Type.ACCEPTED;
@@ -101,9 +102,9 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
      * @return true if processed, false otherwise
      */
     @WithSpan
-    private boolean processInitial(ContractNegotiation negotiation) {
+    private CompletableFuture<StatusResult<Void>> processInitial(ContractNegotiation negotiation) {
         transitionToRequesting(negotiation);
-        return true;
+        return CompletableFuture.completedFuture(StatusResult.success());
     }
 
     /**
@@ -114,11 +115,12 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
      * @return true if processed, false otherwise
      */
     @WithSpan
-    private boolean processRequesting(ContractNegotiation negotiation) {
+    private CompletableFuture<StatusResult<Void>> processRequesting(ContractNegotiation negotiation) {
         var callbackAddress = dataspaceProfileContextRegistry.getWebhook(negotiation.getProtocol());
         if (callbackAddress == null) {
-            transitionToTerminated(negotiation, "No callback address found for protocol: %s".formatted(negotiation.getProtocol()));
-            return true;
+            var message = "No callback address found for protocol: %s".formatted(negotiation.getProtocol());
+            transitionToTerminated(negotiation, message);
+            return CompletableFuture.completedFuture(StatusResult.fatalError(message));
         }
 
         var type = negotiation.getContractOffers().size() == 1 ? Type.INITIAL : Type.COUNTER_OFFER;
@@ -142,7 +144,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
      * @return true if processed, false otherwise
      */
     @WithSpan
-    private boolean processAccepting(ContractNegotiation negotiation) {
+    private CompletableFuture<StatusResult<Void>> processAccepting(ContractNegotiation negotiation) {
         var messageBuilder = ContractNegotiationEventMessage.Builder.newInstance().type(ACCEPTED);
         messageBuilder.policy(negotiation.getLastContractOffer().getPolicy());
         return dispatch(messageBuilder, negotiation, Object.class, "[consumer] send acceptance")
@@ -158,9 +160,9 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
      * @return true if processed, false otherwise
      */
     @WithSpan
-    private boolean processAgreed(ContractNegotiation negotiation) {
+    private CompletableFuture<StatusResult<Void>> processAgreed(ContractNegotiation negotiation) {
         transitionToVerifying(negotiation);
-        return true;
+        return CompletableFuture.completedFuture(StatusResult.success());
     }
 
     /**
@@ -171,7 +173,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
      * @return true if processed, false otherwise
      */
     @WithSpan
-    private boolean processVerifying(ContractNegotiation negotiation) {
+    private CompletableFuture<StatusResult<Void>> processVerifying(ContractNegotiation negotiation) {
         var messageBuilder = ContractAgreementVerificationMessage.Builder.newInstance()
                 .policy(negotiation.getContractAgreement().getPolicy());
 

--- a/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -28,9 +28,11 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Con
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractOfferMessage;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.protocol.ContractNegotiationAck;
 import org.eclipse.edc.policy.model.PolicyType;
+import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.statemachine.StateMachineManager;
 
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import static java.lang.String.format;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.PROVIDER;
@@ -75,11 +77,12 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
      * @return true if processed, false elsewhere
      */
     @WithSpan
-    private boolean processOffering(ContractNegotiation negotiation) {
+    private CompletableFuture<StatusResult<Void>> processOffering(ContractNegotiation negotiation) {
         var callbackAddress = dataspaceProfileContextRegistry.getWebhook(negotiation.getProtocol());
         if (callbackAddress == null) {
-            transitionToTerminated(negotiation, "No callback address found for protocol: %s".formatted(negotiation.getProtocol()));
-            return true;
+            var message = "No callback address found for protocol: %s".formatted(negotiation.getProtocol());
+            transitionToTerminated(negotiation, message);
+            return CompletableFuture.completedFuture(StatusResult.fatalError(message));
         }
 
         var messageBuilder = ContractOfferMessage.Builder.newInstance()
@@ -100,9 +103,9 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
      * @return true if processed, false otherwise
      */
     @WithSpan
-    private boolean processRequested(ContractNegotiation negotiation) {
+    private CompletableFuture<StatusResult<Void>> processRequested(ContractNegotiation negotiation) {
         transitionToAgreeing(negotiation);
-        return true;
+        return CompletableFuture.completedFuture(StatusResult.success());
     }
 
     /**
@@ -111,9 +114,9 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
      * @return true if processed, false otherwise
      */
     @WithSpan
-    private boolean processAccepted(ContractNegotiation negotiation) {
+    private CompletableFuture<StatusResult<Void>> processAccepted(ContractNegotiation negotiation) {
         transitionToAgreeing(negotiation);
-        return true;
+        return CompletableFuture.completedFuture(StatusResult.success());
     }
 
     /**
@@ -124,11 +127,12 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
      * @return true if processed, false elsewhere
      */
     @WithSpan
-    private boolean processAgreeing(ContractNegotiation negotiation) {
+    private CompletableFuture<StatusResult<Void>> processAgreeing(ContractNegotiation negotiation) {
         var callbackAddress = dataspaceProfileContextRegistry.getWebhook(negotiation.getProtocol());
         if (callbackAddress == null) {
-            transitionToTerminated(negotiation, "No callback address found for protocol: %s".formatted(negotiation.getProtocol()));
-            return true;
+            var message = "No callback address found for protocol: %s".formatted(negotiation.getProtocol());
+            transitionToTerminated(negotiation, message);
+            return CompletableFuture.completedFuture(StatusResult.fatalError(message));
         }
 
         var agreement = Optional.ofNullable(negotiation.getContractAgreement())
@@ -170,9 +174,9 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
      * @return true if processed, false otherwise
      */
     @WithSpan
-    private boolean processVerified(ContractNegotiation negotiation) {
+    private CompletableFuture<StatusResult<Void>> processVerified(ContractNegotiation negotiation) {
         transitionToFinalizing(negotiation);
-        return true;
+        return CompletableFuture.completedFuture(StatusResult.success());
     }
 
     /**
@@ -183,7 +187,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
      * @return true if processed, false elsewhere
      */
     @WithSpan
-    private boolean processFinalizing(ContractNegotiation negotiation) {
+    private CompletableFuture<StatusResult<Void>> processFinalizing(ContractNegotiation negotiation) {
         var messageBuilder = ContractNegotiationEventMessage.Builder.newInstance()
                 .type(ContractNegotiationEventMessage.Type.FINALIZED)
                 .policy(negotiation.getContractAgreement().getPolicy());

--- a/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
@@ -182,13 +182,14 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
     }
 
     @WithSpan
-    private boolean processConsumerInitial(TransferProcess process) {
+    private CompletableFuture<StatusResult<Void>> processConsumerInitial(TransferProcess process) {
         var contractId = process.getContractId();
         var policy = policyArchive.findPolicyForContract(contractId);
 
         if (policy == null) {
-            transitionToTerminated(process, "Policy not found for contract: " + contractId);
-            return true;
+            var message = "Policy not found for contract: " + contractId;
+            transitionToTerminated(process, message);
+            return CompletableFuture.completedFuture(StatusResult.fatalError(message));
         }
 
         return entityRetryProcessFactory.retryProcessor(process)
@@ -216,13 +217,14 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
     }
 
     @WithSpan
-    private boolean processProviderInitial(TransferProcess process) {
+    private CompletableFuture<StatusResult<Void>> processProviderInitial(TransferProcess process) {
         var contractId = process.getContractId();
         var policy = policyArchive.findPolicyForContract(contractId);
 
         if (policy == null) {
-            transitionToTerminated(process, "Policy not found for contract: " + contractId);
-            return true;
+            var message = "Policy not found for contract: " + contractId;
+            transitionToTerminated(process, message);
+            return CompletableFuture.completedFuture(StatusResult.fatalError(message));
         }
 
         eventuallySetContentDataAddress(process);
@@ -272,19 +274,21 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
      * @return if the transfer has been processed or not
      */
     @WithSpan
-    private boolean processRequesting(TransferProcess process) {
+    private CompletableFuture<StatusResult<Void>> processRequesting(TransferProcess process) {
         var callbackAddress = dataspaceProfileContextRegistry.getWebhook(process.getProtocol());
 
         if (callbackAddress == null) {
-            transitionToTerminated(process, "No callback address found for protocol: " + process.getProtocol());
-            return true;
+            var message = "No callback address found for protocol: " + process.getProtocol();
+            transitionToTerminated(process, message);
+            return CompletableFuture.completedFuture(StatusResult.fatalError(message));
         }
 
         var agreementId = policyArchive.getAgreementIdForContract(process.getContractId());
 
         if (agreementId == null) {
-            transitionToTerminated(process, "No agreement found for contract: " + process.getContractId());
-            return true;
+            var message = "No agreement found for contract: " + process.getContractId();
+            transitionToTerminated(process, message);
+            return CompletableFuture.completedFuture(StatusResult.fatalError(message));
         }
 
         var dataAddress = dataAddressStore.resolve(process).orElse(f -> null);
@@ -313,7 +317,7 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
      * @return if the transfer has been processed or not
      */
     @WithSpan
-    private boolean processStartupRequested(TransferProcess process) {
+    private CompletableFuture<StatusResult<Void>> processStartupRequested(TransferProcess process) {
         return entityRetryProcessFactory.retryProcessor(process)
                 .doProcess(result("Notify started to data plane " + process.getCounterPartyAddress(), (t, r) ->
                         dataFlowController.started(process))
@@ -331,7 +335,7 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
      * @return if the transfer has been processed or not
      */
     @WithSpan
-    private boolean processStarting(TransferProcess process) {
+    private CompletableFuture<StatusResult<Void>> processStarting(TransferProcess process) {
         Function<RetryProcessor<TransferProcess, ?>, RetryProcessor<TransferProcess, DataAddress>> preProcessing = r -> r
                 .doProcess(result("resolve data address", (p, ignored) -> StatusResult.success(dataAddressStore.resolve(p).orElse(f -> null))));
 
@@ -345,7 +349,7 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
      * @return if the transfer has been processed or not
      */
     @WithSpan
-    private boolean processProviderResuming(TransferProcess process) {
+    private CompletableFuture<StatusResult<Void>> processProviderResuming(TransferProcess process) {
         var policy = policyArchive.findPolicyForContract(process.getContractId());
 
         Function<RetryProcessor<TransferProcess, ?>, RetryProcessor<TransferProcess, DataAddress>> preProcess = r -> r
@@ -355,7 +359,7 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
         return sendStartMessage(process, this::transitionToResuming, preProcess);
     }
 
-    private boolean sendStartMessage(TransferProcess process, Consumer<TransferProcess> onFailure, Function<RetryProcessor<TransferProcess, ?>, RetryProcessor<TransferProcess, DataAddress>> preProcessing) {
+    private CompletableFuture<StatusResult<Void>> sendStartMessage(TransferProcess process, Consumer<TransferProcess> onFailure, Function<RetryProcessor<TransferProcess, ?>, RetryProcessor<TransferProcess, DataAddress>> preProcessing) {
         return preProcessing.apply(entityRetryProcessFactory.retryProcessor(process))
                 .doProcess(futureResult("Dispatch TransferRequestMessage to: " + process.getCounterPartyAddress(), (t, dataAddress) -> {
                     var messageBuilder = TransferStartMessage.Builder.newInstance().dataAddress(dataAddress);
@@ -385,7 +389,7 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
      * @return if the transfer has been processed or not
      */
     @WithSpan
-    private boolean processConsumerResuming(TransferProcess process) {
+    private CompletableFuture<StatusResult<Void>> processConsumerResuming(TransferProcess process) {
         var messageBuilder = TransferStartMessage.Builder.newInstance();
 
         return entityRetryProcessFactory.retryProcessor(process)
@@ -405,7 +409,7 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
      * @return if the transfer has been processed or not
      */
     @WithSpan
-    private boolean processCompleting(TransferProcess process) {
+    private CompletableFuture<StatusResult<Void>> processCompleting(TransferProcess process) {
         var builder = TransferCompletionMessage.Builder.newInstance();
 
         return entityRetryProcessFactory.retryProcessor(process)
@@ -433,7 +437,7 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
      * @return if the transfer has been processed or not
      */
     @WithSpan
-    private boolean processSuspending(TransferProcess process) {
+    private CompletableFuture<StatusResult<Void>> processSuspending(TransferProcess process) {
         var builder = TransferSuspensionMessage.Builder.newInstance()
                 .reason(process.getErrorDetail());
 
@@ -468,10 +472,10 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
      * @return if the transfer has been processed or not
      */
     @WithSpan
-    private boolean processTerminating(TransferProcess process) {
+    private CompletableFuture<StatusResult<Void>> processTerminating(TransferProcess process) {
         if (process.getType() == CONSUMER && process.getState() < REQUESTED.code()) {
             transitionToTerminated(process);
-            return true;
+            return CompletableFuture.completedFuture(StatusResult.success());
         }
 
         return entityRetryProcessFactory.retryProcessor(process)
@@ -525,33 +529,33 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
         return dispatcherRegistry.dispatch(process.getParticipantContextId(), responseType, message);
     }
 
-    private Processor processConsumerTransfersInState(TransferProcessStates state, Function<TransferProcess, Boolean> function) {
+    private Processor processConsumerTransfersInState(TransferProcessStates state, Function<TransferProcess, CompletableFuture<StatusResult<Void>>> function) {
         var filter = new Criterion[]{hasState(state.code()), isNotPending(), Criterion.criterion("type", "=", CONSUMER.name())};
         return createProcessor(function, filter);
     }
 
-    private Processor processProviderTransfersInState(TransferProcessStates state, Function<TransferProcess, Boolean> function) {
+    private Processor processProviderTransfersInState(TransferProcessStates state, Function<TransferProcess, CompletableFuture<StatusResult<Void>>> function) {
         var filter = new Criterion[]{hasState(state.code()), isNotPending(), Criterion.criterion("type", "=", PROVIDER.name())};
         return createProcessor(function, filter);
     }
 
-    private Processor processTransfersInState(TransferProcessStates state, Function<TransferProcess, Boolean> function) {
+    private Processor processTransfersInState(TransferProcessStates state, Function<TransferProcess, CompletableFuture<StatusResult<Void>>> function) {
         var filter = new Criterion[]{hasState(state.code()), isNotPending()};
         return createProcessor(function, filter);
     }
 
-    private ProcessorImpl<TransferProcess> createProcessor(Function<TransferProcess, Boolean> function, Criterion[] filter) {
-        return ProcessorImpl.Builder.newInstance(() -> store.nextNotLeased(batchSize, filter))
+    private ProcessorImpl<TransferProcess> createProcessor(Function<TransferProcess, CompletableFuture<StatusResult<Void>>> function, Criterion[] filter) {
+        return ProcessorImpl.Builder.newInstance(() -> store.nextNotLeased(batchSize, filter), entityRetryProcessConfiguration, clock, monitor)
                 .process(telemetry.contextPropagationMiddleware(function))
                 .guard(pendingGuard, this::setPending)
                 .onNotProcessed(this::breakLease)
                 .build();
     }
 
-    private boolean setPending(TransferProcess transferProcess) {
+    private CompletableFuture<StatusResult<Void>> setPending(TransferProcess transferProcess) {
         transferProcess.setPending(true);
         update(transferProcess);
-        return true;
+        return CompletableFuture.completedFuture(StatusResult.success());
     }
 
     private void transitionToInitial(TransferProcess process) {

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/manager/DataPlaneManagerImpl.java
@@ -52,6 +52,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -316,16 +317,16 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
         update(dataFlow);
     }
 
-    private boolean updateFlowLease(DataFlow dataFlow) {
+    private CompletableFuture<StatusResult<Void>> updateFlowLease(DataFlow dataFlow) {
         dataFlow.setModified();
         store.save(dataFlow);
-        return true;
+        return CompletableFuture.completedFuture(StatusResult.success());
     }
 
-    private boolean restartFlow(DataFlow dataFlow) {
+    private CompletableFuture<StatusResult<Void>> restartFlow(DataFlow dataFlow) {
         monitor.debug("Restarting interrupted flow %s, it was owned by runtime %s".formatted(dataFlow.getId(), dataFlow.getRuntimeId()));
         start(dataFlow);
-        return true;
+        return CompletableFuture.completedFuture(StatusResult.success());
     }
 
     private StatusResult<DataFlow> stop(DataFlow dataFlow) {
@@ -376,7 +377,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
         return ServiceResult.success();
     }
 
-    private boolean processProvisioning(DataFlow dataFlow) {
+    private CompletableFuture<StatusResult<Void>> processProvisioning(DataFlow dataFlow) {
         return entityRetryProcessFactory.retryProcessor(dataFlow)
                 .doProcess(future("provisioning", (flow, e) -> provisionerManager.provision(flow.resourcesToBeProvisioned())))
                 .onSuccess((flow, results) -> {
@@ -406,7 +407,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
                 .execute();
     }
 
-    private boolean processProvisionNotifying(DataFlow dataFlow) {
+    private CompletableFuture<StatusResult<Void>> processProvisionNotifying(DataFlow dataFlow) {
         return entityRetryProcessFactory.retryProcessor(dataFlow)
                 .doProcess(result("provision notifying", (flow, e) -> transferProcessClient.provisioned(flow)))
                 .onSuccess((flow, v) -> {
@@ -429,7 +430,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
                 .execute();
     }
 
-    private boolean processDeprovisioning(DataFlow dataFlow) {
+    private CompletableFuture<StatusResult<Void>> processDeprovisioning(DataFlow dataFlow) {
         return entityRetryProcessFactory.retryProcessor(dataFlow)
                 .doProcess(future("deprovisioning", (flow, e) -> provisionerManager.deprovision(flow.resourcesToBeDeprovisioned())))
                 .onSuccess((flow, results) -> {
@@ -456,14 +457,15 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
                 .execute();
     }
 
-    private boolean processReceived(DataFlow dataFlow) {
+    private CompletableFuture<StatusResult<Void>> processReceived(DataFlow dataFlow) {
         var request = dataFlow.toRequest();
         var transferService = transferServiceRegistry.resolveTransferService(request);
 
         if (transferService == null) {
-            dataFlow.transitToFailed("No transferService available for DataFlow " + dataFlow.getId());
+            var message = "No transferService available for DataFlow " + dataFlow.getId();
+            dataFlow.transitToFailed(message);
             update(dataFlow);
-            return true;
+            return CompletableFuture.completedFuture(StatusResult.fatalError(message));
         }
 
         return entityRetryProcessFactory.retryProcessor(dataFlow)
@@ -508,7 +510,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
                 });
     }
 
-    private boolean processCompleted(DataFlow dataFlow) {
+    private CompletableFuture<StatusResult<Void>> processCompleted(DataFlow dataFlow) {
         return entityRetryProcessFactory.retryProcessor(dataFlow)
                 .doProcess(Process.result("Complete data flow", (d, v) -> transferProcessClient.completed(dataFlow)))
                 .onSuccess((d, v) -> {
@@ -530,7 +532,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
                 .execute();
     }
 
-    private boolean processFailed(DataFlow dataFlow) {
+    private CompletableFuture<StatusResult<Void>> processFailed(DataFlow dataFlow) {
         return entityRetryProcessFactory.retryProcessor(dataFlow)
                 .doProcess(Process.result("Fail data flow", (d, v) -> transferProcessClient.failed(dataFlow, dataFlow.getErrorDetail())))
                 .onSuccess((d, v) -> {
@@ -549,7 +551,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
     }
 
     @SafeVarargs
-    private Processor processDataFlowInState(DataFlowStates state, Function<DataFlow, Boolean> function, Supplier<Criterion>... additionalCriteria) {
+    private Processor processDataFlowInState(DataFlowStates state, Function<DataFlow, CompletableFuture<StatusResult<Void>>> function, Supplier<Criterion>... additionalCriteria) {
         Supplier<Collection<DataFlow>> entitiesSupplier = () -> {
             var additional = Arrays.stream(additionalCriteria).map(Supplier::get);
             var filter = Stream.concat(Stream.of(new Criterion[]{hasState(state.code())}), additional)
@@ -557,7 +559,7 @@ public class DataPlaneManagerImpl extends AbstractStateEntityManager<DataFlow, D
             return store.nextNotLeased(batchSize, filter);
         };
 
-        return ProcessorImpl.Builder.newInstance(entitiesSupplier)
+        return ProcessorImpl.Builder.newInstance(entitiesSupplier, entityRetryProcessConfiguration, clock, monitor)
                 .process(telemetry.contextPropagationMiddleware(function))
                 .onNotProcessed(this::breakLease)
                 .build();

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImpl.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImpl.java
@@ -25,12 +25,14 @@ import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorManager;
 import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorStore;
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.statemachine.AbstractStateEntityManager;
 import org.eclipse.edc.statemachine.Processor;
 import org.eclipse.edc.statemachine.ProcessorImpl;
 import org.eclipse.edc.statemachine.StateMachineManager;
 
 import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.STARTED;
@@ -69,25 +71,27 @@ public class PolicyMonitorManagerImpl extends AbstractStateEntityManager<PolicyM
                 .processor(processEntriesInState(STARTED, this::processMonitoring));
     }
 
-    private boolean processMonitoring(PolicyMonitorEntry entry) {
+    private CompletableFuture<StatusResult<Void>> processMonitoring(PolicyMonitorEntry entry) {
         var transferProcess = transferProcessService.findById(entry.getId());
         if (transferProcess == null) {
-            entry.transitionToFailed("TransferProcess %s does not exist".formatted(entry.getId()));
+            var message = "TransferProcess %s does not exist".formatted(entry.getId());
+            entry.transitionToFailed(message);
             update(entry);
-            return true;
+            return CompletableFuture.completedFuture(StatusResult.fatalError(message));
         }
 
         if (transferProcess.getState() >= TransferProcessStates.COMPLETING.code()) {
             entry.transitionToCompleted();
             update(entry);
-            return true;
+            return CompletableFuture.completedFuture(StatusResult.success());
         }
 
         var contractAgreement = contractAgreementService.findById(entry.getContractId());
         if (contractAgreement == null) {
-            entry.transitionToFailed("ContractAgreement %s does not exist".formatted(entry.getContractId()));
+            var message = "ContractAgreement %s does not exist".formatted(entry.getContractId());
+            entry.transitionToFailed(message);
             update(entry);
-            return true;
+            return CompletableFuture.completedFuture(StatusResult.fatalError(message));
         }
 
         var policy = contractAgreement.getPolicy();
@@ -101,21 +105,22 @@ public class PolicyMonitorManagerImpl extends AbstractStateEntityManager<PolicyM
             if (terminationResult.succeeded()) {
                 entry.transitionToCompleted();
                 update(entry);
-                return true;
+                return CompletableFuture.completedFuture(StatusResult.success());
             }
         }
 
         // we update the state timestamp ensure fairness on polling on  `STARTED` state
         // the lease will be broken in `onNotProcessed`
         entry.updateStateTimestamp();
-        return false;
+        update(entry);
+        return CompletableFuture.completedFuture(StatusResult.success());
     }
 
-    private Processor processEntriesInState(PolicyMonitorEntryStates state, Function<PolicyMonitorEntry, Boolean> function) {
+    private Processor processEntriesInState(PolicyMonitorEntryStates state, Function<PolicyMonitorEntry, CompletableFuture<StatusResult<Void>>> function) {
         var filter = new Criterion[]{ hasState(state.code()) };
-        return ProcessorImpl.Builder.newInstance(() -> store.nextNotLeased(batchSize, filter))
+        return ProcessorImpl.Builder.newInstance(() -> store.nextNotLeased(batchSize, filter), entityRetryProcessConfiguration, clock, monitor)
                 .process(telemetry.contextPropagationMiddleware(function))
-                .onNotProcessed(this::update)
+                .onNotProcessed(this::breakLease)
                 .build();
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Makes "manager" processors method return `CompletableFuture<StatusResult<Void>>` instead of boolean

## Why it does that

EDC-V integration

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
