### PR TITLE
feat: adapt DPS registration to the latest spec

### DIFF
--- a/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/service/EmbeddedDataPlaneSelectorService.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/service/EmbeddedDataPlaneSelectorService.java
@@ -113,8 +113,7 @@ public class EmbeddedDataPlaneSelectorService implements DataPlaneSelectorServic
     public ServiceResult<Void> register(DataPlaneInstance instance) {
         return transactionContext.execute(() -> {
             instance.transitionToRegistered();
-            store.save(instance);
-            return ServiceResult.success();
+            return store.save(instance).flatMap(ServiceResult::from);
         });
     }
 
@@ -135,17 +134,6 @@ public class EmbeddedDataPlaneSelectorService implements DataPlaneSelectorServic
 
             return ServiceResult.from(operation);
         });
-    }
-
-    @Override
-    public ServiceResult<Void> update(DataPlaneInstance instance) {
-        return transactionContext.execute(() -> store.findByIdAndLease(instance.getId())
-                .map(stored -> stored.toBuilder()
-                        .url(instance.getUrl())
-                        .allowedTransferType(instance.getAllowedTransferTypes())
-                        .build())
-                .compose(store::save)
-                .flatMap(ServiceResult::from));
     }
 
     @Override

--- a/core/data-plane-selector/data-plane-selector-core/src/test/java/org/eclipse/edc/connector/dataplane/selector/service/EmbeddedDataPlaneSelectorServiceTest.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/test/java/org/eclipse/edc/connector/dataplane/selector/service/EmbeddedDataPlaneSelectorServiceTest.java
@@ -277,12 +277,23 @@ public class EmbeddedDataPlaneSelectorServiceTest {
     class Register {
         @Test
         void shouldSaveRegisteredInstance() {
+            when(store.save(any())).thenReturn(StoreResult.success());
             var instance = DataPlaneInstance.Builder.newInstance().url("http://any").build();
 
             var result = service.register(instance);
 
             assertThat(result).isSucceeded();
             verify(store).save(argThat(it -> it.getState() == REGISTERED.code()));
+        }
+
+        @Test
+        void shouldFail_whenStoreFails() {
+            when(store.save(any())).thenReturn(StoreResult.generalError("error"));
+            var instance = DataPlaneInstance.Builder.newInstance().url("http://any").build();
+
+            var result = service.register(instance);
+
+            assertThat(result).isFailed();
         }
     }
 
@@ -306,35 +317,6 @@ public class EmbeddedDataPlaneSelectorServiceTest {
             var result = service.unregister(UUID.randomUUID().toString());
 
             assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(CONFLICT);
-            verify(store, never()).save(any());
-        }
-    }
-
-    @Nested
-    class Update {
-        @Test
-        void shouldUpdateInstance() {
-            var id = UUID.randomUUID().toString();
-            var storedInstance = DataPlaneInstance.Builder.newInstance().id(id).url("http://any").build();
-            when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(storedInstance));
-            when(store.save(any())).thenReturn(StoreResult.success());
-            var instance = DataPlaneInstance.Builder.newInstance().id(id).url("http://new-endpoint").build();
-
-            var result = service.update(instance);
-
-            assertThat(result).isSucceeded();
-            verify(store).save(argThat(i -> i.getUrl().toString().equals("http://new-endpoint")));
-        }
-
-        @Test
-        void shouldFail_whenFindByFails() {
-            when(store.findByIdAndLease(any())).thenReturn(StoreResult.notFound("not found"));
-            var id = UUID.randomUUID().toString();
-            var instance = DataPlaneInstance.Builder.newInstance().id(id).url("http://any").build();
-
-            var result = service.update(instance);
-
-            assertThat(result).isFailed();
             verify(store, never()).save(any());
         }
     }

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/domain/DataPlaneRegistrationMessage.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/domain/DataPlaneRegistrationMessage.java
@@ -18,8 +18,6 @@ import java.util.Set;
 
 public record DataPlaneRegistrationMessage(
         String dataplaneId,
-        String name,
-        String description,
         String endpoint,
         Set<String> transferTypes,
         Set<String> labels

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/port/api/DataPlaneRegistrationApi.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/port/api/DataPlaneRegistrationApi.java
@@ -27,7 +27,6 @@ import org.eclipse.edc.api.model.ApiCoreSchema;
 import org.eclipse.edc.signaling.domain.DataPlaneRegistrationMessage;
 
 import static jakarta.ws.rs.HttpMethod.DELETE;
-import static jakarta.ws.rs.HttpMethod.POST;
 import static jakarta.ws.rs.HttpMethod.PUT;
 
 @OpenAPIDefinition
@@ -35,30 +34,18 @@ import static jakarta.ws.rs.HttpMethod.PUT;
 public interface DataPlaneRegistrationApi {
 
     @Operation(
-            method = POST,
-            description = "Register a new Dataplane instance",
+            method = PUT,
+            description = "Register or update a Dataplane instance",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DataPlaneRegistrationMessage.class))),
             responses = {
                     @ApiResponse(responseCode = "200", description = "Dataplane instance correctly registered"),
-                    @ApiResponse(responseCode = "400", description = "Request was malformed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
-            }
-    )
-    Response register(DataPlaneRegistrationMessage registration);
-
-    @Operation(
-            method = PUT,
-            description = "Update a Dataplane instance",
-            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DataPlaneRegistrationMessage.class))),
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "Dataplane instance correctly updated"),
                     @ApiResponse(responseCode = "400", description = "Request was malformed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
                     @ApiResponse(responseCode = "404", description = "Not found",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    Response update(String dataplaneId, DataPlaneRegistrationMessage registration);
+    Response register(DataPlaneRegistrationMessage registration);
 
 
     @Operation(

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/port/api/DataPlaneRegistrationApiController.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/port/api/DataPlaneRegistrationApiController.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.signaling.port.api;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -40,26 +39,18 @@ public class DataPlaneRegistrationApiController implements DataPlaneRegistration
         this.dataPlaneSelectorService = dataPlaneSelectorService;
     }
 
-    @Path("/register")
-    @POST
+    @Path("/")
+    @PUT
     @Override
     public Response register(DataPlaneRegistrationMessage registration) {
-        var dataPlaneInstance = toDataPlaneInstance(registration.dataplaneId(), registration);
+        var dataPlaneInstance = DataPlaneInstance.Builder.newInstance()
+                .id(registration.dataplaneId())
+                .url(registration.endpoint())
+                .allowedTransferType(registration.transferTypes())
+                .build();
 
         dataPlaneSelectorService.register(dataPlaneInstance)
                 .orElseThrow(it -> mapToException(it, DataPlaneInstance.class, registration.dataplaneId()));
-
-        return Response.ok().build();
-    }
-
-    @Path("/{dataplaneId}")
-    @PUT
-    @Override
-    public Response update(@PathParam("dataplaneId") String dataplaneId, DataPlaneRegistrationMessage registration) {
-        var dataPlaneInstance = toDataPlaneInstance(dataplaneId, registration);
-
-        dataPlaneSelectorService.update(dataPlaneInstance)
-                .orElseThrow(it -> mapToException(it, DataPlaneInstance.class, dataplaneId));
 
         return Response.ok().build();
     }
@@ -74,11 +65,4 @@ public class DataPlaneRegistrationApiController implements DataPlaneRegistration
         return Response.ok().build();
     }
 
-    private DataPlaneInstance toDataPlaneInstance(String dataplaneId, DataPlaneRegistrationMessage registration) {
-        return DataPlaneInstance.Builder.newInstance()
-                .id(dataplaneId)
-                .url(registration.endpoint())
-                .allowedTransferType(registration.transferTypes())
-                .build();
-    }
 }

--- a/data-protocols/data-plane-signaling/src/test/java/org/eclipse/edc/signaling/DataPlaneRegistrationApiControllerTest.java
+++ b/data-protocols/data-plane-signaling/src/test/java/org/eclipse/edc/signaling/DataPlaneRegistrationApiControllerTest.java
@@ -46,8 +46,6 @@ public class DataPlaneRegistrationApiControllerTest extends RestControllerTestBa
             when(dataPlaneSelectorService.register(any())).thenReturn(ServiceResult.success());
             var requestBody = Map.of(
                     "dataplaneId", "dataplane-id",
-                    "name", "dataplane-name",
-                    "description", "dataplane-description",
                     "endpoint", "http://dataplane-endpoint",
                     "transferTypes", List.of("transferType-PUSH", "transferType-PULL"),
                     "labels", List.of("label-1", "label-2")
@@ -56,7 +54,7 @@ public class DataPlaneRegistrationApiControllerTest extends RestControllerTestBa
             baseRequest()
                     .contentType(ContentType.JSON)
                     .body(requestBody)
-                    .post("/dataplanes/register")
+                    .put("/dataplanes/")
                     .then()
                     .statusCode(200);
 
@@ -74,8 +72,6 @@ public class DataPlaneRegistrationApiControllerTest extends RestControllerTestBa
 
             var requestBody = Map.of(
                     "dataplaneId", "dataplane-id",
-                    "name", "dataplane-name",
-                    "description", "dataplane-description",
                     "endpoint", "http://dataplane-endpoint",
                     "transferTypes", List.of("transferType-PUSH", "transferType-PULL"),
                     "labels", List.of("label-1", "label-2")
@@ -84,58 +80,7 @@ public class DataPlaneRegistrationApiControllerTest extends RestControllerTestBa
             baseRequest()
                     .contentType(ContentType.JSON)
                     .body(requestBody)
-                    .post("/dataplanes/register")
-                    .then()
-                    .statusCode(409);
-        }
-    }
-
-    @Nested
-    class Update {
-        @Test
-        void shouldUpdateExistingDataPlan() {
-            when(dataPlaneSelectorService.update(any())).thenReturn(ServiceResult.success());
-            var requestBody = Map.of(
-                    "dataplaneId", "dataplane-id",
-                    "name", "dataplane-name",
-                    "description", "dataplane-description",
-                    "endpoint", "http://dataplane-endpoint",
-                    "transferTypes", List.of("transferType-PUSH", "transferType-PULL"),
-                    "labels", List.of("label-1", "label-2")
-            );
-
-            baseRequest()
-                    .contentType(ContentType.JSON)
-                    .body(requestBody)
-                    .put("/dataplanes/dataplane-id")
-                    .then()
-                    .statusCode(200);
-
-            var captor = ArgumentCaptor.forClass(DataPlaneInstance.class);
-            verify(dataPlaneSelectorService).update(captor.capture());
-            var instance = captor.getValue();
-            assertThat(instance.getId()).isEqualTo("dataplane-id");
-            assertThat(instance.getUrl().toString()).isEqualTo("http://dataplane-endpoint");
-            assertThat(instance.getAllowedTransferTypes()).containsExactly("transferType-PUSH", "transferType-PULL");
-        }
-
-        @Test
-        void shouldReturnError_whenUpdateFails() {
-            when(dataPlaneSelectorService.update(any())).thenReturn(ServiceResult.conflict("error"));
-
-            var requestBody = Map.of(
-                    "dataplaneId", "dataplane-id",
-                    "name", "dataplane-name",
-                    "description", "dataplane-description",
-                    "endpoint", "http://dataplane-endpoint",
-                    "transferTypes", List.of("transferType-PUSH", "transferType-PULL"),
-                    "labels", List.of("label-1", "label-2")
-            );
-
-            baseRequest()
-                    .contentType(ContentType.JSON)
-                    .body(requestBody)
-                    .put("/dataplanes/dataplane-id")
+                    .put("/dataplanes/")
                     .then()
                     .statusCode(409);
         }

--- a/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
+++ b/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "2.1.4",
     "urlPath": "/v1",
-    "lastUpdated": "2026-03-17T12:00:01Z",
+    "lastUpdated": "2026-03-19T12:00:01Z",
     "maturity": "stable"
   }
 ]

--- a/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorService.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorService.java
@@ -119,11 +119,6 @@ public class RemoteDataPlaneSelectorService implements DataPlaneSelectorService 
     }
 
     @Override
-    public ServiceResult<Void> update(DataPlaneInstance instance) {
-        return ServiceResult.unexpected("DataPlaneSelectorService.update can only be called as embedded in the control-plane");
-    }
-
-    @Override
     public ServiceResult<DataPlaneInstance> findById(String id) {
         var requestBuilder = new Request.Builder().get().url(url + "/" + id);
 

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
@@ -57,7 +57,8 @@ public interface DataPlaneSelectorService {
     ServiceResult<DataPlaneInstance> selectFor(TransferProcess transferProcess);
 
     /**
-     * Register a data plane instance
+     * Register a data plane instance. The method follows upsert semantics: when a dataplane with the same id exists, it
+     * gets updated.
      */
     ServiceResult<Void> register(DataPlaneInstance instance);
 
@@ -73,14 +74,6 @@ public interface DataPlaneSelectorService {
      * @return successful result if operation completed, failure otherwise.
      */
     ServiceResult<Void> unregister(String instanceId);
-
-    /**
-     * Update a Data Plane instance.
-     *
-     * @param instance the updated instance;
-     * @return successful result if operation completed, failure otherwise
-     */
-    ServiceResult<Void> update(DataPlaneInstance instance);
 
     /**
      * Delete a Data Plane instance.

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Runtimes.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Runtimes.java
@@ -22,8 +22,8 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
-import static java.util.Collections.emptyMap;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 
 public interface Runtimes {
@@ -128,7 +128,7 @@ public interface Runtimes {
                 .endpoint("default", () -> URI.create("http://localhost:" + getFreePort() + "/api"));
 
         static Config config() {
-            return ConfigFactory.fromMap(emptyMap());
+            return ConfigFactory.fromMap(Map.of("dataplane.id", UUID.randomUUID().toString()));
         }
     }
 }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.test.e2e;
 
 import io.restassured.common.mapper.TypeRef;
+import jakarta.json.JsonObject;
 import org.assertj.core.api.ThrowingConsumer;
 import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
 import org.eclipse.edc.junit.extensions.ComponentRuntimeContext;
@@ -27,10 +28,13 @@ import java.util.Map;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.web.spi.configuration.ApiContext.CONTROL;
 import static org.eclipse.edc.web.spi.configuration.ApiContext.MANAGEMENT;
 import static org.eclipse.edc.web.spi.configuration.ApiContext.PROTOCOL;
 
 public class TransferEndToEndParticipant extends Participant {
+
+    private LazySupplier<URI> controlPlaneControl;
 
     protected TransferEndToEndParticipant() {
         super();
@@ -46,7 +50,8 @@ public class TransferEndToEndParticipant extends Participant {
                 .id(id)
                 .name(ctx.getName())
                 .managementUrl(ctx.getEndpoint(MANAGEMENT))
-                .protocolUrl(ctx.getEndpoint(PROTOCOL));
+                .protocolUrl(ctx.getEndpoint(PROTOCOL))
+                .controlUrl(ctx.getEndpoint(CONTROL));
     }
 
     /**
@@ -109,6 +114,17 @@ public class TransferEndToEndParticipant extends Participant {
         assertThat(data).satisfies(bodyAssertion);
     }
 
+    public void registerDataPlane(JsonObject dataPlaneRegistrationMessage) {
+        given()
+                .contentType(JSON)
+                .baseUri(controlPlaneControl.get() + "/dataplanes")
+                .when()
+                .body(dataPlaneRegistrationMessage)
+                .put()
+                .then()
+                .statusCode(200);
+    }
+
     public static class Builder extends Participant.Builder<TransferEndToEndParticipant, Builder> {
 
         protected Builder() {
@@ -124,8 +140,13 @@ public class TransferEndToEndParticipant extends Participant {
             return this;
         }
 
-        public Builder protocolUrl(LazySupplier<URI> managementUrl) {
-            participant.controlPlaneProtocol = managementUrl;
+        public Builder protocolUrl(LazySupplier<URI> protocolUrl) {
+            participant.controlPlaneProtocol = protocolUrl;
+            return this;
+        }
+
+        public Builder controlUrl(LazySupplier<URI> controlUrl) {
+            participant.controlPlaneControl = controlUrl;
             return this;
         }
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/dataplane/DataPlaneSignalingClient.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/dataplane/DataPlaneSignalingClient.java
@@ -15,9 +15,12 @@
 package org.eclipse.edc.test.e2e.dataplane;
 
 import io.restassured.http.ContentType;
+import jakarta.json.JsonObject;
 import org.eclipse.edc.junit.extensions.ComponentRuntimeContext;
 
 import static io.restassured.RestAssured.given;
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 
@@ -63,4 +66,22 @@ public class DataPlaneSignalingClient {
                 .log().ifValidationFails()
                 .statusCode(204);
     }
+
+    public JsonObject getDataPlaneRegistrationMessage() {
+        var dataflowsEndpoint = context.getEndpoint("default").get() + "/v1/dataflows";
+
+        return createObjectBuilder()
+                .add("dataplaneId", context.getConfig().getString("dataplane.id"))
+                .add("endpoint", dataflowsEndpoint)
+                .add("transferTypes", createArrayBuilder()
+                        .add("Finite-PUSH")
+                        .add("Finite-PULL")
+                        .add("NonFinite-PUSH")
+                        .add("NonFinite-PULL")
+                        .add("AsyncPrepare-PUSH")
+                        .add("AsyncStart-PULL")
+                )
+                .build();
+    }
+
 }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/signaling/TransferSignalingEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/signaling/TransferSignalingEndToEndTest.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
 import org.eclipse.edc.test.e2e.Runtimes;
 import org.eclipse.edc.test.e2e.TransferEndToEndParticipant;
 import org.eclipse.edc.test.e2e.dataplane.DataPlaneSignalingClient;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -56,6 +57,17 @@ import static org.eclipse.edc.test.e2e.TransferEndToEndTestBase.PROVIDER_ID;
 
 
 interface TransferSignalingEndToEndTest {
+
+    @BeforeAll
+    static void beforeAll(@Runtime(PROVIDER_CP) TransferEndToEndParticipant provider,
+                          @Runtime(CONSUMER_CP) TransferEndToEndParticipant consumer,
+                          @Runtime(PROVIDER_DP) DataPlaneSignalingClient providerDataPlane,
+                          @Runtime(CONSUMER_DP) DataPlaneSignalingClient consumerDataPlane) {
+
+        provider.registerDataPlane(providerDataPlane.getDataPlaneRegistrationMessage());
+        consumer.registerDataPlane(consumerDataPlane.getDataPlaneRegistrationMessage());
+
+    }
 
     @Test
     default void shouldTransferFiniteDataWithPush(@Runtime(PROVIDER_CP) TransferEndToEndParticipant provider,
@@ -218,9 +230,9 @@ interface TransferSignalingEndToEndTest {
 
     @Test
     default void shouldSupportAsyncStartup(@Runtime(PROVIDER_CP) TransferEndToEndParticipant provider,
-                                   @Runtime(CONSUMER_CP) TransferEndToEndParticipant consumer,
-                                   @Runtime(PROVIDER_DP) DataPlaneSignalingClient providerDataPlane,
-                                   @Runtime(CONSUMER_DP) DataPlaneSignalingClient consumerDataPlane) {
+                                           @Runtime(CONSUMER_CP) TransferEndToEndParticipant consumer,
+                                           @Runtime(PROVIDER_DP) DataPlaneSignalingClient providerDataPlane,
+                                           @Runtime(CONSUMER_DP) DataPlaneSignalingClient consumerDataPlane) {
         var assetId = createOffer(provider);
         var consumerTransferProcessId = consumer.requestAssetFrom(assetId, provider)
                 .withTransferType("AsyncStart-PULL").execute();
@@ -291,7 +303,6 @@ interface TransferSignalingEndToEndTest {
                 .modules(Runtimes.SignalingDataPlane.MODULES)
                 .endpoints(Runtimes.SignalingDataPlane.ENDPOINTS.build())
                 .configurationProvider(Runtimes.SignalingDataPlane::config)
-                .configurationProvider(() -> Runtimes.ControlPlane.controlPlaneEndpointOf(PROVIDER_ENDPOINTS))
                 .paramProvider(DataPlaneSignalingClient.class, DataPlaneSignalingClient::new)
                 .build();
 
@@ -302,7 +313,6 @@ interface TransferSignalingEndToEndTest {
                 .modules(Runtimes.SignalingDataPlane.MODULES)
                 .endpoints(Runtimes.SignalingDataPlane.ENDPOINTS.build())
                 .configurationProvider(Runtimes.SignalingDataPlane::config)
-                .configurationProvider(() -> Runtimes.ControlPlane.controlPlaneEndpointOf(CONSUMER_ENDPOINTS))
                 .paramProvider(DataPlaneSignalingClient.class, DataPlaneSignalingClient::new)
                 .build();
     }
@@ -363,7 +373,6 @@ interface TransferSignalingEndToEndTest {
                 .modules(Runtimes.SignalingDataPlane.MODULES)
                 .endpoints(Runtimes.SignalingDataPlane.ENDPOINTS.build())
                 .configurationProvider(Runtimes.SignalingDataPlane::config)
-                .configurationProvider(() -> Runtimes.ControlPlane.controlPlaneEndpointOf(CONSUMER_ENDPOINTS))
                 .paramProvider(DataPlaneSignalingClient.class, DataPlaneSignalingClient::new)
                 .build();
 
@@ -374,7 +383,6 @@ interface TransferSignalingEndToEndTest {
                 .modules(Runtimes.SignalingDataPlane.MODULES)
                 .endpoints(Runtimes.SignalingDataPlane.ENDPOINTS.build())
                 .configurationProvider(Runtimes.SignalingDataPlane::config)
-                .configurationProvider(() -> Runtimes.ControlPlane.controlPlaneEndpointOf(PROVIDER_ENDPOINTS))
                 .paramProvider(DataPlaneSignalingClient.class, DataPlaneSignalingClient::new)
                 .build();
     }

--- a/system-tests/e2e-transfer-test/signaling-data-plane/src/main/java/org/eclipse/edc/test/runtime/signaling/SignalingDataPlaneRuntimeExtension.java
+++ b/system-tests/e2e-transfer-test/signaling-data-plane/src/main/java/org/eclipse/edc/test/runtime/signaling/SignalingDataPlaneRuntimeExtension.java
@@ -51,8 +51,8 @@ import static java.util.Collections.emptyList;
 
 public class SignalingDataPlaneRuntimeExtension implements ServiceExtension {
 
-    @Setting(key = "signaling.dataplane.controlplane.endpoint")
-    private String controlplaneEndpoint;
+    @Setting(key = "dataplane.id")
+    private String dataplaneId;
     @Configuration
     private ApiConfiguration apiConfiguration;
 
@@ -67,6 +67,7 @@ public class SignalingDataPlaneRuntimeExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         dataplane = Dataplane.newInstance()
+                .id(dataplaneId)
                 .endpoint(apiConfiguration.dataFlowEndpoint())
                 .transferType("Finite-PUSH")
                 .transferType("Finite-PULL")
@@ -84,12 +85,6 @@ public class SignalingDataPlaneRuntimeExtension implements ServiceExtension {
         webService.registerResource(dataplane.controller());
         webService.registerResource(new DataController(monitor));
         webService.registerResource(new ControlController(monitor, dataplane, apiConfiguration));
-    }
-
-    @Override
-    public void start() {
-        dataplane.registerOn(controlplaneEndpoint)
-                .orElseThrow(e -> new RuntimeException("Cannot register dataplane on controlplane", e));
     }
 
     private class DataplaneOnStart implements OnStart {


### PR DESCRIPTION
## What this PR changes/adds

Adapt DPS registration endpoint to the latest spec ([see](https://github.com/eclipse-dataplane-signaling/dataplane-signaling/blob/1b6195502714ea582c2362c630db403e080a5e87/docs/signaling.md#registration)).

Specifically, single PUT endpoint with upsert capabilities left, removed `name` and `description` from registration message

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5574

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
