### PR TITLE
feat: move transfer initiate into command handler

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -61,7 +61,6 @@ import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.Trans
 import org.eclipse.edc.connector.controlplane.services.transferprocess.TransferProcessProtocolServiceImpl;
 import org.eclipse.edc.connector.controlplane.services.transferprocess.TransferProcessProviderFactory;
 import org.eclipse.edc.connector.controlplane.services.transferprocess.TransferProcessServiceImpl;
-import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessManager;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowController;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.TransferTypeParser;
 import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
@@ -126,8 +125,6 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     private PolicyDefinitionStore policyDefinitionStore;
     @Inject
     private TransferProcessStore transferProcessStore;
-    @Inject
-    private TransferProcessManager transferProcessManager;
     @Inject
     private TransactionContext transactionContext;
     @Inject
@@ -240,7 +237,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
 
     @Provider
     public TransferProcessService transferProcessService() {
-        return new TransferProcessServiceImpl(transferProcessStore, transferProcessManager, transactionContext,
+        return new TransferProcessServiceImpl(transferProcessStore, transactionContext,
                 dataAddressValidator, commandHandlerRegistry, transferTypeParser, contractNegotiationStore,
                 QueryValidators.transferProcess());
     }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImpl.java
@@ -18,13 +18,13 @@ package org.eclipse.edc.connector.controlplane.services.transferprocess;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.controlplane.services.query.QueryValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
-import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessManager;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.TransferTypeParser;
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.CompleteTransferCommand;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.InitiateTransferCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.NotifyPreparedCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.NotifyStartedCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.ResumeTransferCommand;
@@ -34,7 +34,6 @@ import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.command.CommandHandlerRegistry;
 import org.eclipse.edc.spi.command.EntityCommand;
 import org.eclipse.edc.spi.query.QuerySpec;
-import org.eclipse.edc.spi.result.AbstractResult;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.domain.transfer.FlowType;
 import org.eclipse.edc.transaction.spi.TransactionContext;
@@ -49,7 +48,6 @@ import static java.lang.String.format;
 
 public class TransferProcessServiceImpl implements TransferProcessService {
     private final TransferProcessStore transferProcessStore;
-    private final TransferProcessManager manager;
     private final TransactionContext transactionContext;
     private final QueryValidator queryValidator;
     private final DataAddressValidatorRegistry dataAddressValidator;
@@ -57,12 +55,11 @@ public class TransferProcessServiceImpl implements TransferProcessService {
     private final TransferTypeParser transferTypeParser;
     private final ContractNegotiationStore contractNegotiationStore;
 
-    public TransferProcessServiceImpl(TransferProcessStore transferProcessStore, TransferProcessManager manager,
+    public TransferProcessServiceImpl(TransferProcessStore transferProcessStore,
                                       TransactionContext transactionContext, DataAddressValidatorRegistry dataAddressValidator,
                                       CommandHandlerRegistry commandHandlerRegistry, TransferTypeParser transferTypeParser,
                                       ContractNegotiationStore contractNegotiationStore, QueryValidator queryValidator) {
         this.transferProcessStore = transferProcessStore;
-        this.manager = manager;
         this.transactionContext = transactionContext;
         this.dataAddressValidator = dataAddressValidator;
         this.commandHandlerRegistry = commandHandlerRegistry;
@@ -134,14 +131,15 @@ public class TransferProcessServiceImpl implements TransferProcessService {
             }
         }
 
-        return transactionContext.execute(() -> {
-            var transferInitiateResult = manager.initiateConsumerRequest(participantContext, request);
-            return Optional.ofNullable(transferInitiateResult)
-                    .filter(AbstractResult::succeeded)
-                    .map(AbstractResult::getContent)
-                    .map(ServiceResult::success)
-                    .orElse(ServiceResult.conflict("Request couldn't be initialised."));
-        });
+        return transactionContext.execute(() -> commandHandlerRegistry
+                .execute(new InitiateTransferCommand(participantContext, request))
+                .flatMap(result -> {
+                    if (result.succeeded()) {
+                        return ServiceResult.success((TransferProcess) result.getContent());
+                    } else {
+                        return ServiceResult.from(result);
+                    }
+                }));
     }
 
     @Override

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessEventDispatchTest.java
@@ -165,7 +165,7 @@ public class TransferProcessEventDispatchTest {
 
         var dataAddress = DataAddress.Builder.newInstance().type("test").build();
         var startMessage = TransferStartMessage.Builder.newInstance()
-                .processId("dataRequestId")
+                .processId(initiateResult.getContent().getId())
                 .protocol("any")
                 .counterPartyAddress("http://any")
                 .dataAddress(dataAddress)
@@ -261,7 +261,6 @@ public class TransferProcessEventDispatchTest {
 
     private TransferRequest createTransferRequest() {
         return TransferRequest.Builder.newInstance()
-                .id("dataRequestId")
                 .dataDestination(DataAddress.Builder.newInstance().type("any").build())
                 .protocol("test")
                 .counterPartyAddress("http://an/address")

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImplTest.java
@@ -19,12 +19,12 @@ import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.Con
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.controlplane.services.query.QueryValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
-import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessManager;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.TransferTypeParser;
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.InitiateTransferCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.ResumeTransferCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.SuspendTransferCommand;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.TerminateTransferCommand;
@@ -33,7 +33,6 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.command.CommandHandlerRegistry;
 import org.eclipse.edc.spi.command.CommandResult;
 import org.eclipse.edc.spi.query.QuerySpec;
-import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceFailure;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -58,7 +57,7 @@ import static org.eclipse.edc.spi.result.ServiceFailure.Reason.BAD_REQUEST;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -72,7 +71,6 @@ class TransferProcessServiceImplTest {
     private final TransferProcess process2 = transferProcess();
     private final QuerySpec query = QuerySpec.Builder.newInstance().limit(5).offset(2).build();
     private final TransferProcessStore store = mock();
-    private final TransferProcessManager manager = mock();
     private final TransactionContext transactionContext = spy(new NoopTransactionContext());
     private final DataAddressValidatorRegistry dataAddressValidator = mock();
     private final CommandHandlerRegistry commandHandlerRegistry = mock();
@@ -80,7 +78,7 @@ class TransferProcessServiceImplTest {
     private final ContractNegotiationStore contractNegotiationStore = mock();
     private final QueryValidator queryValidator = mock();
 
-    private final TransferProcessService service = new TransferProcessServiceImpl(store, manager, transactionContext,
+    private final TransferProcessService service = new TransferProcessServiceImpl(store, transactionContext,
             dataAddressValidator, commandHandlerRegistry, transferTypeParser, contractNegotiationStore, queryValidator);
 
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
@@ -199,12 +197,13 @@ class TransferProcessServiceImplTest {
                     .thenReturn(createContractAgreement(transferProcess.getContractId(), "assetId"));
             when(transferTypeParser.parse(any())).thenReturn(Result.success(new TransferType("DestinationType", FlowType.PUSH)));
             when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
-            when(manager.initiateConsumerRequest(any(), eq(transferRequest))).thenReturn(StatusResult.success(transferProcess));
+            when(commandHandlerRegistry.execute(any())).thenReturn(CommandResult.success(transferProcess));
 
             var result = service.initiateTransfer(participantContext, transferRequest);
 
             assertThat(result).isSucceeded().isEqualTo(transferProcess);
             verify(transactionContext).execute(any(TransactionContext.ResultTransactionBlock.class));
+            verify(commandHandlerRegistry).execute(isA(InitiateTransferCommand.class));
         }
 
         @Test
@@ -217,7 +216,6 @@ class TransferProcessServiceImplTest {
                     .extracting(ServiceFailure::getReason)
                     .isEqualTo(BAD_REQUEST);
             assertThat(result.getFailureDetail()).contains("cannot parse");
-            verifyNoInteractions(manager);
         }
 
         @Test
@@ -231,7 +229,6 @@ class TransferProcessServiceImplTest {
                     .extracting(ServiceFailure::getReason)
                     .isEqualTo(BAD_REQUEST);
             assertThat(result.getFailureMessages()).containsExactly("Contract agreement with id %s not found".formatted(transferRequest().getContractId()));
-            verifyNoInteractions(manager);
         }
 
         @Test
@@ -248,7 +245,21 @@ class TransferProcessServiceImplTest {
                     .extracting(ServiceFailure::getReason)
                     .isEqualTo(BAD_REQUEST);
             assertThat(result.getFailureMessages()).containsExactly("invalid data address");
-            verifyNoInteractions(manager);
+        }
+
+        @Test
+        void shouldFail_whenCommandFails() {
+            var transferRequest = transferRequest();
+            var transferProcess = transferProcess();
+            when(contractNegotiationStore.findContractAgreement(transferRequest.getContractId()))
+                    .thenReturn(createContractAgreement(transferProcess.getContractId(), "assetId"));
+            when(transferTypeParser.parse(any())).thenReturn(Result.success(new TransferType("DestinationType", FlowType.PUSH)));
+            when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
+            when(commandHandlerRegistry.execute(any())).thenReturn(CommandResult.notExecutable("error"));
+
+            var result = service.initiateTransfer(participantContext, transferRequest);
+
+            assertThat(result).isFailed();
         }
 
         @Test
@@ -258,7 +269,7 @@ class TransferProcessServiceImplTest {
             when(contractNegotiationStore.findContractAgreement(transferRequest.getContractId()))
                     .thenReturn(createContractAgreement(transferProcess.getContractId(), "assetId"));
             when(transferTypeParser.parse(any())).thenReturn(Result.success(new TransferType("DestinationType", FlowType.PUSH)));
-            when(manager.initiateConsumerRequest(any(), eq(transferRequest))).thenReturn(StatusResult.success(transferProcess));
+            when(commandHandlerRegistry.execute(any())).thenReturn(CommandResult.success(transferProcess));
 
             var result = service.initiateTransfer(participantContext, transferRequest);
 

--- a/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferManagerExtension.java
+++ b/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferManagerExtension.java
@@ -14,15 +14,12 @@
 
 package org.eclipse.edc.connector.controlplane.transfer;
 
-import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyArchive;
 import org.eclipse.edc.connector.controlplane.transfer.process.TransferProcessManagerImpl;
 import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessManager;
 import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessPendingGuard;
 import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessors;
-import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
 import org.eclipse.edc.connector.controlplane.transfer.spi.retry.TransferWaitStrategy;
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataAddressStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -52,10 +49,6 @@ public class TransferManagerExtension implements ServiceExtension {
     @Inject
     private TransferProcessStore transferProcessStore;
     @Inject
-    private TransferProcessObservable observable;
-    @Inject
-    private PolicyArchive policyArchive;
-    @Inject
     private Clock clock;
     @Inject
     private Telemetry telemetry;
@@ -63,8 +56,6 @@ public class TransferManagerExtension implements ServiceExtension {
     private TransferProcessPendingGuard pendingGuard;
     @Inject
     private ExecutorInstrumentation executorInstrumentation;
-    @Inject
-    private DataAddressStore dataAddressStore;
     @Inject
     private TransferProcessors transferProcessors;
 
@@ -89,18 +80,14 @@ public class TransferManagerExtension implements ServiceExtension {
                 .telemetry(telemetry)
                 .executorInstrumentation(executorInstrumentation)
                 .clock(clock)
-                .observable(observable)
                 .store(transferProcessStore)
-                .policyArchive(policyArchive)
                 .batchSize(stateMachineConfiguration.batchSize())
                 .entityRetryProcessConfiguration(entityRetryProcessConfiguration)
                 .pendingGuard(pendingGuard)
-                .dataAddressStore(dataAddressStore)
                 .transferProcessors(transferProcessors)
                 .build();
 
         context.registerService(TransferProcessManager.class, processManager);
-
     }
 
     @Override

--- a/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
+++ b/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImpl.java
@@ -17,21 +17,14 @@
 
 package org.eclipse.edc.connector.controlplane.transfer.process;
 
-import io.opentelemetry.instrumentation.annotations.WithSpan;
-import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyArchive;
 import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessManager;
 import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessPendingGuard;
 import org.eclipse.edc.connector.controlplane.transfer.spi.TransferProcessors;
-import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataAddressStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.response.StatusResult;
-import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.retry.WaitStrategy;
 import org.eclipse.edc.statemachine.AbstractStateEntityManager;
 import org.eclipse.edc.statemachine.Processor;
@@ -39,8 +32,6 @@ import org.eclipse.edc.statemachine.ProcessorImpl;
 import org.eclipse.edc.statemachine.StateMachineManager;
 
 import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -59,7 +50,6 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATING_REQUESTED;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.isNotPending;
-import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
 
 /**
  * This transfer process manager receives a {@link TransferProcess} and transitions it through its internal state
@@ -84,62 +74,10 @@ import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
  */
 public class TransferProcessManagerImpl extends AbstractStateEntityManager<TransferProcess, TransferProcessStore>
         implements TransferProcessManager {
-    private TransferProcessObservable observable;
-    private PolicyArchive policyArchive;
     private TransferProcessPendingGuard pendingGuard = tp -> false;
-    private DataAddressStore dataAddressStore;
     private TransferProcessors transferProcessors;
 
     private TransferProcessManagerImpl() {
-    }
-
-    /**
-     * Initiate a consumer request TransferProcess.
-     */
-    @WithSpan
-    @Override
-    public StatusResult<TransferProcess> initiateConsumerRequest(ParticipantContext participantContext, TransferRequest transferRequest) {
-        var id = Optional.ofNullable(transferRequest.getId()).orElseGet(() -> UUID.randomUUID().toString());
-        var existingTransferProcess = store.findForCorrelationId(id);
-        if (existingTransferProcess != null) {
-            return StatusResult.success(existingTransferProcess);
-        }
-
-        var policy = policyArchive.findPolicyForContract(transferRequest.getContractId());
-        if (policy == null) {
-            return StatusResult.failure(FATAL_ERROR, "No policy found for contract " + transferRequest.getContractId());
-        }
-
-        var process = TransferProcess.Builder.newInstance()
-                .id(id)
-                .assetId(policy.getTarget())
-                .counterPartyAddress(transferRequest.getCounterPartyAddress())
-                .contractId(transferRequest.getContractId())
-                .protocol(transferRequest.getProtocol())
-                .type(CONSUMER)
-                .clock(clock)
-                .transferType(transferRequest.getTransferType())
-                .privateProperties(transferRequest.getPrivateProperties())
-                .callbackAddresses(transferRequest.getCallbackAddresses())
-                .traceContext(telemetry.getCurrentTraceContext())
-                .participantContextId(participantContext.getParticipantContextId())
-                .dataplaneMetadata(transferRequest.getDataplaneMetadata())
-                .build();
-
-        var dataAddressStorage = Optional.ofNullable(transferRequest.getDataDestination())
-                .map(it -> dataAddressStore.store(it, process))
-                .orElse(StoreResult.success());
-
-        return  dataAddressStorage
-                .compose(v -> update(process))
-                .onSuccess(v -> observable.invokeForEach(l -> l.initiated(process)))
-                .flatMap(r -> {
-                    if (r.succeeded()) {
-                        return StatusResult.success(process);
-                    } else {
-                        return StatusResult.failure(FATAL_ERROR, "Failed to initiate Transfer Process: " + r.getFailureDetail());
-                    }
-                });
     }
 
     @Override
@@ -213,23 +151,8 @@ public class TransferProcessManagerImpl extends AbstractStateEntityManager<Trans
             return manager;
         }
 
-        public Builder observable(TransferProcessObservable observable) {
-            manager.observable = observable;
-            return this;
-        }
-
-        public Builder policyArchive(PolicyArchive policyArchive) {
-            manager.policyArchive = policyArchive;
-            return this;
-        }
-
         public Builder pendingGuard(TransferProcessPendingGuard pendingGuard) {
             manager.pendingGuard = pendingGuard;
-            return this;
-        }
-
-        public Builder dataAddressStore(DataAddressStore dataAddressStore) {
-            manager.dataAddressStore = dataAddressStore;
             return this;
         }
 

--- a/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
+++ b/core/control-plane/control-plane-transfer-manager/src/test/java/org/eclipse/edc/connector/controlplane/transfer/process/TransferProcessManagerImplTest.java
@@ -16,7 +16,6 @@
 
 package org.eclipse.edc.connector.controlplane.transfer.process;
 
-import org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata;
 import org.eclipse.edc.connector.controlplane.asset.spi.index.DataAddressResolver;
 import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyArchive;
 import org.eclipse.edc.connector.controlplane.transfer.observe.TransferProcessObservableImpl;
@@ -29,14 +28,12 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataAddressStor
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataFlowResponse;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferCompletionMessage;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferProcessAck;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferRequestMessage;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferStartMessage;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferSuspensionMessage;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferTerminationMessage;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.protocol.spi.ProtocolWebhookResolver;
 import org.eclipse.edc.spi.EdcException;
@@ -46,7 +43,6 @@ import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.retry.ExponentialWaitStrategy;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.statemachine.retry.EntityRetryProcessConfiguration;
 import org.eclipse.edc.statemachine.retry.EntityRetryProcessFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +58,6 @@ import org.mockito.ArgumentCaptor;
 
 import java.time.Clock;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.UnaryOperator;
@@ -93,7 +88,6 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATED;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATING;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATING_REQUESTED;
-import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.isNotPending;
 import static org.eclipse.edc.spi.query.Criterion.criterion;
@@ -165,12 +159,9 @@ class TransferProcessManagerImplTest {
                 .batchSize(TRANSFER_MANAGER_BATCHSIZE)
                 .monitor(mock())
                 .clock(clock)
-                .observable(observable)
                 .store(transferProcessStore)
-                .policyArchive(policyArchive)
                 .entityRetryProcessConfiguration(entityRetryProcessConfiguration)
                 .pendingGuard(pendingGuard)
-                .dataAddressStore(dataAddressStore)
                 .build();
     }
 
@@ -504,107 +495,6 @@ class TransferProcessManagerImplTest {
             });
         }
 
-    }
-
-    @Nested
-    class InitiateConsumerRequest {
-        @Test
-        void shouldStoreTransferProcessAndDataAddress() {
-            when(policyArchive.findPolicyForContract(any())).thenReturn(Policy.Builder.newInstance().target("assetId").build());
-            when(transferProcessStore.findForCorrelationId("1")).thenReturn(null);
-            var callback = CallbackAddress.Builder.newInstance().uri("local://test").events(Set.of("test")).build();
-            var dataplaneMetadata = DataplaneMetadata.Builder.newInstance().label("label").build();
-            var dataAddress = DataAddress.Builder.newInstance().type("test").build();
-            var transferRequest = TransferRequest.Builder.newInstance()
-                    .id("1")
-                    .dataDestination(dataAddress)
-                    .callbackAddresses(List.of(callback))
-                    .dataplaneMetadata(dataplaneMetadata)
-                    .build();
-            var participantContext = ParticipantContext.Builder.newInstance().participantContextId("id")
-                    .identity("identity")
-                    .build();
-            when(dataAddressStore.store(any(), any())).thenReturn(StoreResult.success());
-
-            var result = manager.initiateConsumerRequest(participantContext, transferRequest);
-
-            assertThat(result).isSucceeded().isNotNull();
-            var captor = ArgumentCaptor.forClass(TransferProcess.class);
-            verify(transferProcessStore, times(RETRY_LIMIT)).save(captor.capture());
-            var transferProcess = captor.getValue();
-            assertThat(transferProcess.getId()).isEqualTo("1");
-            assertThat(transferProcess.getCorrelationId()).isNull();
-            assertThat(transferProcess.getCallbackAddresses()).usingRecursiveFieldByFieldElementComparator().contains(callback);
-            assertThat(transferProcess.getAssetId()).isEqualTo("assetId");
-            assertThat(transferProcess.getDataplaneMetadata()).isSameAs(dataplaneMetadata);
-            assertThat(transferProcess.getDataDestination()).isNull();
-            verify(listener).initiated(any());
-            verify(dataAddressStore).store(dataAddress, transferProcess);
-        }
-
-        @Test
-        void shouldNotStoreDataAddress_whenItsNotProvided() {
-            when(policyArchive.findPolicyForContract(any())).thenReturn(Policy.Builder.newInstance().target("assetId").build());
-            when(transferProcessStore.findForCorrelationId("1")).thenReturn(null);
-            var callback = CallbackAddress.Builder.newInstance().uri("local://test").events(Set.of("test")).build();
-            var dataplaneMetadata = DataplaneMetadata.Builder.newInstance().label("label").build();
-            var transferRequest = TransferRequest.Builder.newInstance()
-                    .id("1")
-                    .callbackAddresses(List.of(callback))
-                    .dataplaneMetadata(dataplaneMetadata)
-                    .build();
-            var participantContext = ParticipantContext.Builder.newInstance().participantContextId("id")
-                    .identity("identity")
-                    .build();
-
-            var result = manager.initiateConsumerRequest(participantContext, transferRequest);
-
-            assertThat(result).isSucceeded().isNotNull();
-            verifyNoInteractions(dataAddressStore);
-        }
-
-        @Test
-        void shouldFail_whenPolicyNotAvailable() {
-            when(policyArchive.findPolicyForContract(any())).thenReturn(null);
-            when(transferProcessStore.findForCorrelationId("1")).thenReturn(null);
-
-            var transferRequest = TransferRequest.Builder.newInstance()
-                    .id("1")
-                    .contractId("contractId")
-                    .dataDestination(DataAddress.Builder.newInstance().type("test").build())
-                    .build();
-
-            var participantContext = ParticipantContext.Builder.newInstance()
-                    .participantContextId("participantContextId").identity("id").build();
-            var result = manager.initiateConsumerRequest(participantContext, transferRequest);
-
-            assertThat(result).isFailed();
-        }
-
-        @Test
-        void shouldFail_whenDataAddressStorageFails() {
-            when(policyArchive.findPolicyForContract(any())).thenReturn(Policy.Builder.newInstance().target("assetId").build());
-            when(transferProcessStore.findForCorrelationId("1")).thenReturn(null);
-            var callback = CallbackAddress.Builder.newInstance().uri("local://test").events(Set.of("test")).build();
-            var dataplaneMetadata = DataplaneMetadata.Builder.newInstance().label("label").build();
-            var dataAddress = DataAddress.Builder.newInstance().type("test").build();
-            var transferRequest = TransferRequest.Builder.newInstance()
-                    .id("1")
-                    .dataDestination(dataAddress)
-                    .callbackAddresses(List.of(callback))
-                    .dataplaneMetadata(dataplaneMetadata)
-                    .build();
-            var participantContext = ParticipantContext.Builder.newInstance().participantContextId("id")
-                    .identity("identity")
-                    .build();
-            when(dataAddressStore.store(any(), any())).thenReturn(StoreResult.generalError("error"));
-
-            var result = manager.initiateConsumerRequest(participantContext, transferRequest);
-
-            assertThat(result).isFailed();
-            verifyNoInteractions(listener);
-            verify(transferProcessStore, never()).save(any());
-        }
     }
 
     @Nested

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferProcessCommandExtension.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferProcessCommandExtension.java
@@ -14,7 +14,9 @@
 
 package org.eclipse.edc.connector.controlplane.transfer;
 
+import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyArchive;
 import org.eclipse.edc.connector.controlplane.transfer.command.handlers.CompleteTransferCommandHandler;
+import org.eclipse.edc.connector.controlplane.transfer.command.handlers.InitiateTransferCommandHandler;
 import org.eclipse.edc.connector.controlplane.transfer.command.handlers.NotifyPreparedCommandHandler;
 import org.eclipse.edc.connector.controlplane.transfer.command.handlers.NotifyStartedCommandHandler;
 import org.eclipse.edc.connector.controlplane.transfer.command.handlers.ResumeTransferCommandHandler;
@@ -27,6 +29,9 @@ import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.command.CommandHandlerRegistry;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.telemetry.Telemetry;
+
+import java.time.Clock;
 
 /**
  * Registers command handlers that the core provides
@@ -39,11 +44,19 @@ public class TransferProcessCommandExtension implements ServiceExtension {
     private TransferProcessObservable observable;
     @Inject
     private DataAddressStore dataAddressStore;
+    @Inject
+    private PolicyArchive policyArchive;
+    @Inject
+    private Clock clock;
+    @Inject
+    private Telemetry telemetry;
+    @Inject
+    private CommandHandlerRegistry registry;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var registry = context.getService(CommandHandlerRegistry.class);
-
+        registry.register(new InitiateTransferCommandHandler(policyArchive, store, dataAddressStore, observable, clock,
+                telemetry, context.getMonitor()));
         registry.register(new TerminateTransferCommandHandler(store));
         registry.register(new SuspendTransferCommandHandler(store));
         registry.register(new ResumeTransferCommandHandler(store));

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/InitiateTransferCommandHandler.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/InitiateTransferCommandHandler.java
@@ -1,0 +1,113 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.transfer.command.handlers;
+
+import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyArchive;
+import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
+import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataAddressStore;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.InitiateTransferCommand;
+import org.eclipse.edc.spi.command.CommandHandler;
+import org.eclipse.edc.spi.command.CommandResult;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.spi.telemetry.Telemetry;
+
+import java.time.Clock;
+import java.util.Optional;
+
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess.Type.CONSUMER;
+
+/**
+ * Initiates a transfer process on the consumer side.
+ */
+public class InitiateTransferCommandHandler implements CommandHandler<InitiateTransferCommand> {
+
+    private final PolicyArchive policyArchive;
+    private final TransferProcessStore store;
+    private final DataAddressStore dataAddressStore;
+    private final TransferProcessObservable observable;
+    private final Clock clock;
+    private final Telemetry telemetry;
+    private final Monitor monitor;
+
+    public InitiateTransferCommandHandler(PolicyArchive policyArchive, TransferProcessStore store,
+                                          DataAddressStore dataAddressStore, TransferProcessObservable observable,
+                                          Clock clock, Telemetry telemetry, Monitor monitor) {
+        this.policyArchive = policyArchive;
+        this.store = store;
+        this.dataAddressStore = dataAddressStore;
+        this.observable = observable;
+        this.clock = clock;
+        this.telemetry = telemetry;
+        this.monitor = monitor;
+    }
+
+    @Override
+    public Class<InitiateTransferCommand> getType() {
+        return InitiateTransferCommand.class;
+    }
+
+    @Override
+    public CommandResult handle(InitiateTransferCommand command) {
+        var transferRequest = command.getRequest();
+        var participantContext = command.getParticipantContext();
+
+        var policy = policyArchive.findPolicyForContract(transferRequest.getContractId());
+        if (policy == null) {
+            return CommandResult.notExecutable("No policy found for contract " + transferRequest.getContractId());
+        }
+
+        var process = TransferProcess.Builder.newInstance()
+                .id(command.getEntityId())
+                .assetId(policy.getTarget())
+                .counterPartyAddress(transferRequest.getCounterPartyAddress())
+                .contractId(transferRequest.getContractId())
+                .protocol(transferRequest.getProtocol())
+                .type(CONSUMER)
+                .clock(clock)
+                .transferType(transferRequest.getTransferType())
+                .privateProperties(transferRequest.getPrivateProperties())
+                .callbackAddresses(transferRequest.getCallbackAddresses())
+                .traceContext(telemetry.getCurrentTraceContext())
+                .participantContextId(participantContext.getParticipantContextId())
+                .dataplaneMetadata(transferRequest.getDataplaneMetadata())
+                .build();
+
+        var dataAddressStorage = Optional.ofNullable(transferRequest.getDataDestination())
+                .map(it -> dataAddressStore.store(it, process))
+                .orElse(StoreResult.success());
+
+        return  dataAddressStorage
+                .compose(v -> update(process))
+                .onSuccess(v -> observable.invokeForEach(l -> l.initiated(process)))
+                .flatMap(r -> {
+                    if (r.succeeded()) {
+                        return CommandResult.success(process);
+                    } else {
+                        return CommandResult.notExecutable("Failed to initiate Transfer Process: " + r.getFailureDetail());
+                    }
+                });
+    }
+
+    protected StoreResult<Void> update(TransferProcess entity) {
+        return store.save(entity)
+                .onSuccess(ignored -> {
+                    monitor.debug(() -> "[%s] %s %s is now in state %s".formatted(this.getClass().getSimpleName(),
+                            entity.getClass().getSimpleName(), entity.getId(), entity.stateAsString()));
+                });
+    }
+}

--- a/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/InitiateTransferCommandHandlerTest.java
+++ b/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/InitiateTransferCommandHandlerTest.java
@@ -1,0 +1,162 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.transfer.command.handlers;
+
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata;
+import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyArchive;
+import org.eclipse.edc.connector.controlplane.transfer.observe.TransferProcessObservableImpl;
+import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessListener;
+import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
+import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataAddressStore;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.InitiateTransferCommand;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.spi.telemetry.Telemetry;
+import org.eclipse.edc.spi.types.domain.DataAddress;
+import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Clock;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class InitiateTransferCommandHandlerTest {
+
+    private final PolicyArchive policyArchive = mock();
+    private final TransferProcessStore store = mock();
+    private final DataAddressStore dataAddressStore = mock();
+    private final TransferProcessListener listener = mock();
+    private final Clock clock = mock();
+    private final Telemetry telemetry = mock();
+    private final Monitor monitor = mock();
+    private final TransferProcessObservable observable = new TransferProcessObservableImpl();
+    private final InitiateTransferCommandHandler handler = new InitiateTransferCommandHandler(policyArchive, store,
+            dataAddressStore, observable, clock, telemetry, monitor);
+
+    @BeforeEach
+    void setUp() {
+        observable.registerListener(listener);
+    }
+
+    @Test
+    void shouldStoreTransferProcessAndDataAddress() {
+        when(policyArchive.findPolicyForContract(any())).thenReturn(Policy.Builder.newInstance().target("assetId").build());
+        when(store.save(any())).thenReturn(StoreResult.success());
+        var callback = CallbackAddress.Builder.newInstance().uri("local://test").events(Set.of("test")).build();
+        var dataplaneMetadata = DataplaneMetadata.Builder.newInstance().label("label").build();
+        var dataAddress = DataAddress.Builder.newInstance().type("test").build();
+        var transferRequest = TransferRequest.Builder.newInstance()
+                .dataDestination(dataAddress)
+                .callbackAddresses(List.of(callback))
+                .dataplaneMetadata(dataplaneMetadata)
+                .build();
+        var participantContext = ParticipantContext.Builder.newInstance().participantContextId("id")
+                .identity("identity")
+                .build();
+        when(dataAddressStore.store(any(), any())).thenReturn(StoreResult.success());
+        var command = new InitiateTransferCommand(participantContext, transferRequest);
+
+        var result = handler.handle(command);
+
+        assertThat(result).isSucceeded().isNotNull();
+        var captor = ArgumentCaptor.forClass(TransferProcess.class);
+        verify(store).save(captor.capture());
+        var transferProcess = captor.getValue();
+        assertThat(transferProcess.getId()).isEqualTo(command.getEntityId());
+        assertThat(transferProcess.getCorrelationId()).isNull();
+        assertThat(transferProcess.getCallbackAddresses()).usingRecursiveFieldByFieldElementComparator().contains(callback);
+        assertThat(transferProcess.getAssetId()).isEqualTo("assetId");
+        assertThat(transferProcess.getDataplaneMetadata()).isSameAs(dataplaneMetadata);
+        assertThat(transferProcess.getDataDestination()).isNull();
+        verify(listener).initiated(any());
+        verify(dataAddressStore).store(dataAddress, transferProcess);
+    }
+
+    @Test
+    void shouldNotStoreDataAddress_whenItsNotProvided() {
+        when(policyArchive.findPolicyForContract(any())).thenReturn(Policy.Builder.newInstance().target("assetId").build());
+        when(store.save(any())).thenReturn(StoreResult.success());
+        var callback = CallbackAddress.Builder.newInstance().uri("local://test").events(Set.of("test")).build();
+        var dataplaneMetadata = DataplaneMetadata.Builder.newInstance().label("label").build();
+        var transferRequest = TransferRequest.Builder.newInstance()
+                .callbackAddresses(List.of(callback))
+                .dataplaneMetadata(dataplaneMetadata)
+                .build();
+        var participantContext = ParticipantContext.Builder.newInstance().participantContextId("id")
+                .identity("identity")
+                .build();
+
+        var result = handler.handle(new InitiateTransferCommand(participantContext, transferRequest));
+
+        assertThat(result).isSucceeded().isNotNull();
+        verifyNoInteractions(dataAddressStore);
+    }
+
+    @Test
+    void shouldFail_whenPolicyNotAvailable() {
+        when(policyArchive.findPolicyForContract(any())).thenReturn(null);
+
+        var transferRequest = TransferRequest.Builder.newInstance()
+                .contractId("contractId")
+                .dataDestination(DataAddress.Builder.newInstance().type("test").build())
+                .build();
+
+        var participantContext = ParticipantContext.Builder.newInstance()
+                .participantContextId("participantContextId").identity("id").build();
+        var result = handler.handle(new InitiateTransferCommand(participantContext, transferRequest));
+
+        assertThat(result).isFailed();
+    }
+
+    @Test
+    void shouldFail_whenDataAddressStorageFails() {
+        when(policyArchive.findPolicyForContract(any())).thenReturn(Policy.Builder.newInstance().target("assetId").build());
+        var callback = CallbackAddress.Builder.newInstance().uri("local://test").events(Set.of("test")).build();
+        var dataplaneMetadata = DataplaneMetadata.Builder.newInstance().label("label").build();
+        var dataAddress = DataAddress.Builder.newInstance().type("test").build();
+        var transferRequest = TransferRequest.Builder.newInstance()
+                .dataDestination(dataAddress)
+                .callbackAddresses(List.of(callback))
+                .dataplaneMetadata(dataplaneMetadata)
+                .build();
+        var participantContext = ParticipantContext.Builder.newInstance().participantContextId("id")
+                .identity("identity")
+                .build();
+        when(dataAddressStore.store(any(), any())).thenReturn(StoreResult.generalError("error"));
+
+        var result = handler.handle(new InitiateTransferCommand(participantContext, transferRequest));
+
+        assertThat(result).isFailed();
+        verifyNoInteractions(listener);
+        verify(store, never()).save(any());
+    }
+
+}

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/transferprocess/to/JsonObjectToTransferRequestTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/transferprocess/to/JsonObjectToTransferRequestTransformer.java
@@ -52,7 +52,6 @@ public class JsonObjectToTransferRequestTransformer extends AbstractJsonLdTransf
     public @Nullable TransferRequest transform(@NotNull JsonObject input, @NotNull TransformerContext context) {
         var builder = TransferRequest.Builder.newInstance();
 
-        builder.id(nodeId(input));
         visitProperties(input, key -> switch (key) {
             case TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS -> value ->
                     builder.counterPartyAddress(transformString(value, context));

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/transferprocess/to/JsonObjectToTransferRequestTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/transferprocess/to/JsonObjectToTransferRequestTransformerTest.java
@@ -67,7 +67,6 @@ class JsonObjectToTransferRequestTransformerTest {
 
         var json = createObjectBuilder()
                 .add(TYPE, TRANSFER_REQUEST_TYPE)
-                .add(ID, "id")
                 .add(TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS, "address")
                 .add(TRANSFER_REQUEST_CONTRACT_ID, "contractId")
                 .add(TRANSFER_REQUEST_DATA_DESTINATION, dataDestinationJson)
@@ -81,7 +80,6 @@ class JsonObjectToTransferRequestTransformerTest {
         var result = transformer.transform(json, context);
 
         assertThat(result).isNotNull();
-        assertThat(result.getId()).isEqualTo("id");
         assertThat(result.getCounterPartyAddress()).isEqualTo("address");
         assertThat(result.getContractId()).isEqualTo("contractId");
         assertThat(result.getDataDestination()).isSameAs(dataDestination);

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/TransferProcessManager.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/TransferProcessManager.java
@@ -14,22 +14,13 @@
 
 package org.eclipse.edc.connector.controlplane.transfer.spi;
 
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.entity.StateEntityManager;
-import org.eclipse.edc.spi.response.StatusResult;
 
 /**
  * Manages data transfer processes. Currently synchronous and asynchronous data transfers are supported.
  */
 @ExtensionPoint
 public interface TransferProcessManager extends StateEntityManager {
-
-    /**
-     * Initiates a data transfer process on the consumer.
-     */
-    StatusResult<TransferProcess> initiateConsumerRequest(ParticipantContext participantContext, TransferRequest transferRequest);
 
 }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferRequest.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferRequest.java
@@ -56,10 +56,6 @@ public class TransferRequest {
         return counterPartyAddress;
     }
 
-    public String getId() {
-        return id;
-    }
-
     public String getContractId() {
         return contractId;
     }

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/command/InitiateTransferCommand.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/command/InitiateTransferCommand.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.transfer.spi.types.command;
+
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.spi.command.EntityCommand;
+
+import java.util.UUID;
+
+/**
+ * Initiates a TransferProcess on the Consumer side
+ */
+public class InitiateTransferCommand extends EntityCommand {
+
+    private final ParticipantContext participantContext;
+    private final TransferRequest request;
+
+    public InitiateTransferCommand(ParticipantContext participantContext, TransferRequest request) {
+        super(UUID.randomUUID().toString());
+        this.participantContext = participantContext;
+        this.request = request;
+    }
+
+    public ParticipantContext getParticipantContext() {
+        return participantContext;
+    }
+
+    public TransferRequest getRequest() {
+        return request;
+    }
+}

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/SerdeEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/SerdeEndToEndTest.java
@@ -405,7 +405,6 @@ public class SerdeEndToEndTest {
             var transferRequest = deserialize(typeTransformerRegistry, validatorRegistry, jsonLd, inputObject, TransferRequest.class);
 
             assertThat(transferRequest).isNotNull();
-            assertThat(transferRequest.getId()).isEqualTo(inputObject.getString(ID));
             assertThat(transferRequest.getCounterPartyAddress()).isEqualTo(inputObject.getString("counterPartyAddress"));
             assertThat(transferRequest.getContractId()).isEqualTo(inputObject.getString("contractId"));
             assertThat(transferRequest.getDataDestination()).extracting(DataAddress::getType).isEqualTo(inputObject.getJsonObject("dataDestination").getString("type"));
@@ -425,7 +424,6 @@ public class SerdeEndToEndTest {
             var transferRequest = deserialize(typeTransformerRegistry, validatorRegistry, jsonLd, inputObject, TransferRequest.class);
 
             assertThat(transferRequest).isNotNull();
-            assertThat(transferRequest.getId()).isEqualTo(inputObject.getString(ID));
             assertThat(transferRequest.getCounterPartyAddress()).isEqualTo(inputObject.getString("counterPartyAddress"));
             assertThat(transferRequest.getContractId()).isEqualTo(inputObject.getString("contractId"));
             assertThat(transferRequest.getDataDestination()).extracting(DataAddress::getType).isEqualTo(inputObject.getJsonObject("dataDestination").getString("type"));

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
@@ -303,11 +303,9 @@ public class TestFunctions {
         var propertiesJson = Json.createObjectBuilder().add("foo", "bar").build();
         var privatePropertiesJson = Json.createObjectBuilder().add("fooPrivate", "bar").build();
 
-
         return createObjectBuilder()
                 .add(TYPE, "TransferRequest")
                 .add(CONTEXT, createContextBuilder(context).build())
-                .add(ID, "id")
                 .add("counterPartyAddress", "address")
                 .add("contractId", "contractId")
                 .add("dataDestination", dataDestination)


### PR DESCRIPTION
## What this PR changes/adds

Moved `TransferProcess` initiate method into command handler.

## Why it does that

move logic out of managers

## Further notes
- the `TransferRequest` message allowed custom id to be used, I guess for a point in time in which this was useful, but, to align with the `ContractRequest` that doesn't permit that, I just removed its evaluation, and the id is automatically generated by the system. This permitted to avoid looking for duplicates, plus, there's no real reason to maintain externally generated ids.
- there will be a subsequent refactoring to remove the `CommandResult` content as it was introduced in #5576 to get the job done, but actually the information that's needed by the service layer (entity id and createdAt) are already available there, and the command should stay without content, for sake of simplicity


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5573

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
