### PR TITLE
feat: decouple webook resolver from the DataspaceProfileContextRegistry

### DIFF
--- a/core/common/participant-context-single-core/build.gradle.kts
+++ b/core/common/participant-context-single-core/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 }
 
 dependencies {
+    api(project(":spi:common:protocol-spi"))
     api(project(":spi:common:participant-context-single-spi"))
     api(project(":spi:common:participant-context-config-spi"))
 

--- a/core/common/participant-context-single-core/src/main/java/org/eclipse/edc/participantcontext/single/SingleParticipantContextServicesExtension.java
+++ b/core/common/participant-context-single-core/src/main/java/org/eclipse/edc/participantcontext/single/SingleParticipantContextServicesExtension.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.participantcontext.single;
+
+import org.eclipse.edc.participantcontext.single.protocol.SingleParticipantProtocolWebhookResolver;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.protocol.spi.ProtocolWebhookResolver;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtension;
+
+@Extension(value = SingleParticipantContextServicesExtension.NAME)
+public class SingleParticipantContextServicesExtension implements ServiceExtension {
+
+    public static final String NAME = "Single Participant Context Services Extension";
+
+    @Inject
+    private Monitor monitor;
+
+    @Inject
+    private DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+    
+    @Provider
+    public ProtocolWebhookResolver protocolWebhookResolver() {
+        return new SingleParticipantProtocolWebhookResolver(dataspaceProfileContextRegistry);
+    }
+
+}

--- a/core/common/participant-context-single-core/src/main/java/org/eclipse/edc/participantcontext/single/protocol/SingleParticipantProtocolWebhookResolver.java
+++ b/core/common/participant-context-single-core/src/main/java/org/eclipse/edc/participantcontext/single/protocol/SingleParticipantProtocolWebhookResolver.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.participantcontext.single.protocol;
+
+import org.eclipse.edc.protocol.spi.DataspaceProfileContext;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.protocol.spi.ProtocolWebhook;
+import org.eclipse.edc.protocol.spi.ProtocolWebhookResolver;
+import org.jetbrains.annotations.Nullable;
+
+public class SingleParticipantProtocolWebhookResolver implements ProtocolWebhookResolver {
+
+    private final DataspaceProfileContextRegistry registry;
+
+    public SingleParticipantProtocolWebhookResolver(DataspaceProfileContextRegistry registry) {
+        this.registry = registry;
+    }
+
+    // we ignore the participantContextId since we only support a single participant context
+    // TODO remove this once we have multiple participant context support in the protocol layer and remove the single participant protocol API
+    @Override
+    public @Nullable ProtocolWebhook getWebhook(String participantContextId, String protocol) {
+        return registry.getProfiles().stream().filter(it -> it.name().equals(protocol))
+                .map(DataspaceProfileContext::webhook).findAny().orElse(null);
+    }
+}

--- a/core/common/participant-context-single-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/core/common/participant-context-single-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -13,3 +13,4 @@
 #
 
 org.eclipse.edc.participantcontext.single.SingleParticipantContextDefaultServicesExtension
+org.eclipse.edc.participantcontext.single.SingleParticipantContextServicesExtension

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -39,6 +39,7 @@ import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolv
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.protocol.spi.ProtocolWebhookResolver;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.iam.ClaimToken;
@@ -85,6 +86,7 @@ class ContractNegotiationEventDispatchTest {
             .build();
     protected DataspaceProfileContextRegistry dataspaceProfileContextRegistry = mock();
     protected ParticipantIdentityResolver identityResolver = mock();
+    protected ProtocolWebhookResolver protocolWebhookResolver = mock();
 
     @BeforeEach
     void setUp(RuntimeExtension extension) {
@@ -99,8 +101,10 @@ class ContractNegotiationEventDispatchTest {
         extension.registerServiceMock(IdentityService.class, identityService);
         extension.registerServiceMock(DataPlaneClientFactory.class, mock());
         extension.registerServiceMock(DataFlowController.class, mock());
+        extension.registerServiceMock(ProtocolWebhookResolver.class, protocolWebhookResolver);
 
-        when(dataspaceProfileContextRegistry.getWebhook(any())).thenReturn(() -> "http://callback.address");
+
+        when(protocolWebhookResolver.getWebhook(any(), any())).thenReturn(() -> "http://callback.address");
         when(dataspaceProfileContextRegistry.getIdExtractionFunction(any())).thenReturn(ct -> CONSUMER);
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessEventDispatchTest.java
@@ -44,6 +44,7 @@ import org.eclipse.edc.participant.spi.ParticipantAgentService;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.protocol.spi.ProtocolWebhookResolver;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventRouter;
@@ -101,7 +102,8 @@ public class TransferProcessEventDispatchTest {
             .registerServiceMock(ParticipantAgentService.class, mock())
             .registerServiceMock(DataPlaneClientFactory.class, mock())
             .registerServiceMock(DataFlowController.class, mock())
-            .registerServiceMock(DataAddressStore.class, mock());
+            .registerServiceMock(DataAddressStore.class, mock())
+            .registerServiceMock(ProtocolWebhookResolver.class, mock());
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
             .participantContextId("participantContextId")
             .identity("participantId")
@@ -109,8 +111,8 @@ public class TransferProcessEventDispatchTest {
     private final EventSubscriber eventSubscriber = mock();
 
     @BeforeEach
-    void setup(DataFlowController dataFlowController, DataAddressStore dataAddressStore, DataspaceProfileContextRegistry dataspaceProfileContextRegistry) {
-        when(dataspaceProfileContextRegistry.getWebhook(any())).thenReturn(() -> "http://dummy");
+    void setup(DataFlowController dataFlowController, DataAddressStore dataAddressStore, DataspaceProfileContextRegistry dataspaceProfileContextRegistry, ProtocolWebhookResolver protocolWebhookResolver) {
+        when(protocolWebhookResolver.getWebhook(any(), any())).thenReturn(() -> "http://dummy");
         when(dataspaceProfileContextRegistry.getIdExtractionFunction(any())).thenReturn(ct -> "id");
         when(dataFlowController.prepare(any(), any())).thenReturn(StatusResult.success(DataFlowResponse.Builder.newInstance().build()));
         when(dataFlowController.started(any())).thenReturn(StatusResult.success());

--- a/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ConsumerContractNegotiationManagerImplTest.java
@@ -29,7 +29,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractO
 import org.eclipse.edc.connector.controlplane.contract.spi.types.protocol.ContractNegotiationAck;
 import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.protocol.spi.ProtocolWebhookResolver;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -91,7 +91,7 @@ class ConsumerContractNegotiationManagerImplTest {
     private final ContractNegotiationStore store = mock();
     private final RemoteMessageDispatcherRegistry dispatcherRegistry = mock();
     private final ContractNegotiationListener listener = mock();
-    private final DataspaceProfileContextRegistry dataspaceProfileContextRegistry = mock();
+    private final ProtocolWebhookResolver protocolWebhookResolver = mock();
     private final ParticipantIdentityResolver identityResolver = mock();
     private final String protocolWebhookUrl = "http://protocol.webhook/url";
     private final ContractNegotiationPendingGuard pendingGuard = mock();
@@ -102,7 +102,7 @@ class ConsumerContractNegotiationManagerImplTest {
         when(store.save(any())).thenReturn(StoreResult.success());
         var observable = new ContractNegotiationObservableImpl();
         observable.registerListener(listener);
-        var negotiationProcessors = new NegotiationProcessorsImpl(mock(), dataspaceProfileContextRegistry, observable, store,
+        var negotiationProcessors = new NegotiationProcessorsImpl(mock(), protocolWebhookResolver, observable, store,
                 identityResolver, mock(), dispatcherRegistry, new EntityRetryProcessConfiguration(RETRY_LIMIT, () -> new ExponentialWaitStrategy(0L))
         );
         manager = ConsumerContractNegotiationManagerImpl.Builder.newInstance()
@@ -133,7 +133,7 @@ class ConsumerContractNegotiationManagerImplTest {
         var ack = ContractNegotiationAck.Builder.newInstance().providerPid("providerPid").build();
         when(dispatcherRegistry.dispatch(any(), any(), any())).thenReturn(completedFuture(StatusResult.success(ack)));
         when(store.findById(negotiation.getId())).thenReturn(negotiation);
-        when(dataspaceProfileContextRegistry.getWebhook(any())).thenReturn(() -> protocolWebhookUrl);
+        when(protocolWebhookResolver.getWebhook(any(), any())).thenReturn(() -> protocolWebhookUrl);
 
 
         manager.start();
@@ -160,7 +160,7 @@ class ConsumerContractNegotiationManagerImplTest {
         var ack = ContractNegotiationAck.Builder.newInstance().providerPid("providerPid").build();
         when(dispatcherRegistry.dispatch(any(), any(), any())).thenReturn(completedFuture(StatusResult.success(ack)));
         when(store.findById(negotiation.getId())).thenReturn(negotiation);
-        when(dataspaceProfileContextRegistry.getWebhook(any())).thenReturn(() -> protocolWebhookUrl);
+        when(protocolWebhookResolver.getWebhook(any(), any())).thenReturn(() -> protocolWebhookUrl);
 
 
         manager.start();
@@ -184,7 +184,7 @@ class ConsumerContractNegotiationManagerImplTest {
         var ack = ContractNegotiationAck.Builder.newInstance().providerPid("providerPid").build();
         when(dispatcherRegistry.dispatch(any(), any(), any())).thenReturn(completedFuture(StatusResult.success(ack)));
         when(store.findById(negotiation.getId())).thenReturn(negotiation);
-        when(dataspaceProfileContextRegistry.getWebhook(any())).thenReturn(() -> protocolWebhookUrl);
+        when(protocolWebhookResolver.getWebhook(any(), any())).thenReturn(() -> protocolWebhookUrl);
 
         manager.start();
 
@@ -210,7 +210,7 @@ class ConsumerContractNegotiationManagerImplTest {
         var ack = ContractNegotiationAck.Builder.newInstance().providerPid("providerPid").build();
         when(dispatcherRegistry.dispatch(any(), any(), any())).thenReturn(completedFuture(StatusResult.success(ack)));
         when(store.findById(negotiation.getId())).thenReturn(negotiation);
-        when(dataspaceProfileContextRegistry.getWebhook(any())).thenReturn(null);
+        when(protocolWebhookResolver.getWebhook(any(), any())).thenReturn(null);
 
 
         manager.start();
@@ -313,7 +313,7 @@ class ConsumerContractNegotiationManagerImplTest {
         when(store.nextNotLeased(anyInt(), stateIs(starting.code()))).thenReturn(List.of(negotiation)).thenReturn(emptyList());
         when(dispatcherRegistry.dispatch(any(), any(), any())).thenReturn(result);
         when(store.findById(negotiation.getId())).thenReturn(negotiation);
-        when(dataspaceProfileContextRegistry.getWebhook(negotiation.getProtocol())).thenReturn(() -> protocolWebhookUrl);
+        when(protocolWebhookResolver.getWebhook(negotiation.getParticipantContextId(), negotiation.getProtocol())).thenReturn(() -> protocolWebhookUrl);
 
         manager.start();
 

--- a/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
+++ b/core/control-plane/control-plane-contract-manager/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/ProviderContractNegotiationManagerImplTest.java
@@ -34,7 +34,7 @@ import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionS
 import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.policy.model.PolicyType;
-import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.protocol.spi.ProtocolWebhookResolver;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.query.Criterion;
@@ -102,7 +102,7 @@ class ProviderContractNegotiationManagerImplTest {
     private final PolicyDefinitionStore policyStore = mock();
     private final ContractNegotiationListener listener = mock();
     private final ContractNegotiationPendingGuard pendingGuard = mock();
-    private final DataspaceProfileContextRegistry dataspaceProfileContextRegistry = mock();
+    private final ProtocolWebhookResolver protocolWebhookResolver = mock();
     private final ParticipantIdentityResolver identityResolver = mock();
     private ProviderContractNegotiationManagerImpl manager;
 
@@ -111,7 +111,7 @@ class ProviderContractNegotiationManagerImplTest {
         when(store.save(any())).thenReturn(StoreResult.success());
         var observable = new ContractNegotiationObservableImpl();
         observable.registerListener(listener);
-        var negotiationProcessors = new NegotiationProcessorsImpl(mock(), dataspaceProfileContextRegistry, observable, store,
+        var negotiationProcessors = new NegotiationProcessorsImpl(mock(), protocolWebhookResolver, observable, store,
                 identityResolver, Clock.systemDefaultZone(), dispatcherRegistry, new EntityRetryProcessConfiguration(RETRY_LIMIT, () -> new ExponentialWaitStrategy(0L))
         );
         manager = ProviderContractNegotiationManagerImpl.Builder.newInstance()
@@ -130,7 +130,7 @@ class ProviderContractNegotiationManagerImplTest {
         var ack = ContractNegotiationAck.Builder.newInstance().consumerPid("consumerPid").build();
         when(dispatcherRegistry.dispatch(any(), any(), any())).thenReturn(completedFuture(StatusResult.success(ack)));
         when(store.findById(negotiation.getId())).thenReturn(negotiation);
-        when(dataspaceProfileContextRegistry.getWebhook(negotiation.getProtocol())).thenReturn(() -> "http://callback.address");
+        when(protocolWebhookResolver.getWebhook(negotiation.getParticipantContextId(), negotiation.getProtocol())).thenReturn(() -> "http://callback.address");
 
         manager.start();
 
@@ -156,7 +156,7 @@ class ProviderContractNegotiationManagerImplTest {
         var ack = ContractNegotiationAck.Builder.newInstance().consumerPid("consumerPid").build();
         when(dispatcherRegistry.dispatch(any(), any(), any())).thenReturn(completedFuture(StatusResult.success(ack)));
         when(store.findById(negotiation.getId())).thenReturn(negotiation);
-        when(dataspaceProfileContextRegistry.getWebhook(negotiation.getProtocol())).thenReturn(null);
+        when(protocolWebhookResolver.getWebhook(negotiation.getParticipantContextId(), negotiation.getProtocol())).thenReturn(null);
 
         manager.start();
 
@@ -223,7 +223,7 @@ class ProviderContractNegotiationManagerImplTest {
         when(dispatcherRegistry.dispatch(any(), any(), any())).thenReturn(completedFuture(StatusResult.success("any")));
         when(store.findById(negotiation.getId())).thenReturn(negotiation);
         when(policyStore.findById(any())).thenReturn(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).id("policyId").build());
-        when(dataspaceProfileContextRegistry.getWebhook(negotiation.getProtocol())).thenReturn(() -> "http://callback.address");
+        when(protocolWebhookResolver.getWebhook(negotiation.getParticipantContextId(), negotiation.getProtocol())).thenReturn(() -> "http://callback.address");
         when(identityResolver.getParticipantId(negotiation.getParticipantContextId(), negotiation.getProtocol())).thenReturn(PROVIDER_ID);
 
         manager.start();
@@ -300,7 +300,7 @@ class ProviderContractNegotiationManagerImplTest {
         when(store.nextNotLeased(anyInt(), stateIs(starting.code()))).thenReturn(List.of(negotiation)).thenReturn(emptyList());
         when(dispatcherRegistry.dispatch(any(), any(), any())).thenReturn(result);
         when(store.findById(negotiation.getId())).thenReturn(negotiation);
-        when(dataspaceProfileContextRegistry.getWebhook(negotiation.getProtocol())).thenReturn(() -> "http://callback.address");
+        when(protocolWebhookResolver.getWebhook(negotiation.getParticipantContextId(), negotiation.getProtocol())).thenReturn(() -> "http://callback.address");
         when(identityResolver.getParticipantId(negotiation.getParticipantContextId(), negotiation.getProtocol())).thenReturn(PROVIDER_ID);
 
         manager.start();

--- a/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/ContractCoreExtension.java
+++ b/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/ContractCoreExtension.java
@@ -35,7 +35,7 @@ import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolv
 import org.eclipse.edc.policy.engine.spi.PolicyEngine;
 import org.eclipse.edc.policy.engine.spi.RuleBindingRegistry;
 import org.eclipse.edc.policy.model.Permission;
-import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.protocol.spi.ProtocolWebhookResolver;
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -87,7 +87,7 @@ public class ContractCoreExtension implements ServiceExtension {
     @Inject
     private ContractNegotiationObservable observable;
     @Inject
-    private DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
+    private ProtocolWebhookResolver protocolWebhookResolver;
     @Inject
     private ContractNegotiationStore store;
     @Inject
@@ -111,7 +111,7 @@ public class ContractCoreExtension implements ServiceExtension {
 
     @Provider
     public NegotiationProcessors negotiationProcessors() {
-        return new NegotiationProcessorsImpl(monitor, dataspaceProfileContextRegistry, observable, store,
+        return new NegotiationProcessorsImpl(monitor, protocolWebhookResolver, observable, store,
                 identityResolver, clock, dispatcherRegistry, stateMachineConfiguration.entityRetryProcessConfiguration()
         );
     }

--- a/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/NegotiationProcessorsImpl.java
+++ b/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/NegotiationProcessorsImpl.java
@@ -29,7 +29,7 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Con
 import org.eclipse.edc.connector.controlplane.contract.spi.types.protocol.ContractNegotiationAck;
 import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
 import org.eclipse.edc.policy.model.PolicyType;
-import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.protocol.spi.ProtocolWebhookResolver;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.response.StatusResult;
@@ -50,7 +50,7 @@ import static org.eclipse.edc.statemachine.retry.processor.Process.futureResult;
 public class NegotiationProcessorsImpl implements NegotiationProcessors {
 
     private final Monitor monitor;
-    private final DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
+    private final ProtocolWebhookResolver protocolWebhookResolver;
     private final ContractNegotiationObservable observable;
     private final ContractNegotiationStore store;
     private final EntityRetryProcessFactory entityRetryProcessFactory;
@@ -58,13 +58,13 @@ public class NegotiationProcessorsImpl implements NegotiationProcessors {
     private final Clock clock;
     private final RemoteMessageDispatcherRegistry dispatcherRegistry;
 
-    public NegotiationProcessorsImpl(Monitor monitor, DataspaceProfileContextRegistry dataspaceProfileContextRegistry,
+    public NegotiationProcessorsImpl(Monitor monitor, ProtocolWebhookResolver protocolWebhookResolver,
                                      ContractNegotiationObservable observable, ContractNegotiationStore store,
                                      ParticipantIdentityResolver identityResolver, Clock clock,
                                      RemoteMessageDispatcherRegistry dispatcherRegistry,
                                      EntityRetryProcessConfiguration entityRetryProcessConfiguration) {
         this.monitor = monitor;
-        this.dataspaceProfileContextRegistry = dataspaceProfileContextRegistry;
+        this.protocolWebhookResolver = protocolWebhookResolver;
         this.observable = observable;
         this.store = store;
         this.identityResolver = identityResolver;
@@ -83,7 +83,7 @@ public class NegotiationProcessorsImpl implements NegotiationProcessors {
     @WithSpan
     @Override
     public CompletableFuture<StatusResult<Void>> processRequesting(ContractNegotiation negotiation) {
-        var callbackAddress = dataspaceProfileContextRegistry.getWebhook(negotiation.getProtocol());
+        var callbackAddress = protocolWebhookResolver.getWebhook(negotiation.getParticipantContextId(), negotiation.getProtocol());
         if (callbackAddress == null) {
             var message = "No callback address found for protocol: %s".formatted(negotiation.getProtocol());
             transitionToTerminated(negotiation, message);
@@ -139,7 +139,7 @@ public class NegotiationProcessorsImpl implements NegotiationProcessors {
     @WithSpan
     @Override
     public CompletableFuture<StatusResult<Void>> processOffering(ContractNegotiation negotiation) {
-        var callbackAddress = dataspaceProfileContextRegistry.getWebhook(negotiation.getProtocol());
+        var callbackAddress = protocolWebhookResolver.getWebhook(negotiation.getParticipantContextId(), negotiation.getProtocol());
         if (callbackAddress == null) {
             var message = "No callback address found for protocol: %s".formatted(negotiation.getProtocol());
             transitionToTerminated(negotiation, message);
@@ -174,7 +174,7 @@ public class NegotiationProcessorsImpl implements NegotiationProcessors {
     @WithSpan
     @Override
     public CompletableFuture<StatusResult<Void>> processAgreeing(ContractNegotiation negotiation) {
-        var callbackAddress = dataspaceProfileContextRegistry.getWebhook(negotiation.getProtocol());
+        var callbackAddress = protocolWebhookResolver.getWebhook(negotiation.getParticipantContextId(), negotiation.getProtocol());
         if (callbackAddress == null) {
             var message = "No callback address found for protocol: %s".formatted(negotiation.getProtocol());
             transitionToTerminated(negotiation, message);

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/profile/DataspaceProfileContextRegistryImpl.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/profile/DataspaceProfileContextRegistryImpl.java
@@ -20,7 +20,6 @@ import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.protocol.spi.ParticipantIdExtractionFunction;
 import org.eclipse.edc.protocol.spi.ProtocolVersion;
 import org.eclipse.edc.protocol.spi.ProtocolVersions;
-import org.eclipse.edc.protocol.spi.ProtocolWebhook;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -43,33 +42,28 @@ public class DataspaceProfileContextRegistryImpl implements DataspaceProfileCont
 
     @Override
     public ProtocolVersions getProtocolVersions() {
-        var versions = profiles().stream().map(DataspaceProfileContext::protocolVersion).distinct().toList();
+        var versions = getProfiles().stream().map(DataspaceProfileContext::protocolVersion).distinct().toList();
 
         return new ProtocolVersions(versions);
     }
 
     @Override
-    public @Nullable ProtocolWebhook getWebhook(String protocol) {
-        return profiles().stream().filter(it -> it.name().equals(protocol))
-                .map(DataspaceProfileContext::webhook).findAny().orElse(null);
-    }
-
-    @Override
     public @Nullable ProtocolVersion getProtocolVersion(String protocol) {
-        return profiles().stream().filter(it -> it.name().equals(protocol))
+        return getProfiles().stream().filter(it -> it.name().equals(protocol))
                 .map(DataspaceProfileContext::protocolVersion).findAny().orElse(null);
     }
 
     @Override
     public @Nullable ParticipantIdExtractionFunction getIdExtractionFunction(String protocol) {
-        return profiles().stream()
+        return getProfiles().stream()
                 .filter(it -> it.name().equals(protocol))
                 .map(DataspaceProfileContext::idExtractionFunction)
                 .findAny()
                 .orElse(null);
     }
 
-    private List<DataspaceProfileContext> profiles() {
+    @Override
+    public List<DataspaceProfileContext> getProfiles() {
         return standardProfiles.isEmpty() ? defaultProfiles : standardProfiles;
     }
 }

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/controlplane/profile/DataspaceProfileContextRegistryImplTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/controlplane/profile/DataspaceProfileContextRegistryImplTest.java
@@ -54,23 +54,27 @@ class DataspaceProfileContextRegistryImplTest {
     }
 
     @Nested
-    class Resolve {
-
+    class GetProfiles {
         @Test
-        void shouldReturnNull_whenNoWebhookFound() {
-            var result = registry.getWebhook("unexistent");
+        void shouldReturnProfiles_whenContextsRegisteredDefault() {
+            var version = new ProtocolVersion("version name", "/path", "binding");
+            var profile = new DataspaceProfileContext("profile", version, () -> "url", ct -> "id");
+            registry.registerDefault(profile);
 
-            assertThat(result).isNull();
+            assertThat(registry.getProfiles()).hasSize(1).containsExactly(profile);
         }
 
         @Test
-        void shouldReturnWebhookForName() {
-            var version = new ProtocolVersion("version name", "/path", "binding");
-            registry.registerDefault(new DataspaceProfileContext("profile", version, () -> "url", ct -> "id"));
+        void shouldIgnoreDefaultContexts_whenStandardAreRegistered() {
+            var defaultVersion = new ProtocolVersion("default", "/path", "binding");
+            var standardVersion = new ProtocolVersion("default", "/path", "binding");
+            var defaultProfile = new DataspaceProfileContext("default", defaultVersion, () -> "url", ct -> "id");
+            var standardProfile = new DataspaceProfileContext("standard", standardVersion, () -> "url", ct -> "id");
 
-            var result = registry.getWebhook("profile");
-
-            assertThat(result.url()).isEqualTo("url");
+            registry.registerDefault(defaultProfile);
+            registry.register(standardProfile);
+            
+            assertThat(registry.getProfiles()).hasSize(1).containsExactly(standardProfile);
         }
     }
 

--- a/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
+++ b/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
@@ -38,7 +38,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.Transf
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferTerminationMessage;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.protocol.spi.ProtocolWebhookResolver;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.query.Criterion;
@@ -131,7 +131,7 @@ class TransferProcessManagerImplTest {
     private final DataFlowController dataFlowController = mock();
     private final Clock clock = Clock.systemUTC();
     private final TransferProcessListener listener = mock();
-    private final DataspaceProfileContextRegistry dataspaceProfileContextRegistry = mock();
+    private final ProtocolWebhookResolver protocolWebhookResolver = mock();
     private final DataAddressResolver addressResolver = mock();
     private final DataAddressStore dataAddressStore = mock();
     private final String protocolWebhookUrl = "http://protocol.webhook/url";
@@ -148,7 +148,7 @@ class TransferProcessManagerImplTest {
 
     @BeforeEach
     void setup() {
-        when(dataspaceProfileContextRegistry.getWebhook(any())).thenReturn(() -> protocolWebhookUrl);
+        when(protocolWebhookResolver.getWebhook(any(), any())).thenReturn(() -> protocolWebhookUrl);
         when(policyArchive.findPolicyForContract(any())).thenReturn(Policy.Builder.newInstance().build());
         when(policyArchive.getAgreementIdForContract(any())).thenReturn("agreementId");
         when(transferProcessStore.save(any())).thenReturn(StoreResult.success());
@@ -158,7 +158,7 @@ class TransferProcessManagerImplTest {
         var entityRetryProcessFactory = new EntityRetryProcessFactory(mock(), clock, entityRetryProcessConfiguration);
         var transformerProcessors = new TransferProcessorsImpl(policyArchive, entityRetryProcessFactory,
                 dataFlowController, dataAddressStore, observable, transferProcessStore, mock(), addressResolver,
-                dataspaceProfileContextRegistry, dispatcherRegistry);
+                protocolWebhookResolver, dispatcherRegistry);
         manager = TransferProcessManagerImpl.Builder.newInstance()
                 .transferProcessors(transformerProcessors)
                 .waitStrategy(() -> 10000L)
@@ -216,6 +216,76 @@ class TransferProcessManagerImplTest {
             });
             verify(dispatcherRegistry, only()).dispatch(any(), any(), any());
         });
+    }
+
+    private Criterion[] consumerStateIs(int state) {
+        return aryEq(new Criterion[]{hasState(state), isNotPending(), criterion("type", "=", CONSUMER.name())});
+    }
+
+    private Criterion[] providerStateIs(int state) {
+        return aryEq(new Criterion[]{hasState(state), isNotPending(), criterion("type", "=", PROVIDER.name())});
+    }
+
+    private Criterion[] stateIs(int state) {
+        return aryEq(new Criterion[]{hasState(state), isNotPending()});
+    }
+
+    private TransferProcess createTransferProcess(TransferProcessStates inState) {
+        return createTransferProcessBuilder(inState).build();
+    }
+
+    private TransferProcess.Builder createTransferProcessBuilder(TransferProcessStates state) {
+        var processId = UUID.randomUUID().toString();
+
+        return TransferProcess.Builder.newInstance()
+                .type(CONSUMER)
+                .id("test-process-" + processId)
+                .state(state.code())
+                .correlationId(UUID.randomUUID().toString())
+                .counterPartyAddress("http://an/address")
+                .contractId(UUID.randomUUID().toString())
+                .assetId(UUID.randomUUID().toString())
+                .dataDestination(DataAddress.Builder.newInstance().type(DESTINATION_TYPE).build())
+                .participantContextId(PARTICIPANT_CONTEXT_ID)
+                .protocol("protocol");
+    }
+
+    private static class DispatchFailureArguments implements ArgumentsProvider {
+
+        private static final int RETRIES_NOT_EXHAUSTED = RETRY_LIMIT;
+        private static final int RETRIES_EXHAUSTED = RETRIES_NOT_EXHAUSTED + 1;
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
+            CompletableFuture<StatusResult<Object>> genericError = failedFuture(new EdcException("error"));
+            var fatalError = completedFuture(StatusResult.failure(FATAL_ERROR));
+            return Stream.of(
+                    // retries not exhausted
+                    new DispatchFailure(REQUESTING, REQUESTING, genericError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
+                    new DispatchFailure(STARTING, STARTING, genericError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).type(PROVIDER)),
+                    new DispatchFailure(COMPLETING, COMPLETING, genericError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
+                    new DispatchFailure(SUSPENDING, SUSPENDING, genericError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
+                    new DispatchFailure(RESUMING, RESUMING, genericError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).type(PROVIDER)),
+                    new DispatchFailure(RESUMING, RESUMING, genericError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).type(CONSUMER)),
+                    new DispatchFailure(TERMINATING, TERMINATING, genericError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
+                    // retries exhausted
+                    new DispatchFailure(REQUESTING, TERMINATED, genericError, b -> b.stateCount(RETRIES_EXHAUSTED)),
+                    new DispatchFailure(STARTING, TERMINATING, genericError, b -> b.stateCount(RETRIES_EXHAUSTED).type(PROVIDER)),
+                    new DispatchFailure(COMPLETING, TERMINATING, genericError, b -> b.stateCount(RETRIES_EXHAUSTED)),
+                    new DispatchFailure(SUSPENDING, TERMINATING, genericError, b -> b.stateCount(RETRIES_EXHAUSTED)),
+                    new DispatchFailure(RESUMING, TERMINATING, genericError, b -> b.stateCount(RETRIES_EXHAUSTED).type(CONSUMER)),
+                    new DispatchFailure(RESUMING, TERMINATING, genericError, b -> b.stateCount(RETRIES_EXHAUSTED).type(PROVIDER)),
+                    new DispatchFailure(TERMINATING, TERMINATED, genericError, b -> b.stateCount(RETRIES_EXHAUSTED)),
+                    // fatal error, in this case retry should never be done
+                    new DispatchFailure(REQUESTING, TERMINATED, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
+                    new DispatchFailure(STARTING, TERMINATING, fatalError, b -> b.type(PROVIDER).stateCount(RETRIES_NOT_EXHAUSTED)),
+                    new DispatchFailure(COMPLETING, TERMINATING, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
+                    new DispatchFailure(SUSPENDING, TERMINATING, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
+                    new DispatchFailure(RESUMING, TERMINATING, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).type(CONSUMER)),
+                    new DispatchFailure(RESUMING, TERMINATING, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).type(PROVIDER)),
+                    new DispatchFailure(TERMINATING, TERMINATED, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED))
+            );
+        }
     }
 
     @Nested
@@ -1027,76 +1097,6 @@ class TransferProcessManagerImplTest {
             });
         }
 
-    }
-
-    private Criterion[] consumerStateIs(int state) {
-        return aryEq(new Criterion[]{hasState(state), isNotPending(), criterion("type", "=", CONSUMER.name())});
-    }
-
-    private Criterion[] providerStateIs(int state) {
-        return aryEq(new Criterion[]{hasState(state), isNotPending(), criterion("type", "=", PROVIDER.name())});
-    }
-
-    private Criterion[] stateIs(int state) {
-        return aryEq(new Criterion[]{hasState(state), isNotPending()});
-    }
-
-    private TransferProcess createTransferProcess(TransferProcessStates inState) {
-        return createTransferProcessBuilder(inState).build();
-    }
-
-    private TransferProcess.Builder createTransferProcessBuilder(TransferProcessStates state) {
-        var processId = UUID.randomUUID().toString();
-
-        return TransferProcess.Builder.newInstance()
-                .type(CONSUMER)
-                .id("test-process-" + processId)
-                .state(state.code())
-                .correlationId(UUID.randomUUID().toString())
-                .counterPartyAddress("http://an/address")
-                .contractId(UUID.randomUUID().toString())
-                .assetId(UUID.randomUUID().toString())
-                .dataDestination(DataAddress.Builder.newInstance().type(DESTINATION_TYPE).build())
-                .participantContextId(PARTICIPANT_CONTEXT_ID)
-                .protocol("protocol");
-    }
-
-    private static class DispatchFailureArguments implements ArgumentsProvider {
-
-        private static final int RETRIES_NOT_EXHAUSTED = RETRY_LIMIT;
-        private static final int RETRIES_EXHAUSTED = RETRIES_NOT_EXHAUSTED + 1;
-
-        @Override
-        public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
-            CompletableFuture<StatusResult<Object>> genericError = failedFuture(new EdcException("error"));
-            var fatalError = completedFuture(StatusResult.failure(FATAL_ERROR));
-            return Stream.of(
-                    // retries not exhausted
-                    new DispatchFailure(REQUESTING, REQUESTING, genericError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
-                    new DispatchFailure(STARTING, STARTING, genericError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).type(PROVIDER)),
-                    new DispatchFailure(COMPLETING, COMPLETING, genericError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
-                    new DispatchFailure(SUSPENDING, SUSPENDING, genericError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
-                    new DispatchFailure(RESUMING, RESUMING, genericError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).type(PROVIDER)),
-                    new DispatchFailure(RESUMING, RESUMING, genericError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).type(CONSUMER)),
-                    new DispatchFailure(TERMINATING, TERMINATING, genericError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
-                    // retries exhausted
-                    new DispatchFailure(REQUESTING, TERMINATED, genericError, b -> b.stateCount(RETRIES_EXHAUSTED)),
-                    new DispatchFailure(STARTING, TERMINATING, genericError, b -> b.stateCount(RETRIES_EXHAUSTED).type(PROVIDER)),
-                    new DispatchFailure(COMPLETING, TERMINATING, genericError, b -> b.stateCount(RETRIES_EXHAUSTED)),
-                    new DispatchFailure(SUSPENDING, TERMINATING, genericError, b -> b.stateCount(RETRIES_EXHAUSTED)),
-                    new DispatchFailure(RESUMING, TERMINATING, genericError, b -> b.stateCount(RETRIES_EXHAUSTED).type(CONSUMER)),
-                    new DispatchFailure(RESUMING, TERMINATING, genericError, b -> b.stateCount(RETRIES_EXHAUSTED).type(PROVIDER)),
-                    new DispatchFailure(TERMINATING, TERMINATED, genericError, b -> b.stateCount(RETRIES_EXHAUSTED)),
-                    // fatal error, in this case retry should never be done
-                    new DispatchFailure(REQUESTING, TERMINATED, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
-                    new DispatchFailure(STARTING, TERMINATING, fatalError, b -> b.type(PROVIDER).stateCount(RETRIES_NOT_EXHAUSTED)),
-                    new DispatchFailure(COMPLETING, TERMINATING, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
-                    new DispatchFailure(SUSPENDING, TERMINATING, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED)),
-                    new DispatchFailure(RESUMING, TERMINATING, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).type(CONSUMER)),
-                    new DispatchFailure(RESUMING, TERMINATING, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED).type(PROVIDER)),
-                    new DispatchFailure(TERMINATING, TERMINATED, fatalError, b -> b.stateCount(RETRIES_NOT_EXHAUSTED))
-            );
-        }
     }
 
 }

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferCoreExtension.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferCoreExtension.java
@@ -26,7 +26,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowControll
 import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataAddressStore;
-import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.protocol.spi.ProtocolWebhookResolver;
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -82,7 +82,7 @@ public class TransferCoreExtension implements ServiceExtension {
     @Inject
     private DataAddressResolver addressResolver;
     @Inject
-    private DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
+    private ProtocolWebhookResolver protocolWebhookResolver;
     @Inject
     private RemoteMessageDispatcherRegistry dispatcherRegistry;
     @Inject
@@ -108,7 +108,7 @@ public class TransferCoreExtension implements ServiceExtension {
         var entityRetryProcessConfiguration = stateMachineConfiguration.entityRetryProcessConfiguration();
         var entityRetryProcessFactory = new EntityRetryProcessFactory(monitor, clock, entityRetryProcessConfiguration);
         return new TransferProcessorsImpl(policyArchive, entityRetryProcessFactory, dataFlowController, dataAddressStore,
-                observable, store, monitor, addressResolver, dataspaceProfileContextRegistry, dispatcherRegistry);
+                observable, store, monitor, addressResolver, protocolWebhookResolver, dispatcherRegistry);
     }
 
 }

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/processors/TransferProcessorsImpl.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/processors/TransferProcessorsImpl.java
@@ -31,7 +31,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.Transf
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferStartMessage;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferSuspensionMessage;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferTerminationMessage;
-import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.protocol.spi.ProtocolWebhookResolver;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.response.StatusResult;
@@ -65,14 +65,14 @@ public class TransferProcessorsImpl implements TransferProcessors {
     private final TransferProcessStore store;
     private final Monitor monitor;
     private final DataAddressResolver addressResolver;
-    private final DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
+    private final ProtocolWebhookResolver protocolWebhookResolver;
     private final RemoteMessageDispatcherRegistry dispatcherRegistry;
 
     public TransferProcessorsImpl(PolicyArchive policyArchive, EntityRetryProcessFactory entityRetryProcessFactory,
                                   DataFlowController dataFlowController, DataAddressStore dataAddressStore,
                                   TransferProcessObservable observable, TransferProcessStore store, Monitor monitor,
                                   DataAddressResolver addressResolver,
-                                  DataspaceProfileContextRegistry dataspaceProfileContextRegistry,
+                                  ProtocolWebhookResolver protocolWebhookResolver,
                                   RemoteMessageDispatcherRegistry dispatcherRegistry) {
         this.policyArchive = policyArchive;
         this.entityRetryProcessFactory = entityRetryProcessFactory;
@@ -82,7 +82,7 @@ public class TransferProcessorsImpl implements TransferProcessors {
         this.store = store;
         this.monitor = monitor;
         this.addressResolver = addressResolver;
-        this.dataspaceProfileContextRegistry = dataspaceProfileContextRegistry;
+        this.protocolWebhookResolver = protocolWebhookResolver;
         this.dispatcherRegistry = dispatcherRegistry;
     }
 
@@ -163,7 +163,7 @@ public class TransferProcessorsImpl implements TransferProcessors {
     @WithSpan
     @Override
     public CompletableFuture<StatusResult<Void>> processRequesting(TransferProcess process) {
-        var callbackAddress = dataspaceProfileContextRegistry.getWebhook(process.getProtocol());
+        var callbackAddress = protocolWebhookResolver.getWebhook(process.getParticipantContextId(), process.getProtocol());
 
         if (callbackAddress == null) {
             var message = "No callback address found for protocol: " + process.getProtocol();

--- a/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/DspCatalogApi2025Extension.java
+++ b/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/DspCatalogApi2025Extension.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.protocol.dsp.catalog.validation.CatalogRequestMessageVali
 import org.eclipse.edc.protocol.dsp.http.spi.message.ContinuationTokenManager;
 import org.eclipse.edc.protocol.dsp.http.spi.message.DspRequestHandler;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.protocol.spi.ProtocolWebhookResolver;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -39,7 +40,7 @@ import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
 
-import java.util.Objects;
+import java.util.Optional;
 
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DATASPACE_PROTOCOL_HTTP_V_2025_1;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
@@ -82,6 +83,9 @@ public class DspCatalogApi2025Extension implements ServiceExtension {
     @Inject
     private SingleParticipantContextSupplier participantContextSupplier;
 
+    @Inject
+    private ProtocolWebhookResolver protocolWebhookResolver;
+
     @Override
     public String name() {
         return NAME;
@@ -110,11 +114,14 @@ public class DspCatalogApi2025Extension implements ServiceExtension {
     }
 
     private void registerDataService() {
+        dataServiceRegistry.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, this::createDataService);
+    }
 
-        var endpointUrl = Objects.requireNonNull(dataspaceProfileContextRegistry.getWebhook(DATASPACE_PROTOCOL_HTTP_V_2025_1)).url();
-        dataServiceRegistry.register(DATASPACE_PROTOCOL_HTTP_V_2025_1, (ctx, protocol) -> DataService.Builder.newInstance()
-                .endpointDescription("dspace:connector")
-                .endpointUrl(endpointUrl)
-                .build());
+    private DataService createDataService(String participantContextId, String protocol) {
+        return Optional.ofNullable(protocolWebhookResolver.getWebhook(participantContextId, protocol))
+                .map(webhook -> DataService.Builder.newInstance()
+                        .endpointDescription("dspace:connector")
+                        .endpointUrl(webhook.url())
+                        .build()).orElse(null);
     }
 }

--- a/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/DataspaceProfileContextRegistry.java
+++ b/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/DataspaceProfileContextRegistry.java
@@ -16,6 +16,8 @@ package org.eclipse.edc.protocol.spi;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
+
 /**
  * A registry of configured {@link DataspaceProfileContext}.
  * Profile contexts can be of 2 types: default and standard.
@@ -49,16 +51,6 @@ public interface DataspaceProfileContextRegistry {
     ProtocolVersions getProtocolVersions();
 
     /**
-     * Resolve a webhook for a protocol.
-     *
-     * @param protocol The protocol
-     * @return The webhook for the protocol, or null if no webhook is registered for the protocol
-     */
-    @Nullable
-    ProtocolWebhook getWebhook(String protocol);
-
-
-    /**
      * Get the protocol version for a given protocol.
      *
      * @param protocol The protocol name
@@ -66,7 +58,7 @@ public interface DataspaceProfileContextRegistry {
      */
     @Nullable
     ProtocolVersion getProtocolVersion(String protocol);
-    
+
     /**
      * Get the function for participant id extraction for a given protocol.
      *
@@ -75,4 +67,11 @@ public interface DataspaceProfileContextRegistry {
      */
     @Nullable
     ParticipantIdExtractionFunction getIdExtractionFunction(String protocol);
+
+    /**
+     * Get all the registered profiles, if a standard profile is registered, only the standard ones are returned, otherwise all the default ones are returned.
+     *
+     * @return a list of profile contexts. Always not null.
+     */
+    List<DataspaceProfileContext> getProfiles();
 }

--- a/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/ProtocolWebhookResolver.java
+++ b/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/ProtocolWebhookResolver.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Resolves a {@link ProtocolWebhook} for a given participant context and protocol.
+ */
+@ExtensionPoint
+public interface ProtocolWebhookResolver {
+
+    /**
+     * Resolves a {@link ProtocolWebhook} for a given participant context and protocol.
+     *
+     * @param participantContextId the participant context id
+     * @param protocol             the protocol
+     * @return the resolved {@link ProtocolWebhook}, or null if no webhook is found for the given participant context and protocol
+     */
+    @Nullable
+    ProtocolWebhook getWebhook(String participantContextId, String protocol);
+}

--- a/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataplaneSelectorControlApiEndToEndTest.java
+++ b/system-tests/e2e-dataplane-tests/tests/src/test/java/org/eclipse/edc/test/e2e/DataplaneSelectorControlApiEndToEndTest.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.protocol.spi.ProtocolWebhook;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.Order;
@@ -53,6 +54,7 @@ public class DataplaneSelectorControlApiEndToEndTest {
             ":extensions:data-plane:data-plane-signaling:data-plane-signaling-client",
             ":extensions:data-plane-selector:data-plane-selector-control-api")
             .registerServiceMock(ProtocolWebhook.class, mock())
+            .registerServiceMock(DataspaceProfileContextRegistry.class, mock())
             .configurationProvider(() -> ConfigFactory.fromMap(Map.of(
                     "web.http.control.port", String.valueOf(controlPort),
                     "web.http.control.path", "/control",


### PR DESCRIPTION
## What this PR changes/adds

decouple protocol webook resolver from the `DataspaceProfileContextRegistry`. 

For making it work in a backward compatible way currenty the only implementation of a `ProtocolWebookResolver` is `SingleParticipantProtocolWebhookResolver` which is in the shim layer for running a connector in single participant mode for now. This will probably be removed once we complete the EDC-v merge
and transition the dsp protocol impl to be participant context aware only.

## Why it does that

support for EDC-V

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5558 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
