### PR TITLE
feat: port authz and authn for mgmt api

### DIFF
--- a/extensions/common/api/management-api-authorization/build.gradle.kts
+++ b/extensions/common/api/management-api-authorization/build.gradle.kts
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+dependencies {
+    api(project(":spi:common:auth-spi"))
+    api(libs.jakarta.rsApi)
+    implementation(project(":extensions:common:auth:auth-authorization-oauth2-lib"))
+    implementation(libs.jakarta.annotation)
+}

--- a/extensions/common/api/management-api-authorization/src/main/java/org/eclipse/edc/connector/api/management/authz/ManagementApiAuthorizationExtension.java
+++ b/extensions/common/api/management-api-authorization/src/main/java/org/eclipse/edc/connector/api/management/authz/ManagementApiAuthorizationExtension.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.authz;
+
+import org.eclipse.edc.api.auth.spi.AuthorizationService;
+import org.eclipse.edc.api.authorization.filter.RoleBasedAccessFeature;
+import org.eclipse.edc.api.authorization.filter.ScopeBasedAccessFeature;
+import org.eclipse.edc.api.authorization.service.AuthorizationServiceImpl;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+
+import static org.eclipse.edc.connector.api.management.authz.ManagementApiAuthorizationExtension.NAME;
+
+@Extension(NAME)
+public class ManagementApiAuthorizationExtension implements ServiceExtension {
+
+    public static final String NAME = "Management API Authorization Extension";
+    @Inject
+    private WebService webService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var alias = ApiContext.MANAGEMENT;
+        webService.registerResource(alias, new RoleBasedAccessFeature());
+        webService.registerResource(alias, new ScopeBasedAccessFeature());
+    }
+
+    @Provider
+    public AuthorizationService authorizationService() {
+        return new AuthorizationServiceImpl();
+    }
+
+
+}

--- a/extensions/common/api/management-api-authorization/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/common/api/management-api-authorization/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.connector.api.management.authz.ManagementApiAuthorizationExtension

--- a/extensions/common/api/management-api-oauth2-authentication/build.gradle.kts
+++ b/extensions/common/api/management-api-oauth2-authentication/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+dependencies {
+    api(project(":spi:common:web-spi"))
+    implementation(project(":core:common:lib:token-lib"))
+    implementation(project(":core:common:lib:crypto-common-lib"))
+    implementation(project(":core:common:lib:keys-lib"))
+    implementation(project(":extensions:common:auth:auth-authentication-oauth2-lib"))
+    implementation(libs.jakarta.rsApi)
+    implementation(libs.jakarta.annotation)
+
+    testImplementation(project(":core:common:junit"))
+    testRuntimeOnly(libs.jersey.common) // needs the RuntimeDelegate
+}

--- a/extensions/common/api/management-api-oauth2-authentication/src/main/java/org/eclipse/edc/connector/api/management/authn/ManagementApiOauth2AuthenticationExtension.java
+++ b/extensions/common/api/management-api-oauth2-authentication/src/main/java/org/eclipse/edc/connector/api/management/authn/ManagementApiOauth2AuthenticationExtension.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.authn;
+
+import org.eclipse.edc.api.authentication.JwksResolver;
+import org.eclipse.edc.api.authentication.filter.JwtValidatorFilter;
+import org.eclipse.edc.api.authentication.filter.ServicePrincipalAuthenticationFilter;
+import org.eclipse.edc.keys.spi.KeyParserRegistry;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.token.rules.ExpirationIssuedAtValidationRule;
+import org.eclipse.edc.token.rules.IssuerEqualsValidationRule;
+import org.eclipse.edc.token.rules.NotBeforeValidationRule;
+import org.eclipse.edc.token.spi.TokenValidationRule;
+import org.eclipse.edc.token.spi.TokenValidationService;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Clock;
+import java.util.List;
+
+import static org.eclipse.edc.connector.api.management.authn.ManagementApiOauth2AuthenticationExtension.NAME;
+
+@Extension(NAME)
+public class ManagementApiOauth2AuthenticationExtension implements ServiceExtension {
+
+    public static final String NAME = "Management API OAuth2 Authentication Extension";
+    private static final long FIVE_MINUTES = 1000 * 60 * 5;
+    @Inject
+    private WebService webService;
+    @Inject
+    private Clock clock;
+    @Inject
+    private KeyParserRegistry keyParserRegistry;
+    @Inject
+    private ParticipantContextService participantContextService;
+    @Configuration
+    private OauthConfiguration oauthConfiguration;
+    @Inject
+    private TokenValidationService tokenValidationService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var alias = ApiContext.MANAGEMENT;
+        webService.registerResource(alias, new ServicePrincipalAuthenticationFilter(participantContextService));
+
+        URL url;
+        try {
+            url = new URL(oauthConfiguration.jwksUrl());
+        } catch (MalformedURLException e) {
+            throw new EdcException(e);
+        }
+        webService.registerResource(alias, new JwtValidatorFilter(tokenValidationService, new JwksResolver(url, keyParserRegistry, oauthConfiguration.cacheValidityInMillis), getRules()));
+    }
+
+    private List<TokenValidationRule> getRules() {
+        return List.of(
+                new IssuerEqualsValidationRule(oauthConfiguration.expectedIssuer),
+                new NotBeforeValidationRule(clock, 0, true),
+                new ExpirationIssuedAtValidationRule(clock, 0, false)
+        );
+    }
+
+    @Settings
+    record OauthConfiguration(
+            @Setting(key = "edc.iam.oauth2.issuer", description = "Issuer of the OAuth2 server", required = false)
+            String expectedIssuer,
+            @Setting(key = "edc.iam.oauth2.jwks.url", description = "Absolute URL where the JWKS of the OAuth2 server is hosted")
+            String jwksUrl,
+            @Setting(key = "edc.iam.oauth2.jwks.cache.validity", description = "Time (in ms) that cached JWKS are cached", defaultValue = "" + FIVE_MINUTES)
+            long cacheValidityInMillis
+    ) {
+
+    }
+}

--- a/extensions/common/api/management-api-oauth2-authentication/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/common/api/management-api-oauth2-authentication/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.connector.api.management.authn.ManagementApiOauth2AuthenticationExtension

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -195,6 +195,8 @@ include(":extensions:federated-catalog:store:sql:target-node-directory-sql")
 include(":extensions:common:api:control-api-configuration")
 include(":extensions:common:api:management-api-configuration")
 include(":extensions:common:api:management-api-schema-validator")
+include(":extensions:common:api:management-api-authorization")
+include(":extensions:common:api:management-api-oauth2-authentication")
 include(":extensions:federated-catalog:api:federated-catalog-api")
 
 include(":extensions:control-plane:api:control-plane-api")


### PR DESCRIPTION
## What this PR changes/adds

Port authz and authn extensions for mgmt api from virtual connector.

Applied the naming Management in those two extensions since they refer to the management api context only

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5564 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
