### PR TITLE
refactor: move negotiation initialize logic into command handler

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -22,7 +22,6 @@ import org.eclipse.edc.connector.controlplane.asset.spi.observe.AssetObservableI
 import org.eclipse.edc.connector.controlplane.catalog.spi.DataServiceRegistry;
 import org.eclipse.edc.connector.controlplane.catalog.spi.DatasetResolver;
 import org.eclipse.edc.connector.controlplane.contract.spi.definition.observe.ContractDefinitionObservableImpl;
-import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ConsumerContractNegotiationManager;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.observe.ContractNegotiationObservable;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.controlplane.contract.spi.offer.ConsumerOfferResolver;
@@ -124,8 +123,6 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Inject
     private ContractNegotiationStore contractNegotiationStore;
     @Inject
-    private ConsumerContractNegotiationManager consumerContractNegotiationManager;
-    @Inject
     private PolicyDefinitionStore policyDefinitionStore;
     @Inject
     private TransferProcessStore transferProcessStore;
@@ -222,7 +219,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
 
     @Provider
     public ContractNegotiationService contractNegotiationService() {
-        return new ContractNegotiationServiceImpl(contractNegotiationStore, consumerContractNegotiationManager,
+        return new ContractNegotiationServiceImpl(contractNegotiationStore,
                 transactionContext, commandHandlerRegistry, QueryValidators.contractNegotiation());
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImpl.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.edc.connector.controlplane.services.contractnegotiation;
 
-import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ConsumerContractNegotiationManager;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.command.InitiateNegotiationCommand;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.command.TerminateNegotiationCommand;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
@@ -38,16 +38,14 @@ import static java.util.Optional.ofNullable;
 public class ContractNegotiationServiceImpl implements ContractNegotiationService {
 
     private final ContractNegotiationStore store;
-    private final ConsumerContractNegotiationManager consumerManager;
     private final TransactionContext transactionContext;
     private final CommandHandlerRegistry commandHandlerRegistry;
     private final QueryValidator queryValidator;
 
-    public ContractNegotiationServiceImpl(ContractNegotiationStore store, ConsumerContractNegotiationManager consumerManager,
+    public ContractNegotiationServiceImpl(ContractNegotiationStore store,
                                           TransactionContext transactionContext, CommandHandlerRegistry commandHandlerRegistry,
                                           QueryValidator queryValidator) {
         this.store = store;
-        this.consumerManager = consumerManager;
         this.transactionContext = transactionContext;
         this.commandHandlerRegistry = commandHandlerRegistry;
         this.queryValidator = queryValidator;
@@ -84,8 +82,16 @@ public class ContractNegotiationServiceImpl implements ContractNegotiationServic
     }
 
     @Override
-    public ContractNegotiation initiateNegotiation(ParticipantContext participantContext, ContractRequest request) {
-        return transactionContext.execute(() -> consumerManager.initiate(participantContext, request).getContent());
+    public ServiceResult<ContractNegotiation> initiateNegotiation(ParticipantContext participantContext, ContractRequest request) {
+        return transactionContext.execute(() -> commandHandlerRegistry
+                .execute(new InitiateNegotiationCommand(participantContext, request))
+                .flatMap(result -> {
+                    if (result.succeeded()) {
+                        return ServiceResult.success((ContractNegotiation) result.getContent());
+                    } else {
+                        return ServiceResult.from(result);
+                    }
+                }));
     }
 
     @Override

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImplTest.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.edc.connector.controlplane.services.contractnegotiation;
 
-import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ConsumerContractNegotiationManager;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.command.InitiateNegotiationCommand;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.command.TerminateNegotiationCommand;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
@@ -28,7 +28,6 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.command.CommandHandlerRegistry;
 import org.eclipse.edc.spi.command.CommandResult;
 import org.eclipse.edc.spi.query.QuerySpec;
-import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceFailure;
 import org.eclipse.edc.spi.result.StoreResult;
@@ -65,12 +64,11 @@ import static org.mockito.Mockito.when;
 class ContractNegotiationServiceImplTest {
 
     private final ContractNegotiationStore store = mock();
-    private final ConsumerContractNegotiationManager consumerManager = mock();
     private final CommandHandlerRegistry commandHandlerRegistry = mock();
     private final TransactionContext transactionContext = new NoopTransactionContext();
     private final QueryValidator queryValidator = mock();
 
-    private final ContractNegotiationService service = new ContractNegotiationServiceImpl(store, consumerManager, transactionContext, commandHandlerRegistry, queryValidator);
+    private final ContractNegotiationService service = new ContractNegotiationServiceImpl(store, transactionContext, commandHandlerRegistry, queryValidator);
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
             .participantContextId("participantContextId")
             .identity("participantId")
@@ -183,20 +181,42 @@ class ContractNegotiationServiceImplTest {
         assertThat(result).isNull();
     }
 
-    @Test
-    void initiateNegotiation_callsManager() {
-        var contractNegotiation = createContractNegotiation("negotiationId");
-        when(consumerManager.initiate(isA(ParticipantContext.class), isA(ContractRequest.class))).thenReturn(StatusResult.success(contractNegotiation));
+    @Nested
+    class InitiateNegotiation {
 
-        var request = ContractRequest.Builder.newInstance()
-                .counterPartyAddress("address")
-                .protocol("protocol")
-                .contractOffer(createContractOffer())
-                .build();
+        @Test
+        void initiateNegotiation_shouldExecuteCommand() {
+            var contractNegotiation = createContractNegotiation("negotiationId");
+            when(commandHandlerRegistry.execute(any())).thenReturn(CommandResult.success(contractNegotiation));
 
-        var result = service.initiateNegotiation(participantContext, request);
+            var request = ContractRequest.Builder.newInstance()
+                    .counterPartyAddress("address")
+                    .protocol("protocol")
+                    .contractOffer(createContractOffer())
+                    .build();
 
-        assertThat(result).matches(it -> it.getId().equals("negotiationId"));
+            var result = service.initiateNegotiation(participantContext, request);
+
+            assertThat(result).isSucceeded().satisfies(negotiation -> {
+                assertThat(negotiation.getId()).isEqualTo("negotiationId");
+            });
+            verify(commandHandlerRegistry).execute(isA(InitiateNegotiationCommand.class));
+        }
+
+        @Test
+        void shouldReturnNull_whenCommandExecutionFails() {
+            when(commandHandlerRegistry.execute(any())).thenReturn(CommandResult.notExecutable("error"));
+
+            var request = ContractRequest.Builder.newInstance()
+                    .counterPartyAddress("address")
+                    .protocol("protocol")
+                    .contractOffer(createContractOffer())
+                    .build();
+
+            var result = service.initiateNegotiation(participantContext, request);
+
+            assertThat(result).isFailed();
+        }
     }
 
     @Test

--- a/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/ContractManagerExtension.java
+++ b/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/ContractManagerExtension.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ContractN
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.NegotiationProcessors;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.NegotiationWaitStrategy;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ProviderContractNegotiationManager;
-import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.observe.ContractNegotiationObservable;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -57,8 +56,6 @@ public class ContractManagerExtension implements ServiceExtension {
     @Inject
     private Clock clock;
     @Inject
-    private ContractNegotiationObservable observable;
-    @Inject
     private ContractNegotiationPendingGuard pendingGuard;
     @Inject
     private ExecutorInstrumentation executorInstrumentation;
@@ -86,7 +83,6 @@ public class ContractManagerExtension implements ServiceExtension {
                 .negotiationProcessors(negotiationProcessors)
                 .waitStrategy(waitStrategy)
                 .monitor(monitor)
-                .observable(observable)
                 .clock(clock)
                 .telemetry(telemetry)
                 .executorInstrumentation(executorInstrumentation)
@@ -100,7 +96,6 @@ public class ContractManagerExtension implements ServiceExtension {
                 .negotiationProcessors(negotiationProcessors)
                 .waitStrategy(waitStrategy)
                 .monitor(monitor)
-                .observable(observable)
                 .clock(clock)
                 .telemetry(telemetry)
                 .executorInstrumentation(executorInstrumentation)

--- a/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/AbstractContractNegotiationManager.java
+++ b/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/AbstractContractNegotiationManager.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.connector.controlplane.contract.negotiation;
 
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ContractNegotiationPendingGuard;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.NegotiationProcessors;
-import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.observe.ContractNegotiationObservable;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
@@ -35,7 +34,6 @@ import static org.eclipse.edc.spi.persistence.StateEntityStore.isNotPending;
 
 public abstract class AbstractContractNegotiationManager extends AbstractStateEntityManager<ContractNegotiation, ContractNegotiationStore> {
 
-    protected ContractNegotiationObservable observable;
     protected ContractNegotiationPendingGuard pendingGuard = it -> false;
     protected NegotiationProcessors negotiationProcessors;
 
@@ -73,11 +71,6 @@ public abstract class AbstractContractNegotiationManager extends AbstractStateEn
             super.build();
             Objects.requireNonNull(manager.negotiationProcessors, "negotiationProcessors");
             return manager;
-        }
-
-        public Builder<T> observable(ContractNegotiationObservable observable) {
-            manager.observable = observable;
-            return this;
         }
 
         public Builder<T> pendingGuard(ContractNegotiationPendingGuard pendingGuard) {

--- a/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -18,15 +18,9 @@
 
 package org.eclipse.edc.connector.controlplane.contract.negotiation;
 
-import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.ConsumerContractNegotiationManager;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
-import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.statemachine.StateMachineManager;
-
-import java.util.UUID;
 
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.CONSUMER;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.ACCEPTING;
@@ -42,36 +36,6 @@ import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiat
 public class ConsumerContractNegotiationManagerImpl extends AbstractContractNegotiationManager implements ConsumerContractNegotiationManager {
 
     private ConsumerContractNegotiationManagerImpl() {
-    }
-
-    /**
-     * Initiates a new {@link ContractNegotiation}. The ContractNegotiation is created and persisted, which moves it to
-     * state REQUESTING.
-     *
-     * @param request Container object containing all relevant request parameters.
-     * @return a {@link StatusResult}: OK
-     */
-    @WithSpan
-    @Override
-    public StatusResult<ContractNegotiation> initiate(ParticipantContext participantContext, ContractRequest request) {
-        var id = UUID.randomUUID().toString();
-        var negotiation = ContractNegotiation.Builder.newInstance()
-                .id(id)
-                .protocol(request.getProtocol())
-                .counterPartyId(request.getProviderId())
-                .counterPartyAddress(request.getCounterPartyAddress())
-                .callbackAddresses(request.getCallbackAddresses())
-                .traceContext(telemetry.getCurrentTraceContext())
-                .participantContextId(participantContext.getParticipantContextId())
-                .type(CONSUMER)
-                .build();
-
-        negotiation.addContractOffer(request.getContractOffer());
-        negotiation.transitionInitial();
-        update(negotiation);
-        observable.invokeForEach(l -> l.initiated(negotiation));
-
-        return StatusResult.success(negotiation);
     }
 
     @Override

--- a/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -24,13 +24,10 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.Contr
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractNegotiationEventMessage;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
-import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequestMessage;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.protocol.ContractNegotiationAck;
-import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
 import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.spi.EdcException;
@@ -40,7 +37,6 @@ import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.retry.ExponentialWaitStrategy;
-import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.statemachine.retry.EntityRetryProcessConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -94,16 +90,11 @@ class ConsumerContractNegotiationManagerImplTest {
     private static final int RETRY_LIMIT = 1;
     private final ContractNegotiationStore store = mock();
     private final RemoteMessageDispatcherRegistry dispatcherRegistry = mock();
-    private final PolicyDefinitionStore policyStore = mock();
     private final ContractNegotiationListener listener = mock();
     private final DataspaceProfileContextRegistry dataspaceProfileContextRegistry = mock();
     private final ParticipantIdentityResolver identityResolver = mock();
     private final String protocolWebhookUrl = "http://protocol.webhook/url";
     private final ContractNegotiationPendingGuard pendingGuard = mock();
-    private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId(PARTICIPANT_CONTEXT_ID)
-            .identity("participantId")
-            .build();
     private ConsumerContractNegotiationManagerImpl manager;
 
     @BeforeEach
@@ -117,40 +108,10 @@ class ConsumerContractNegotiationManagerImplTest {
         manager = ConsumerContractNegotiationManagerImpl.Builder.newInstance()
                 .negotiationProcessors(negotiationProcessors)
                 .monitor(mock(Monitor.class))
-                .observable(observable)
                 .store(store)
                 .entityRetryProcessConfiguration(new EntityRetryProcessConfiguration(RETRY_LIMIT, () -> new ExponentialWaitStrategy(0L)))
                 .pendingGuard(pendingGuard)
                 .build();
-    }
-
-    @Test
-    void initiate_shouldSaveNewNegotiationInInitialState() {
-        var contractOffer = contractOffer();
-
-        var request = ContractRequest.Builder.newInstance()
-                .counterPartyAddress("callbackAddress")
-                .protocol("protocol")
-                .contractOffer(contractOffer)
-                .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
-                        .uri("local://test")
-                        .build()))
-                .build();
-
-        var result = manager.initiate(participantContext, request);
-
-        assertThat(result.succeeded()).isTrue();
-        verify(store).save(argThat(negotiation ->
-                negotiation.getState() == INITIAL.code() &&
-                        negotiation.getCounterPartyId().equals("providerId") &&
-                        negotiation.getCounterPartyAddress().equals(request.getCounterPartyAddress()) &&
-                        negotiation.getProtocol().equals(request.getProtocol()) &&
-                        negotiation.getCorrelationId() == null &&
-                        negotiation.getContractOffers().size() == 1 &&
-                        negotiation.getLastContractOffer().equals(contractOffer) &&
-                        negotiation.getCallbackAddresses().size() == 1));
-
-        verify(listener).initiated(any());
     }
 
     @Test

--- a/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -117,7 +117,6 @@ class ProviderContractNegotiationManagerImplTest {
         manager = ProviderContractNegotiationManagerImpl.Builder.newInstance()
                 .negotiationProcessors(negotiationProcessors)
                 .monitor(mock())
-                .observable(observable)
                 .store(store)
                 .entityRetryProcessConfiguration(new EntityRetryProcessConfiguration(RETRY_LIMIT, () -> new ExponentialWaitStrategy(0L)))
                 .pendingGuard(pendingGuard)

--- a/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/ContractNegotiationCommandExtension.java
+++ b/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/ContractNegotiationCommandExtension.java
@@ -14,13 +14,16 @@
 
 package org.eclipse.edc.connector.controlplane.contract;
 
+import org.eclipse.edc.connector.controlplane.contract.negotiation.command.handlers.InitiateNegotiationCommandHandler;
 import org.eclipse.edc.connector.controlplane.contract.negotiation.command.handlers.TerminateNegotiationCommandHandler;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.observe.ContractNegotiationObservable;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.command.CommandHandlerRegistry;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.telemetry.Telemetry;
 
 import static org.eclipse.edc.connector.controlplane.contract.ContractNegotiationCommandExtension.NAME;
 
@@ -40,12 +43,16 @@ public class ContractNegotiationCommandExtension implements ServiceExtension {
 
     @Inject
     private ContractNegotiationStore store;
-
     @Inject
     private CommandHandlerRegistry registry;
+    @Inject
+    private ContractNegotiationObservable observable;
+    @Inject
+    private Telemetry telemetry;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
+        registry.register(new InitiateNegotiationCommandHandler(store, observable, telemetry, context.getMonitor()));
         registry.register(new TerminateNegotiationCommandHandler(store));
     }
 

--- a/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/command/handlers/InitiateNegotiationCommandHandler.java
+++ b/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/command/handlers/InitiateNegotiationCommandHandler.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.contract.negotiation.command.handlers;
+
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.observe.ContractNegotiationObservable;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.command.InitiateNegotiationCommand;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.spi.command.CommandHandler;
+import org.eclipse.edc.spi.command.CommandResult;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.telemetry.Telemetry;
+
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.CONSUMER;
+
+/**
+ * Initiates a contract negotiation for the given provider offer. The offer will have been obtained from a previous
+ * contract offer request sent to the provider.
+ */
+public class InitiateNegotiationCommandHandler implements CommandHandler<InitiateNegotiationCommand> {
+
+    private final ContractNegotiationStore store;
+    private final ContractNegotiationObservable observable;
+    private final Telemetry telemetry;
+    private final Monitor monitor;
+
+    public InitiateNegotiationCommandHandler(ContractNegotiationStore store, ContractNegotiationObservable observable,
+                                             Telemetry telemetry, Monitor monitor) {
+        this.store = store;
+        this.observable = observable;
+        this.telemetry = telemetry;
+        this.monitor = monitor;
+    }
+
+    @Override
+    public Class<InitiateNegotiationCommand> getType() {
+        return InitiateNegotiationCommand.class;
+    }
+
+    /**
+     * Initiates a new {@link ContractNegotiation}. The ContractNegotiation is created and persisted, which moves it to
+     * state REQUESTING.
+     *
+     * @param command the command;
+     * @return success if initialized, failure otherwise.
+     */
+    @WithSpan
+    @Override
+    public CommandResult handle(InitiateNegotiationCommand command) {
+        var request = command.getRequest();
+        var participantContext = command.getParticipantContext();
+
+        var negotiation = ContractNegotiation.Builder.newInstance()
+                .id(command.getEntityId())
+                .protocol(request.getProtocol())
+                .counterPartyId(request.getProviderId())
+                .counterPartyAddress(request.getCounterPartyAddress())
+                .callbackAddresses(request.getCallbackAddresses())
+                .traceContext(telemetry.getCurrentTraceContext())
+                .participantContextId(participantContext.getParticipantContextId())
+                .type(CONSUMER)
+                .build();
+
+        negotiation.addContractOffer(request.getContractOffer());
+        negotiation.transitionInitial();
+        var save = store.save(negotiation);
+        if (save.failed()) {
+            return CommandResult.notExecutable(save.getFailureDetail());
+        }
+
+        monitor.debug(() -> "[%s] %s %s is now in state %s".formatted(this.getClass().getSimpleName(),
+                negotiation.getClass().getSimpleName(), negotiation.getId(), negotiation.stateAsString()));
+
+        observable.invokeForEach(l -> l.initiated(negotiation));
+
+        return CommandResult.success(negotiation);
+    }
+
+}

--- a/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/command/handlers/InitiateNegotiationCommandHandlerTest.java
+++ b/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/command/handlers/InitiateNegotiationCommandHandlerTest.java
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.contract.negotiation.command.handlers;
+
+import org.eclipse.edc.connector.controlplane.contract.observe.ContractNegotiationObservableImpl;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.observe.ContractNegotiationListener;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.observe.ContractNegotiationObservable;
+import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.command.InitiateNegotiationCommand;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractOffer;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.INITIAL;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class InitiateNegotiationCommandHandlerTest {
+
+    private final ContractNegotiationStore store = mock();
+    private final ContractNegotiationListener listener = mock();
+    private final ContractNegotiationObservable observable = new ContractNegotiationObservableImpl();
+    private final InitiateNegotiationCommandHandler handler = new InitiateNegotiationCommandHandler(store, observable, mock(), mock());
+
+    @BeforeEach
+    void setUp() {
+        observable.registerListener(listener);
+    }
+
+    @Test
+    void shouldSaveNewNegotiationInInitialState() {
+        when(store.save(any())).thenReturn(StoreResult.success());
+        var participantContext = ParticipantContext.Builder.newInstance()
+                .participantContextId("participantContextId")
+                .identity("participantId")
+                .build();
+        var request = ContractRequest.Builder.newInstance()
+                .counterPartyAddress("callbackAddress")
+                .protocol("protocol")
+                .contractOffer(contractOffer())
+                .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
+                        .uri("local://test")
+                        .build()))
+                .build();
+
+        var result = handler.handle(new InitiateNegotiationCommand(participantContext, request));
+
+        assertThat(result).isSucceeded().isNotNull().isInstanceOfSatisfying(ContractNegotiation.class, negotiation -> {
+            assertThat(negotiation.getState()).isEqualTo(INITIAL.code());
+            assertThat(negotiation.getCounterPartyId()).isEqualTo("providerId");
+            assertThat(negotiation.getCounterPartyAddress()).isEqualTo(request.getCounterPartyAddress());
+            assertThat(negotiation.getProtocol()).isEqualTo(request.getProtocol());
+            assertThat(negotiation.getCorrelationId()).isNull();
+            assertThat(negotiation.getContractOffers()).hasSize(1);
+            assertThat(negotiation.getLastContractOffer()).isEqualTo(contractOffer());
+            assertThat(negotiation.getCallbackAddresses()).hasSize(1);
+
+            verify(store).save(negotiation);
+        });
+
+        verify(listener).initiated(any());
+    }
+
+    @Test
+    void shouldFail_whenStorageFails() {
+        when(store.save(any())).thenReturn(StoreResult.generalError("error"));
+        var participantContext = ParticipantContext.Builder.newInstance()
+                .participantContextId("participantContextId")
+                .identity("participantId")
+                .build();
+        var request = ContractRequest.Builder.newInstance()
+                .counterPartyAddress("callbackAddress")
+                .protocol("protocol")
+                .contractOffer(contractOffer())
+                .callbackAddresses(List.of(CallbackAddress.Builder.newInstance()
+                        .uri("local://test")
+                        .build()))
+                .build();
+
+        var result = handler.handle(new InitiateNegotiationCommand(participantContext, request));
+
+        assertThat(result).isFailed();
+        verifyNoInteractions(listener);
+    }
+
+    private ContractOffer contractOffer() {
+        return ContractOffer.Builder.newInstance().id("id:assetId:random")
+                .policy(Policy.Builder.newInstance().assigner("providerId").build())
+                .assetId("assetId")
+                .build();
+    }
+
+
+}

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiController.java
@@ -113,7 +113,8 @@ public class BaseContractNegotiationApiController {
         var contractRequest = transformerRegistry.transform(requestObject, ContractRequest.class)
                 .orElseThrow(InvalidRequestException::new);
 
-        var contractNegotiation = service.initiateNegotiation(participantContext, contractRequest);
+        var contractNegotiation = service.initiateNegotiation(participantContext, contractRequest)
+                .orElseThrow(exceptionMapper(ContractNegotiation.class));
 
         var responseDto = IdResponse.Builder.newInstance()
                 .id(contractNegotiation.getId())

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
@@ -37,6 +37,7 @@ import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -329,69 +330,104 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
         verifyNoMoreInteractions(transformerRegistry, service);
     }
 
-    @Test
-    void initiate() {
-        when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
-        var contractNegotiation = createContractNegotiation("cn1");
-        var responseBody = createObjectBuilder().add(TYPE, ID_RESPONSE_TYPE).add(ID, contractNegotiation.getId()).build();
+    @Nested
+    class Initiate {
+        @Test
+        void shouldInitiateNegotiation() {
+            when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
+            var contractNegotiation = createContractNegotiation("cn1");
+            var responseBody = createObjectBuilder().add(TYPE, ID_RESPONSE_TYPE).add(ID, contractNegotiation.getId()).build();
 
-        when(transformerRegistry.transform(any(JsonObject.class), eq(ContractRequest.class))).thenReturn(Result.success(
-                ContractRequest.Builder.newInstance()
-                        .protocol("test-protocol")
-                        .counterPartyAddress("test-cb")
-                        .contractOffer(ContractOffer.Builder.newInstance()
-                                .id("test-offer-id")
-                                .assetId(randomUUID().toString())
-                                .policy(Policy.Builder.newInstance().build())
-                                .build())
-                        .build()));
+            when(transformerRegistry.transform(any(JsonObject.class), eq(ContractRequest.class))).thenReturn(Result.success(
+                    ContractRequest.Builder.newInstance()
+                            .protocol("test-protocol")
+                            .counterPartyAddress("test-cb")
+                            .contractOffer(ContractOffer.Builder.newInstance()
+                                    .id("test-offer-id")
+                                    .assetId(randomUUID().toString())
+                                    .policy(Policy.Builder.newInstance().build())
+                                    .build())
+                            .build()));
 
-        when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
-        when(service.initiateNegotiation(any(ParticipantContext.class), any(ContractRequest.class))).thenReturn(contractNegotiation);
+            when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
+            when(service.initiateNegotiation(any(ParticipantContext.class), any(ContractRequest.class))).thenReturn(ServiceResult.success(contractNegotiation));
 
-        when(transformerRegistry.transform(any(IdResponse.class), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
+            when(transformerRegistry.transform(any(IdResponse.class), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
 
-        baseRequest()
-                .contentType(JSON)
-                .body(createObjectBuilder().build())
-                .post()
-                .then()
-                .statusCode(200)
-                .body(ID, is(contractNegotiation.getId()));
+            baseRequest()
+                    .contentType(JSON)
+                    .body(createObjectBuilder().build())
+                    .post()
+                    .then()
+                    .statusCode(200)
+                    .body(ID, is(contractNegotiation.getId()));
 
-        verify(service).initiateNegotiation(any(), any());
-        verify(transformerRegistry).transform(any(JsonObject.class), eq(ContractRequest.class));
-        verify(transformerRegistry).transform(any(IdResponse.class), eq(JsonObject.class));
-        verifyNoMoreInteractions(transformerRegistry, service);
-    }
+            verify(service).initiateNegotiation(any(), any());
+            verify(transformerRegistry).transform(any(JsonObject.class), eq(ContractRequest.class));
+            verify(transformerRegistry).transform(any(IdResponse.class), eq(JsonObject.class));
+            verifyNoMoreInteractions(transformerRegistry, service);
+        }
 
-    @Test
-    void initiate_shouldReturnBadRequest_whenValidationFails() {
-        when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.failure(violation("error", "path")));
+        @Test
+        void shouldFail_whenServiceFails() {
+            when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
+            var contractNegotiation = createContractNegotiation("cn1");
+            var responseBody = createObjectBuilder().add(TYPE, ID_RESPONSE_TYPE).add(ID, contractNegotiation.getId()).build();
+            when(transformerRegistry.transform(any(JsonObject.class), eq(ContractRequest.class))).thenReturn(Result.success(
+                    ContractRequest.Builder.newInstance()
+                            .protocol("test-protocol")
+                            .counterPartyAddress("test-cb")
+                            .contractOffer(ContractOffer.Builder.newInstance()
+                                    .id("test-offer-id")
+                                    .assetId(randomUUID().toString())
+                                    .policy(Policy.Builder.newInstance().build())
+                                    .build())
+                            .build()));
 
-        baseRequest()
-                .contentType(JSON)
-                .body(createObjectBuilder().build())
-                .post()
-                .then()
-                .statusCode(400);
+            when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
+            when(service.initiateNegotiation(any(ParticipantContext.class), any(ContractRequest.class))).thenReturn(ServiceResult.unexpected("error"));
+            when(transformerRegistry.transform(any(IdResponse.class), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
 
-        verify(validatorRegistry).validate(eq(ContractRequest.CONTRACT_REQUEST_TYPE), any());
-        verifyNoInteractions(transformerRegistry, service);
-    }
+            baseRequest()
+                    .contentType(JSON)
+                    .body(createObjectBuilder().build())
+                    .post()
+                    .then()
+                    .statusCode(500);
 
-    @Test
-    void initiate_invalidRequest() {
-        when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
-        when(transformerRegistry.transform(any(JsonObject.class), any())).thenReturn(Result.failure("test-failure"));
+            verify(service).initiateNegotiation(any(), any());
+            verify(transformerRegistry).transform(any(JsonObject.class), eq(ContractRequest.class));
+            verifyNoMoreInteractions(transformerRegistry, service);
+        }
 
-        baseRequest()
-                .contentType(JSON)
-                .body(createObjectBuilder().build())
-                .post()
-                .then()
-                .statusCode(400);
-        verifyNoMoreInteractions(service);
+        @Test
+        void shouldReturnBadRequest_whenValidationFails() {
+            when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.failure(violation("error", "path")));
+
+            baseRequest()
+                    .contentType(JSON)
+                    .body(createObjectBuilder().build())
+                    .post()
+                    .then()
+                    .statusCode(400);
+
+            verify(validatorRegistry).validate(eq(ContractRequest.CONTRACT_REQUEST_TYPE), any());
+            verifyNoInteractions(transformerRegistry, service);
+        }
+
+        @Test
+        void invalidRequest() {
+            when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
+            when(transformerRegistry.transform(any(JsonObject.class), any())).thenReturn(Result.failure("test-failure"));
+
+            baseRequest()
+                    .contentType(JSON)
+                    .body(createObjectBuilder().build())
+                    .post()
+                    .then()
+                    .statusCode(400);
+            verifyNoMoreInteractions(service);
+        }
     }
 
     @Test

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/command/CommandResult.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/command/CommandResult.java
@@ -20,14 +20,18 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public class CommandResult extends AbstractResult<Void, CommandFailure, CommandResult> {
+public class CommandResult extends AbstractResult<Object, CommandFailure, CommandResult> {
 
-    protected CommandResult(Void content, CommandFailure failure) {
+    protected CommandResult(Object content, CommandFailure failure) {
         super(content, failure);
     }
 
     public static CommandResult success() {
         return new CommandResult(null, null);
+    }
+
+    public static CommandResult success(Object content) {
+        return new CommandResult(content, null);
     }
 
     public static CommandResult notFound(String message) {

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/negotiation/ConsumerContractNegotiationManager.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/negotiation/ConsumerContractNegotiationManager.java
@@ -15,12 +15,8 @@
 
 package org.eclipse.edc.connector.controlplane.contract.spi.negotiation;
 
-import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
-import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.entity.StateEntityManager;
-import org.eclipse.edc.spi.response.StatusResult;
 
 /**
  * Manages contract negotiations on the consumer participant.
@@ -29,10 +25,5 @@ import org.eclipse.edc.spi.response.StatusResult;
  */
 @ExtensionPoint
 public interface ConsumerContractNegotiationManager extends StateEntityManager {
-
-    /**
-     * Initiates a contract negotiation for the given provider offer. The offer will have been obtained from a previous contract offer request sent to the provider.
-     */
-    StatusResult<ContractNegotiation> initiate(ParticipantContext participantContext, ContractRequest request);
 
 }

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/command/InitiateNegotiationCommand.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/command/InitiateNegotiationCommand.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.contract.spi.types.command;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.spi.command.EntityCommand;
+
+import java.util.UUID;
+
+/**
+ * Initiates a new Contract Negotiation
+ */
+public class InitiateNegotiationCommand extends EntityCommand {
+
+    private final ParticipantContext participantContext;
+    private final ContractRequest request;
+
+    public InitiateNegotiationCommand(ParticipantContext participantContext, ContractRequest request) {
+        super(UUID.randomUUID().toString());
+        this.participantContext = participantContext;
+        this.request = request;
+    }
+
+    public ContractRequest getRequest() {
+        return request;
+    }
+
+    public ParticipantContext getParticipantContext() {
+        return participantContext;
+    }
+}

--- a/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/contractnegotiation/ContractNegotiationService.java
+++ b/spi/control-plane/control-plane-spi/src/main/java/org/eclipse/edc/connector/controlplane/services/spi/contractnegotiation/ContractNegotiationService.java
@@ -64,9 +64,9 @@ public interface ContractNegotiationService {
      *
      * @param participantContext the participant context
      * @param request            the contract offer request
-     * @return the contract negotiation initiated
+     * @return success with the contract negotiation initiated, failure otherwise
      */
-    ContractNegotiation initiateNegotiation(ParticipantContext participantContext, ContractRequest request);
+    ServiceResult<ContractNegotiation> initiateNegotiation(ParticipantContext participantContext, ContractRequest request);
 
     /**
      * Terminate a contract negotiation

--- a/system-tests/telemetry/telemetry-test-runner/src/test/java/org/eclipse/edc/test/e2e/tracing/TracingEndToEndTest.java
+++ b/system-tests/telemetry/telemetry-test-runner/src/test/java/org/eclipse/edc/test/e2e/tracing/TracingEndToEndTest.java
@@ -86,7 +86,7 @@ public class TracingEndToEndTest extends BaseTelemetryEndToEndTest {
                 .body(requestJson)
                 .post("/management/v3/contractnegotiations")
                 .then()
-                .log().ifError()
+                .log().ifValidationFails()
                 .statusCode(200)
                 .contentType(JSON)
                 .extract().jsonPath().getString(ID);
@@ -98,7 +98,7 @@ public class TracingEndToEndTest extends BaseTelemetryEndToEndTest {
                     assertThat(spans.stream())
                             .map(Span::getName)
                             .filteredOn(it -> !it.startsWith("HTTP"))
-                            .contains("ConsumerContractNegotiationManagerImpl.initiate");
+                            .contains("InitiateNegotiationCommandHandler.handle");
                 }
         );
     }


### PR DESCRIPTION
## What this PR changes/adds

Moves the negotiation initialization logic into a command handler

## Why it does that

remove logic from managers

## Further notes

- the `CommandResult` was bringing a `Void` type, but this command required an actual content. My thought is that `CommandResult` is too similar to `ServiceResult`, so we could just stick with the latter and get rid of the `CommandResult`. TBD in a separate PR


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5572

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
