### PR TITLE
refactor: rename participant DID setting

### DIFF
--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/build.gradle.kts
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(project(":spi:common:participant-spi"))
     implementation(project(":spi:common:participant-context-config-spi"))
     implementation(project(":spi:common:protocol-spi"))
+
     implementation(project(":core:common:lib:util-lib"))
     implementation(project(":core:common:lib:crypto-common-lib"))
     implementation(project(":core:common:lib:token-lib"))

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpCoreExtension.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpCoreExtension.java
@@ -23,7 +23,6 @@ import org.eclipse.edc.iam.decentralizedclaims.spi.ClaimTokenCreatorFunction;
 import org.eclipse.edc.iam.decentralizedclaims.spi.DcpParticipantAgentServiceExtension;
 import org.eclipse.edc.iam.decentralizedclaims.spi.PresentationRequestService;
 import org.eclipse.edc.iam.decentralizedclaims.spi.SecureTokenService;
-import org.eclipse.edc.iam.decentralizedclaims.spi.validation.TokenValidationAction;
 import org.eclipse.edc.iam.decentralizedclaims.spi.verification.SignatureSuiteRegistry;
 import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
@@ -57,7 +56,6 @@ import org.eclipse.edc.verifiablecredentials.jwt.rules.SubJwkIsNullRule;
 import org.eclipse.edc.verifiablecredentials.jwt.rules.TokenNotNullRule;
 import org.eclipse.edc.verifiablecredentials.linkeddata.DidMethodResolver;
 import org.eclipse.edc.verifiablecredentials.linkeddata.LdpVerifier;
-import org.jetbrains.annotations.NotNull;
 
 import java.net.URISyntaxException;
 import java.time.Clock;
@@ -76,66 +74,64 @@ public class DcpCoreExtension implements ServiceExtension {
     public static final String JSON_2020_SIGNATURE_SUITE = "JsonWebSignature2020";
     public static final long DEFAULT_CLEANUP_PERIOD_SECONDS = 60;
 
-    @Setting(description = "DID of the participant")
-    private static final String ISSUER_ID_KEY = "edc.iam.issuer.id";
-    @Setting(description = "The period of the JTI entry reaper thread in seconds", defaultValue = DEFAULT_CLEANUP_PERIOD_SECONDS + "", key = "edc.sql.store.jti.cleanup.period")
+    @Setting(description = "DID of the participant, only needed if different from the value in edc.participant.id", required = false)
+    public static final String PARTICIPANT_DID = "edc.participant.did";
+
+    @Setting(description = "DEPRECATED: DID of the participant, please refer to " + PARTICIPANT_DID)
+    @Deprecated(since = "0.17.0")
+    public static final String DEPRECATED_ISSUER_ID_KEY = "edc.iam.issuer.id";
+
+    @Setting(
+            key = "edc.sql.store.jti.cleanup.period",
+            description = "The period of the JTI entry reaper thread in seconds",
+            defaultValue = DEFAULT_CLEANUP_PERIOD_SECONDS + "")
     private long reaperCleanupPeriod;
-    @Setting(description = "Activate or deactivate JTI validation", key = "edc.iam.accesstoken.jti.validation", defaultValue = "true")
+
+    @Setting(
+            key = "edc.iam.accesstoken.jti.validation",
+            description = "Activate or deactivate JTI validation",
+            defaultValue = "true")
     private boolean activateJtiValidation;
 
     @Inject
     private SecureTokenService secureTokenService;
-
     @Inject
     private TrustedIssuerRegistry trustedIssuerRegistry;
-
     @Inject
     private TypeManager typeManager;
-
     @Inject
     private SignatureSuiteRegistry signatureSuiteRegistry;
-
     @Inject
     private JsonLd jsonLd;
-
     @Inject
     private Clock clock;
     @Inject
     private DidResolverRegistry didResolverRegistry;
-
     @Inject
     private TokenValidationService tokenValidationService;
-
     @Inject
     private TokenValidationRulesRegistry rulesRegistry;
     @Inject
     private DidPublicKeyResolver didPublicKeyResolver;
     @Inject
     private ClaimTokenCreatorFunction claimTokenFunction;
-
     @Inject
     private ParticipantAgentService participantAgentService;
-
     @Inject(required = false)
     private DcpParticipantAgentServiceExtension participantAgentServiceExtension;
-
     @Inject
     private RevocationServiceRegistry revocationServiceRegistry;
-
     @Inject
     private ParticipantContextConfig participantContextConfig;
-
     @Inject
     private JtiValidationStore jtiValidationStore;
     @Inject
     private ExecutorInstrumentation executorInstrumentation;
-
     @Inject
     private PresentationRequestService presentationRequestService;
 
     private PresentationVerifier presentationVerifier;
     private ScheduledFuture<?> jtiEntryReaperThread;
-
 
     @Override
     public void initialize(ServiceExtensionContext context) {
@@ -188,12 +184,13 @@ public class DcpCoreExtension implements ServiceExtension {
 
     @Provider
     public IdentityService createIdentityService(ServiceExtensionContext context) {
-        var validationAction = tokenValidationAction();
+        var didConfigProvider = new DidConfigProvider(participantContextConfig, context.getMonitor());
+        var validationAction = new SelfIssueIdTokenValidationAction(tokenValidationService, rulesRegistry, didPublicKeyResolver, didConfigProvider);
 
         var credentialValidationService = new VerifiableCredentialValidationServiceImpl(createPresentationVerifier(context),
                 trustedIssuerRegistry, revocationServiceRegistry, clock, typeManager.getMapper());
 
-        return new DcpIdentityService(secureTokenService, this::didResolver, validationAction,
+        return new DcpIdentityService(secureTokenService, didConfigProvider, validationAction,
                 presentationRequestService, claimTokenFunction, credentialValidationService);
     }
 
@@ -213,15 +210,6 @@ public class DcpCoreExtension implements ServiceExtension {
             presentationVerifier = new MultiFormatPresentationVerifier(jwtVerifier, ldpVerifier);
         }
         return presentationVerifier;
-    }
-
-    private String didResolver(String participantContext) {
-        return participantContextConfig.getString(participantContext, ISSUER_ID_KEY);
-    }
-
-    @NotNull
-    private TokenValidationAction tokenValidationAction() {
-        return new SelfIssueIdTokenValidationAction(tokenValidationService, rulesRegistry, didPublicKeyResolver, this::didResolver);
     }
 
 }

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/DidConfigProvider.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/DidConfigProvider.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.decentralizedclaims.core;
+
+import org.eclipse.edc.participantcontext.spi.config.ParticipantContextConfig;
+import org.eclipse.edc.spi.monitor.Monitor;
+
+import java.util.function.Function;
+
+import static org.eclipse.edc.iam.decentralizedclaims.core.DcpCoreExtension.DEPRECATED_ISSUER_ID_KEY;
+import static org.eclipse.edc.iam.decentralizedclaims.core.DcpCoreExtension.PARTICIPANT_DID;
+
+/**
+ * Provide configured DID.
+ */
+public class DidConfigProvider implements Function<String, String> {
+
+    public static final String PARTICIPANT_ID = "edc.participant.id";
+
+    private final ParticipantContextConfig config;
+    private final Monitor monitor;
+
+    public DidConfigProvider(ParticipantContextConfig config, Monitor monitor) {
+        this.config = config;
+        this.monitor = monitor;
+    }
+
+    @Override
+    public String apply(String participantContextId) {
+        var participantId = config.getString(participantContextId, PARTICIPANT_ID, null);
+        if (participantId != null) {
+            return participantId;
+        }
+
+        var participantDid = config.getString(participantContextId, PARTICIPANT_DID, null);
+        if (participantDid != null) {
+            return participantDid;
+        }
+
+        var participantDidDeprecated = config.getString(participantContextId, DEPRECATED_ISSUER_ID_KEY, null);
+        if (participantDidDeprecated != null) {
+            monitor.warning("Setting %s has been deprecated in favor of %s (or %s if the value configured is already the participant DID), please adapt your configuration"
+                    .formatted(DEPRECATED_ISSUER_ID_KEY, PARTICIPANT_DID, PARTICIPANT_ID));
+            return participantDidDeprecated;
+        }
+
+        return null;
+    }
+}

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpCoreExtensionTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpCoreExtensionTest.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.iam.decentralizedclaims.core.DcpCoreExtension.DCP_SELF_ISSUED_TOKEN_CONTEXT;
+import static org.eclipse.edc.iam.decentralizedclaims.core.DcpCoreExtension.DEPRECATED_ISSUER_ID_KEY;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -54,7 +55,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(DependencyInjectionExtension.class)
 class DcpCoreExtensionTest {
 
-    private static final String CONNECTOR_DID_PROPERTY = "edc.iam.issuer.id";
     private static final String CLEANUP_PERIOD = "edc.sql.store.jti.cleanup.period";
     private final JtiValidationStore storeMock = mock();
     private final TypeTransformerRegistry transformerRegistry = mock();
@@ -70,9 +70,8 @@ class DcpCoreExtensionTest {
         context.registerService(TokenValidationRulesRegistry.class, rulesRegistry);
 
         var config = ConfigFactory.fromMap(Map.of(
-                CONNECTOR_DID_PROPERTY, "did:web:test",
+                DEPRECATED_ISSUER_ID_KEY, "did:web:test",
                 CLEANUP_PERIOD, "1"
-
         ));
         when(context.getConfig()).thenReturn(config);
     }
@@ -104,7 +103,6 @@ class DcpCoreExtensionTest {
         assertThat(rulesRegistry.getRules(DCP_SELF_ISSUED_TOKEN_CONTEXT))
                 .extracting(TokenValidationRule::getClass)
                 .containsExactlyInAnyOrderElementsOf(expectedRules);
-
     }
 
     @Test
@@ -139,4 +137,14 @@ class DcpCoreExtensionTest {
                 .untilAsserted(() -> verify(storeMock, atLeastOnce()).deleteExpired());
     }
 
+    @Test
+    void shouldFallbackToParticipantId_whenDidNotSet(ServiceExtensionContext context, ObjectFactory objectFactory) {
+        var config = ConfigFactory.fromMap(Map.of(
+                "edc.participant.id", "did:web:test",
+                CLEANUP_PERIOD, "1"
+        ));
+        when(context.getConfig()).thenReturn(config);
+
+        objectFactory.constructInstance(DcpCoreExtension.class);
+    }
 }

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/DidConfigProviderTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/DidConfigProviderTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.decentralizedclaims.core;
+
+import org.eclipse.edc.participantcontext.spi.config.ParticipantContextConfig;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.iam.decentralizedclaims.core.DcpCoreExtension.DEPRECATED_ISSUER_ID_KEY;
+import static org.eclipse.edc.iam.decentralizedclaims.core.DcpCoreExtension.PARTICIPANT_DID;
+import static org.eclipse.edc.iam.decentralizedclaims.core.DidConfigProvider.PARTICIPANT_ID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DidConfigProviderTest {
+
+    private final ParticipantContextConfig config = mock();
+    private final Monitor monitor = mock();
+    private final DidConfigProvider provider = new DidConfigProvider(config, monitor);
+
+    @Test
+    void shouldReturnNullIfNoDidConfigured() {
+        when(config.getString(any(), any(), any())).thenReturn(null);
+
+        var did = provider.apply("participantContextId");
+
+        assertThat(did).isNull();
+    }
+
+    @Test
+    void shouldReturnConfiguredParticipantId() {
+        when(config.getString(any(), eq(PARTICIPANT_ID), any())).thenReturn("did:participant");
+
+        var did = provider.apply("participantContextId");
+
+        assertThat(did).isEqualTo("did:participant");
+    }
+
+    @Test
+    void shouldFallbackToParticipantDid_whenParticipantIdNotConfigured() {
+        when(config.getString(any(), eq(PARTICIPANT_ID), any())).thenReturn(null);
+        when(config.getString(any(), eq(PARTICIPANT_DID), any())).thenReturn("did:participant:value");
+
+        var did = provider.apply("participantContextId");
+
+        assertThat(did).isEqualTo("did:participant:value");
+    }
+
+    @Test
+    void shouldFallbackToDeprecatedSetting_whenAllTheOthersAreNull() {
+        when(config.getString(any(), eq(PARTICIPANT_ID), any())).thenReturn(null);
+        when(config.getString(any(), eq(PARTICIPANT_DID), any())).thenReturn(null);
+        when(config.getString(any(), eq(DEPRECATED_ISSUER_ID_KEY), any())).thenReturn("did:participant:deprecated");
+
+        var did = provider.apply("participantContextId");
+
+        assertThat(did).isEqualTo("did:participant:deprecated");
+        verify(monitor).warning(anyString());
+    }
+}

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/validation/SelfIssueIdTokenValidationActionComponentTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/validation/SelfIssueIdTokenValidationActionComponentTest.java
@@ -50,6 +50,7 @@ import java.util.Date;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.iam.decentralizedclaims.core.DcpCoreExtension.PARTICIPANT_DID;
 import static org.eclipse.edc.iam.decentralizedclaims.spi.TestFunctions.createToken;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -64,7 +65,6 @@ public class SelfIssueIdTokenValidationActionComponentTest {
     public static final String CONSUMER_DID = "did:web:consumer";
     public static final String CONSUMER_DID_KEY = "did:web:consumer#key";
     public static final String EXPECTED_AUDIENCE = "did:web:test";
-    private static final String CONNECTOR_DID_PROPERTY = "edc.iam.issuer.id";
     private static final String CLEANUP_PERIOD = "edc.sql.store.jti.cleanup.period";
     private static final ECKeyGenerator EC_KEY_GENERATOR = new ECKeyGenerator(Curve.P_256);
     private final JtiValidationStore storeMock = mock();
@@ -94,7 +94,7 @@ public class SelfIssueIdTokenValidationActionComponentTest {
         context.registerService(TokenValidationService.class, tokenValidationService);
 
         var config = ConfigFactory.fromMap(Map.of(
-                CONNECTOR_DID_PROPERTY, EXPECTED_AUDIENCE,
+                PARTICIPANT_DID, EXPECTED_AUDIENCE,
                 CLEANUP_PERIOD, "1"
         ));
         when(context.getConfig()).thenReturn(config);

--- a/resources/openapi/catalog-api.version
+++ b/resources/openapi/catalog-api.version
@@ -1,1 +1,0 @@
-extensions/federated-catalog/api/federated-catalog-api/src/main/resources/catalog-version.json

--- a/system-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
+++ b/system-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
@@ -73,7 +73,7 @@ public class BomSmokeTests {
                                     put("web.http.management.path", "/api/management");
                                     put("edc.iam.sts.privatekey.alias", "privatekey");
                                     put("edc.iam.sts.publickey.id", "publickey");
-                                    put("edc.iam.issuer.id", "did:web:someone");
+                                    put("edc.participant.did", "did:web:someone");
                                 }})
                         )
         );
@@ -97,7 +97,7 @@ public class BomSmokeTests {
                                 put("web.http.catalog.path", "/api/catalog");
                                 put("web.http.version.port", String.valueOf(getFreePort()));
                                 put("edc.catalog.cache.execution.period.seconds", "5");
-                                put("edc.iam.issuer.id", "did:web:testparticipant");
+                                put("edc.participant.did", "did:web:testparticipant");
                                 put("edc.iam.sts.privatekey.alias", "private-alias");
                                 put("edc.iam.sts.publickey.id", "public-key-id");
                                 put("edc.catalog.cache.execution.delay.seconds", "0");

--- a/system-tests/tck/dcp-tck-tests/src/test/java/org/eclipse/edc/tck/dcp/presentation/DcpPresentationFlowTest.java
+++ b/system-tests/tck/dcp-tck-tests/src/test/java/org/eclipse/edc/tck/dcp/presentation/DcpPresentationFlowTest.java
@@ -93,7 +93,7 @@ public class DcpPresentationFlowTest {
                             // use DSP endpoints as trigger endpoint
                             "web.http.protocol.path", PROTOCOL_API_PATH,
                             "web.http.protocol.port", PROTOCOL_API_PORT,
-                            "edc.iam.issuer.id", VERIFIER_DID,
+                            "edc.participant.did", VERIFIER_DID,
                             "edc.iam.sts.oauth.token.url", "https://example.com/token",
                             "edc.iam.sts.oauth.client.id", "test-client-id",
                             "edc.iam.sts.oauth.client.secret.alias", "test-secret-alias"

--- a/system-tests/tck/dcp-tck-tests/src/test/java/org/eclipse/edc/tck/dcp/presentation/DcpPresentationFlowWithDockerTest.java
+++ b/system-tests/tck/dcp-tck-tests/src/test/java/org/eclipse/edc/tck/dcp/presentation/DcpPresentationFlowWithDockerTest.java
@@ -95,7 +95,7 @@ public class DcpPresentationFlowWithDockerTest {
                             "web.http.port", String.valueOf(getFreePort()),
                             "web.http.protocol.path", PROTOCOL_API_PATH,
                             "web.http.protocol.port", PROTOCOL_API_PORT,
-                            "edc.iam.issuer.id", VERIFIER_DID,
+                            "edc.participant.did", VERIFIER_DID,
                             "edc.iam.sts.oauth.token.url", "https://example.com/token",
                             "edc.iam.sts.oauth.client.id", "test-client-id",
                             "edc.iam.sts.oauth.client.secret.alias", "test-secret-alias"


### PR DESCRIPTION
## What this PR changes/adds

Renamed the misleading `edc.iam.issuer.id` setting to `edc.participant.did`.
The first choice, BTW, will be to use `edc.participant.id`, as for 99% of the cases that will coincide with the DID. `edc.participant.did` could be set the audience.

`edc.iam.issuer.id` has been deprecated, but still working.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5302 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
