### PR TITLE
feat: expose DPS registration endpoint in management context

### DIFF
--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingApiExtension.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingApiExtension.java
@@ -18,7 +18,7 @@ import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.Trans
 import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.signaling.port.api.DataPlaneRegistrationApiController;
+import org.eclipse.edc.signaling.port.api.DataPlaneRegistrationApiV4Controller;
 import org.eclipse.edc.signaling.port.api.DataPlaneTransferApiController;
 import org.eclipse.edc.signaling.port.transformer.DataAddressToDspDataAddressTransformer;
 import org.eclipse.edc.signaling.port.transformer.DataFlowResponseMessageToDataFlowResponseTransformer;
@@ -56,7 +56,8 @@ public class DataPlaneSignalingApiExtension implements ServiceExtension {
         typeTransformerRegistry.register(new DataAddressToDspDataAddressTransformer());
         typeTransformerRegistry.register(new DataFlowResponseMessageToDataFlowResponseTransformer());
         typeTransformerRegistry.register(new DspDataAddressToDataAddressTransformer());
-        webService.registerResource(ApiContext.CONTROL, new DataPlaneRegistrationApiController(dataPlaneSelectorService));
+
+        webService.registerResource(ApiContext.MANAGEMENT, new DataPlaneRegistrationApiV4Controller(dataPlaneSelectorService));
         webService.registerResource(ApiContext.CONTROL, new DataPlaneTransferApiController(transferProcessService, typeTransformerRegistry));
     }
 

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/port/api/DataPlaneRegistrationApiV4.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/port/api/DataPlaneRegistrationApiV4.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.signaling.port.api;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -29,9 +30,9 @@ import org.eclipse.edc.signaling.domain.DataPlaneRegistrationMessage;
 import static jakarta.ws.rs.HttpMethod.DELETE;
 import static jakarta.ws.rs.HttpMethod.PUT;
 
-@OpenAPIDefinition
-@Tag(name = "Dataplane Signaling Registration")
-public interface DataPlaneRegistrationApi {
+@OpenAPIDefinition(info = @Info(version = "v4"))
+@Tag(name = "Dataplane Signaling Registration v4beta")
+public interface DataPlaneRegistrationApiV4 {
 
     @Operation(
             method = PUT,

--- a/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/port/api/DataPlaneRegistrationApiV4Controller.java
+++ b/data-protocols/data-plane-signaling/src/main/java/org/eclipse/edc/signaling/port/api/DataPlaneRegistrationApiV4Controller.java
@@ -28,18 +28,17 @@ import org.eclipse.edc.signaling.domain.DataPlaneRegistrationMessage;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.mapToException;
 
-@Path("/dataplanes")
+@Path("/v4beta/dataplanes")
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
-public class DataPlaneRegistrationApiController implements DataPlaneRegistrationApi {
+public class DataPlaneRegistrationApiV4Controller implements DataPlaneRegistrationApiV4 {
 
     private final DataPlaneSelectorService dataPlaneSelectorService;
 
-    public DataPlaneRegistrationApiController(DataPlaneSelectorService dataPlaneSelectorService) {
+    public DataPlaneRegistrationApiV4Controller(DataPlaneSelectorService dataPlaneSelectorService) {
         this.dataPlaneSelectorService = dataPlaneSelectorService;
     }
 
-    @Path("/")
     @PUT
     @Override
     public Response register(DataPlaneRegistrationMessage registration) {

--- a/data-protocols/data-plane-signaling/src/test/java/org/eclipse/edc/signaling/DataPlaneRegistrationApiV4ControllerTest.java
+++ b/data-protocols/data-plane-signaling/src/test/java/org/eclipse/edc/signaling/DataPlaneRegistrationApiV4ControllerTest.java
@@ -18,7 +18,7 @@ import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
-import org.eclipse.edc.signaling.port.api.DataPlaneRegistrationApiController;
+import org.eclipse.edc.signaling.port.api.DataPlaneRegistrationApiV4Controller;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
 import org.junit.jupiter.api.Nested;
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class DataPlaneRegistrationApiControllerTest extends RestControllerTestBase {
+public class DataPlaneRegistrationApiV4ControllerTest extends RestControllerTestBase {
 
     private final DataPlaneSelectorService dataPlaneSelectorService = mock();
 
@@ -115,12 +115,13 @@ public class DataPlaneRegistrationApiControllerTest extends RestControllerTestBa
 
     @Override
     protected Object controller() {
-        return new DataPlaneRegistrationApiController(dataPlaneSelectorService);
+        return new DataPlaneRegistrationApiV4Controller(dataPlaneSelectorService);
     }
 
     private RequestSpecification baseRequest() {
         return given()
                 .baseUri("http://localhost:" + port)
+                .basePath("/v4beta")
                 .when();
     }
 }

--- a/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
+++ b/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "2.1.4",
     "urlPath": "/v1",
-    "lastUpdated": "2026-03-19T12:00:01Z",
+    "lastUpdated": "2026-03-20T12:00:01Z",
     "maturity": "stable"
   }
 ]

--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -8,7 +8,7 @@
   {
     "version": "4.0.0-beta",
     "urlPath": "/v4beta",
-    "lastUpdated": "2026-03-17T08:43:01Z",
+    "lastUpdated": "2026-03-20T08:43:01Z",
     "maturity": "beta"
   }
 ]

--- a/extensions/common/api/version-api/src/main/java/org/eclipse/edc/connector/api/management/version/v1/VersionApiController.java
+++ b/extensions/common/api/version-api/src/main/java/org/eclipse/edc/connector/api/management/version/v1/VersionApiController.java
@@ -38,7 +38,6 @@ public class VersionApiController implements VersionApi {
     }
 
     @GET
-    @Path("/")
     @Override
     public Map<String, List<VersionRecord>> getVersion() {
         return apiVersionService.getRecords();

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
@@ -62,11 +62,6 @@ public interface DataPlaneSelectorService {
      */
     ServiceResult<Void> register(DataPlaneInstance instance);
 
-    @Deprecated(since = "0.15.0")
-    default ServiceResult<Void> addInstance(DataPlaneInstance instance) {
-        return register(instance);
-    }
-
     /**
      * Unregister a Data Plane instance. The state will transition to {@link DataPlaneInstanceStates#UNREGISTERED}.
      *

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndParticipant.java
@@ -28,13 +28,10 @@ import java.util.Map;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.edc.web.spi.configuration.ApiContext.CONTROL;
 import static org.eclipse.edc.web.spi.configuration.ApiContext.MANAGEMENT;
 import static org.eclipse.edc.web.spi.configuration.ApiContext.PROTOCOL;
 
 public class TransferEndToEndParticipant extends Participant {
-
-    private LazySupplier<URI> controlPlaneControl;
 
     protected TransferEndToEndParticipant() {
         super();
@@ -50,8 +47,7 @@ public class TransferEndToEndParticipant extends Participant {
                 .id(id)
                 .name(ctx.getName())
                 .managementUrl(ctx.getEndpoint(MANAGEMENT))
-                .protocolUrl(ctx.getEndpoint(PROTOCOL))
-                .controlUrl(ctx.getEndpoint(CONTROL));
+                .protocolUrl(ctx.getEndpoint(PROTOCOL));
     }
 
     /**
@@ -115,12 +111,10 @@ public class TransferEndToEndParticipant extends Participant {
     }
 
     public void registerDataPlane(JsonObject dataPlaneRegistrationMessage) {
-        given()
+        baseManagementRequest()
                 .contentType(JSON)
-                .baseUri(controlPlaneControl.get() + "/dataplanes")
-                .when()
                 .body(dataPlaneRegistrationMessage)
-                .put()
+                .put("/dataplanes")
                 .then()
                 .statusCode(200);
     }
@@ -142,11 +136,6 @@ public class TransferEndToEndParticipant extends Participant {
 
         public Builder protocolUrl(LazySupplier<URI> protocolUrl) {
             participant.controlPlaneProtocol = protocolUrl;
-            return this;
-        }
-
-        public Builder controlUrl(LazySupplier<URI> controlUrl) {
-            participant.controlPlaneControl = controlUrl;
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

Exposes the DPS registration endpoint under the `management` api context

## Why it does that

data plane registration is a resource that would be used from admins/operators and not really something targeted for intra-component communication

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5568

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
