### PR TITLE
refactor: switch policy monitor manager from state machine to watchdog

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPoint.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPoint.java
@@ -189,9 +189,9 @@ public class ConfigurationInjectionPoint<T> implements InjectionPoint<T> {
                 .filter(f -> f.getAnnotation(Setting.class) != null)
                 .map(f -> {
                     if (settingContext == null) {
-                        return new SettingInjectionPoint<>(null, f, f.getAnnotation(Setting.class), targetInstance.getClass());
+                        return new SettingInjectionPoint<>(null, f, f.getAnnotation(Setting.class));
                     } else {
-                        return new SettingInjectionPoint<>(null, f, f.getAnnotation(Setting.class), targetInstance.getClass(), settingContext);
+                        return new SettingInjectionPoint<>(null, f, f.getAnnotation(Setting.class), settingContext);
                     }
                 });
     }

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/InjectionPointScanner.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/InjectionPointScanner.java
@@ -46,7 +46,7 @@ public class InjectionPointScanner {
                 .filter(f -> f.getAnnotation(Setting.class) != null && !Setting.NULL.equals(f.getAnnotation(Setting.class).key()))
                 .map(f -> {
                     var annotation = f.getAnnotation(Setting.class);
-                    return new SettingInjectionPoint<>(instance, f, annotation, targetClass);
+                    return new SettingInjectionPoint<>(instance, f, annotation);
                 });
 
         // scan configuration injection points

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/SettingInjectionPoint.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/SettingInjectionPoint.java
@@ -22,6 +22,8 @@ import org.eclipse.edc.spi.system.ValueProvider;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Field;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
 
@@ -47,7 +49,6 @@ public class SettingInjectionPoint<T> implements InjectionPoint<T> {
     private final T objectInstance;
     private final Field targetField;
     private final Setting annotationValue;
-    private final Class<?> declaringClass;
     private final String key;
 
     /**
@@ -56,16 +57,14 @@ public class SettingInjectionPoint<T> implements InjectionPoint<T> {
      * @param objectInstance  The object instance that contains the annotated field. May be null in case the declaring class is not a {@link org.eclipse.edc.spi.system.SystemExtension}
      * @param targetField     The annotated {@link Field}
      * @param annotationValue The concrete annotation instance (needed to obtain its attributes)
-     * @param declaringClass  The class where the annotated field is declared. Usually, this is {@code objectInstance.getClass()}.
      */
-    public SettingInjectionPoint(T objectInstance, Field targetField, Setting annotationValue, Class<?> declaringClass) {
-        this(objectInstance, targetField, annotationValue, declaringClass, null);
+    public SettingInjectionPoint(T objectInstance, Field targetField, Setting annotationValue) {
+        this(objectInstance, targetField, annotationValue, null);
     }
 
-    public SettingInjectionPoint(T objectInstance, Field targetField, Setting annotationValue, Class<?> declaringClass, SettingContext settingContext) {
+    public SettingInjectionPoint(T objectInstance, Field targetField, Setting annotationValue, SettingContext settingContext) {
         this.objectInstance = objectInstance;
         this.targetField = targetField;
-        this.declaringClass = declaringClass;
         this.targetField.setAccessible(true);
         this.annotationValue = annotationValue;
         this.key = settingContext == null ? annotationValue.key() : settingContext.value() + "." + annotationValue.key();
@@ -201,9 +200,13 @@ public class SettingInjectionPoint<T> implements InjectionPoint<T> {
             if (valueType == Double.class || valueType == double.class) {
                 return Double.parseDouble(string);
             }
-        } catch (NumberFormatException e) {
+            if (valueType == Duration.class) {
+                return Duration.parse(string);
+            }
+        } catch (NumberFormatException | DateTimeParseException e) {
             throw new EdcInjectionException("Config field '%s' is of type '%s', but the value resolved from key '%s' is \"%s\" which cannot be interpreted as %s.".formatted(targetField.getName(), valueType, key, string, valueType));
         }
+
         if (valueType == Boolean.class || valueType == boolean.class) {
             return Boolean.parseBoolean(string);
         }

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPointTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPointTest.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,7 +56,7 @@ class ConfigurationInjectionPointTest {
 
         @Test
         void setTargetValue() {
-            var result = injectionPoint.setTargetValue(new ConfigurationObject("foo", 42L, null, 3.14159));
+            var result = injectionPoint.setTargetValue(new ConfigurationObject("foo", 42L, null, 3.14159, Duration.ofSeconds(3)));
 
             assertThat(result.succeeded()).isTrue();
         }
@@ -76,11 +77,17 @@ class ConfigurationInjectionPointTest {
         void resolve_objectIsRecord() {
             var context = mock(ServiceExtensionContext.class);
             when(context.getMonitor()).thenReturn(mock());
-            when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of("foo.bar.baz", "asdf",
-                    "test.key3", "42")));
+            when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
+                    "foo.bar.baz", "asdf",
+                    "test.key3", "42",
+                    "test.duration", "PT10S"
+            )));
 
             var res = injectionPoint.resolve(context, mock());
-            assertThat(res).isInstanceOf(ConfigurationObject.class);
+
+            assertThat(res).isInstanceOfSatisfying(ConfigurationObject.class, configurationObject -> {
+                assertThat(configurationObject.duration()).isEqualTo(Duration.ofSeconds(10));
+            });
         }
 
         @Test

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/SettingInjectionPointTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/SettingInjectionPointTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.boot.system.injection;
 
-import org.eclipse.edc.boot.system.testextensions.ConfigurationObject;
 import org.eclipse.edc.boot.system.testextensions.ExtensionWithConfigValue;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -45,7 +44,7 @@ class SettingInjectionPointTest {
         @Test
         void isRequired() {
             assertThat(getInjectionPoint().isRequired()).isTrue();
-            var ip2 = createInjectionPoint(getTargetObject(), "optionalVal", Long.class);
+            var ip2 = createInjectionPoint(getTargetObject(), "optionalVal");
             assertThat(ip2.isRequired()).isFalse();
         }
 
@@ -77,7 +76,7 @@ class SettingInjectionPointTest {
             var config = ConfigFactory.fromMap(Map.of());
             when(contextMock.getConfig()).thenReturn(config);
             when(contextMock.getMonitor()).thenReturn(mock());
-            var ip = createInjectionPoint(getInjectionPoint(), "requiredValWithDefault", ExtensionWithConfigValue.class);
+            var ip = createInjectionPoint(getInjectionPoint(), "requiredValWithDefault");
             assertThat(ip.resolve(contextMock, new InjectionPointDefaultServiceSupplier())).isEqualTo(ExtensionWithConfigValue.DEFAULT_VALUE);
         }
 
@@ -87,7 +86,7 @@ class SettingInjectionPointTest {
             var config = ConfigFactory.fromMap(Map.of());
             when(contextMock.getConfig()).thenReturn(config);
             when(contextMock.getMonitor()).thenReturn(mock());
-            var ip = createInjectionPoint(getTargetObject(), "requiredDoubleVal", ExtensionWithConfigValue.class);
+            var ip = createInjectionPoint(getTargetObject(), "requiredDoubleVal");
             assertThatThrownBy(() -> ip.resolve(contextMock, mock())).isInstanceOf(EdcInjectionException.class);
         }
 
@@ -112,13 +111,13 @@ class SettingInjectionPointTest {
             var contextMock = mock(ServiceExtensionContext.class);
             var config = ConfigFactory.fromMap(Map.of());
             when(contextMock.getConfig()).thenReturn(config);
-            var ip = createInjectionPoint(getTargetObject(), "optionalVal", ExtensionWithConfigValue.class);
+            var ip = createInjectionPoint(getTargetObject(), "optionalVal");
             assertThat(ip.resolve(contextMock, mock())).isNull();
         }
 
         @Test
         void isSatisfiedBy_whenOptional() {
-            var ip = createInjectionPoint(getTargetObject(), "optionalVal", ExtensionWithConfigValue.class);
+            var ip = createInjectionPoint(getTargetObject(), "optionalVal");
             var contextMock = mock(ServiceExtensionContext.class);
             var config = ConfigFactory.fromMap(Map.of());
             when(contextMock.getConfig()).thenReturn(config);
@@ -127,7 +126,7 @@ class SettingInjectionPointTest {
 
         @Test
         void isSatisfiedBy_whenRequired_satisfiedByDefaultValue() {
-            var ip = createInjectionPoint(getTargetObject(), "requiredValWithDefault", ExtensionWithConfigValue.class);
+            var ip = createInjectionPoint(getTargetObject(), "requiredValWithDefault");
             var contextMock = mock(ServiceExtensionContext.class);
             var config = ConfigFactory.fromMap(Map.of());
             when(contextMock.getConfig()).thenReturn(config);
@@ -137,7 +136,7 @@ class SettingInjectionPointTest {
 
         @Test
         void isSatisfiedBy_whenRequired_satisfiedByConfig() {
-            var ip = createInjectionPoint(getTargetObject(), "requiredVal", ExtensionWithConfigValue.class);
+            var ip = createInjectionPoint(getTargetObject(), "requiredVal");
             var contextMock = mock(ServiceExtensionContext.class);
             var config = ConfigFactory.fromMap(Map.of("test.key", "test.value"));
             when(contextMock.getConfig()).thenReturn(config);
@@ -147,7 +146,7 @@ class SettingInjectionPointTest {
 
         @Test
         void isSatisfiedBy_whenRequired_notSatisfied() {
-            var ip = createInjectionPoint(getTargetObject(), "requiredVal", ExtensionWithConfigValue.class);
+            var ip = createInjectionPoint(getTargetObject(), "requiredVal");
             var contextMock = mock(ServiceExtensionContext.class);
             var config = ConfigFactory.fromMap(Map.of());
             when(contextMock.getConfig()).thenReturn(config);
@@ -160,7 +159,7 @@ class SettingInjectionPointTest {
     class DeclaredOnExtension extends Tests {
 
         private final ExtensionWithConfigValue targetObject = new ExtensionWithConfigValue();
-        private final SettingInjectionPoint<?> injectionPoint = createInjectionPoint(targetObject, "requiredVal", targetObject.getClass());
+        private final SettingInjectionPoint<?> injectionPoint = createInjectionPoint(targetObject, "requiredVal");
 
         @Test
         void getTargetInstance() {
@@ -190,7 +189,7 @@ class SettingInjectionPointTest {
 
     @Nested
     class DeclaredOnConfigObject extends Tests {
-        private final SettingInjectionPoint<?> injectionPoint = createInjectionPoint(null, "requiredVal", ConfigurationObject.class);
+        private final SettingInjectionPoint<?> injectionPoint = createInjectionPoint(null, "requiredVal");
 
         @Test
         void getTargetInstance() {
@@ -198,7 +197,7 @@ class SettingInjectionPointTest {
         }
 
         @Test
-        void setTargetValue() throws IllegalAccessException {
+        void setTargetValue() {
             assertThat(getInjectionPoint().setTargetValue("test").succeeded()).isFalse();
         }
 
@@ -213,10 +212,9 @@ class SettingInjectionPointTest {
         }
     }
 
-
-    private SettingInjectionPoint<?> createInjectionPoint(Object targetObject, String fieldName, Class<?> targetClass) {
+    private SettingInjectionPoint<?> createInjectionPoint(Object targetObject, String fieldName) {
         var field = getDeclaredField(ExtensionWithConfigValue.class, fieldName);
-        return new SettingInjectionPoint<>(targetObject, field, field.getAnnotation(Setting.class), targetClass);
+        return new SettingInjectionPoint<>(targetObject, field, field.getAnnotation(Setting.class));
     }
 
 }

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/testextensions/ConfigurationObject.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/testextensions/ConfigurationObject.java
@@ -17,12 +17,15 @@ package org.eclipse.edc.boot.system.testextensions;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 
+import java.time.Duration;
+
 import static org.eclipse.edc.boot.system.testextensions.ExtensionWithConfigValue.DEFAULT_VALUE;
 
 @Settings
 public record ConfigurationObject(@Setting(key = "foo.bar.baz") String requiredVal,
                                   @Setting(key = "quizz.quazz", required = false) Long optionalVal,
                                   @Setting(key = "test.key2", defaultValue = DEFAULT_VALUE) String requiredValWithDefault,
-                                  @Setting(key = "test.key3", defaultValue = DEFAULT_VALUE) Double requiredDoubleVal) {
+                                  @Setting(key = "test.key3", defaultValue = DEFAULT_VALUE) Double requiredDoubleVal,
+                                  @Setting(key = "test.duration", defaultValue = "PT1S") Duration duration) {
 
 }

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/testextensions/ExtensionWithConfigValue.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/testextensions/ExtensionWithConfigValue.java
@@ -17,6 +17,8 @@ package org.eclipse.edc.boot.system.testextensions;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 
+import java.time.Duration;
+
 public class ExtensionWithConfigValue implements ServiceExtension {
 
     public static final String DEFAULT_VALUE = "default-value";
@@ -31,4 +33,7 @@ public class ExtensionWithConfigValue implements ServiceExtension {
 
     @Setting(key = "test.key3", defaultValue = DEFAULT_VALUE)
     private Double requiredDoubleVal;
+
+    @Setting(key = "test.duration", defaultValue = "PT1H")
+    private Duration duration;
 }

--- a/core/policy-monitor/policy-monitor-core/build.gradle.kts
+++ b/core/policy-monitor/policy-monitor-core/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 dependencies {
     api(project(":spi:policy-monitor:policy-monitor-spi"))
     api(project(":spi:common:json-ld-spi"))
+    api(project(":spi:common:transaction-spi"))
     api(project(":spi:control-plane:control-plane-spi"))
     api(project(":spi:control-plane:policy-spi"))
     api(project(":spi:control-plane:transfer-spi"))

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorConfiguration.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.policy.monitor;
+
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+
+import java.time.Duration;
+
+/**
+ * Configuration for the policy monitor watchdog.
+ */
+@Settings
+public record PolicyMonitorConfiguration(
+
+        @Setting(
+                description = "The number of policy monitor entries to be evaluated on every watchdog run.",
+                key = "batch-size",
+                defaultValue = "20"
+        )
+        int batchSize,
+
+        @Setting(
+                description = "Time period between policy monitor evaluations in ISO-8061 duration format.",
+                key = "period",
+                defaultValue = "PT1H"
+        )
+        Duration period
+) {
+}

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorDefaultServicesExtension.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorDefaultServicesExtension.java
@@ -15,7 +15,7 @@
 package org.eclipse.edc.connector.policy.monitor;
 
 import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorStore;
-import org.eclipse.edc.connector.policy.monitor.store.sql.InMemoryPolicyMonitorStore;
+import org.eclipse.edc.connector.policy.monitor.store.InMemoryPolicyMonitorStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorExtension.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.controlplane.policy.contract.ContractExpiryChec
 import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.ContractAgreementService;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.controlplane.transfer.spi.event.TransferProcessStarted;
+import org.eclipse.edc.connector.policy.monitor.manager.PolicyMonitor;
 import org.eclipse.edc.connector.policy.monitor.manager.PolicyMonitorManagerImpl;
 import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorContext;
 import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorManager;
@@ -36,7 +37,7 @@ import org.eclipse.edc.spi.system.ExecutorInstrumentation;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.telemetry.Telemetry;
-import org.eclipse.edc.statemachine.StateMachineConfiguration;
+import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import java.time.Clock;
 
@@ -53,62 +54,49 @@ public class PolicyMonitorExtension implements ServiceExtension {
 
     @SettingContext("edc.policy.monitor")
     @Configuration
-    private StateMachineConfiguration stateMachineConfiguration;
+    private PolicyMonitorConfiguration configuration;
 
     @Inject
     private ExecutorInstrumentation executorInstrumentation;
-
     @Inject
     private Telemetry telemetry;
-
     @Inject
     private Clock clock;
-
     @Inject
     private EventRouter eventRouter;
-
     @Inject
     private ContractAgreementService contractAgreementService;
-
     @Inject
     private PolicyEngine policyEngine;
-
     @Inject
     private TransferProcessService transferProcessService;
-
     @Inject
     private PolicyMonitorStore policyMonitorStore;
-
     @Inject
     private RuleBindingRegistry ruleBindingRegistry;
+    @Inject
+    private TransactionContext transactionContext;
 
     private PolicyMonitorManager manager;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
 
+        failWhenSettingsAreNotUpdated(context);
+
         policyEngine.registerScope(POLICY_MONITOR_SCOPE, PolicyMonitorContext.class);
         ruleBindingRegistry.bind(ODRL_USE_ACTION_ATTRIBUTE, POLICY_MONITOR_SCOPE);
         ruleBindingRegistry.bind(CONTRACT_EXPIRY_EVALUATION_KEY, POLICY_MONITOR_SCOPE);
         policyEngine.registerFunction(PolicyMonitorContext.class, Permission.class, CONTRACT_EXPIRY_EVALUATION_KEY, new ContractExpiryCheckFunction<>());
 
-        manager = PolicyMonitorManagerImpl.Builder.newInstance()
-                .clock(clock)
-                .batchSize(stateMachineConfiguration.batchSize())
-                .waitStrategy(stateMachineConfiguration.iterationWaitExponentialWaitStrategy())
-                .executorInstrumentation(executorInstrumentation)
-                .monitor(context.getMonitor())
-                .telemetry(telemetry)
-                .contractAgreementService(contractAgreementService)
-                .policyEngine(policyEngine)
-                .transferProcessService(transferProcessService)
-                .store(policyMonitorStore)
-                .entityRetryProcessConfiguration(stateMachineConfiguration.entityRetryProcessConfiguration())
-                .build();
+        var policyMonitor = new PolicyMonitor(policyMonitorStore, telemetry, transferProcessService,
+                contractAgreementService, policyEngine, context.getMonitor(), clock, transactionContext);
+
+        manager = new PolicyMonitorManagerImpl(policyMonitor, configuration, executorInstrumentation, context.getMonitor(), policyMonitorStore, clock);
 
         context.registerService(PolicyMonitorManager.class, manager);
 
-        eventRouter.registerSync(TransferProcessStarted.class, new StartMonitoring(manager));
+        eventRouter.registerSync(TransferProcessStarted.class, new StartMonitoring(policyMonitor));
     }
 
     @Override
@@ -120,6 +108,20 @@ public class PolicyMonitorExtension implements ServiceExtension {
     public void shutdown() {
         if (manager != null) {
             manager.stop();
+        }
+    }
+
+    @Deprecated(since = "0.17.0")
+    private void failWhenSettingsAreNotUpdated(ServiceExtensionContext context) {
+        if (!context.getConfig("edc.policy.monitor.state-machine").getEntries().isEmpty()) {
+            var message = """
+                    Policy Monitor model has been changed from a state machine to a watchdog, please
+                    review the configuration accordingly: 'edc.policy.manager.batch-size' to set up the batch size,
+                    'edc.policy.manager.period' to set up the period in ISO-8061 Duration format. The
+                    'edc.policy.manager.state-machine' settings must be deleted.
+                    """;
+            context.getMonitor().severe(message);
+            throw new RuntimeException(message);
         }
     }
 

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitor.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitor.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.policy.monitor.manager;
+
+import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.ContractAgreementService;
+import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.TerminateTransferCommand;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorContext;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntry;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorStore;
+import org.eclipse.edc.policy.engine.spi.PolicyEngine;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.eclipse.edc.spi.telemetry.Telemetry;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+
+import java.time.Clock;
+import java.time.Instant;
+
+public class PolicyMonitor {
+
+    private final PolicyMonitorStore store;
+    private final Telemetry telemetry;
+    private final TransferProcessService transferProcessService;
+    private final ContractAgreementService contractAgreementService;
+    private final PolicyEngine policyEngine;
+    private final Monitor monitor;
+    private final Clock clock;
+    private final TransactionContext transactionContext;
+
+    public PolicyMonitor(PolicyMonitorStore store, Telemetry telemetry, TransferProcessService transferProcessService,
+                         ContractAgreementService contractAgreementService, PolicyEngine policyEngine, Monitor monitor,
+                         Clock clock, TransactionContext transactionContext) {
+        this.store = store;
+        this.telemetry = telemetry;
+        this.transferProcessService = transferProcessService;
+        this.contractAgreementService = contractAgreementService;
+        this.policyEngine = policyEngine;
+        this.monitor = monitor.withPrefix(getClass().getSimpleName());
+        this.clock = clock;
+        this.transactionContext = transactionContext;
+    }
+
+    public StatusResult<Void> start(String transferProcessId, String contractId) {
+        var entry = PolicyMonitorEntry.Builder.newInstance()
+                .id(transferProcessId)
+                .contractId(contractId)
+                .traceContext(telemetry.getCurrentTraceContext())
+                .build();
+
+        entry.transitionToStarted();
+
+        return store.save(entry).flatMap(StatusResult::from);
+    }
+
+    public void monitor(PolicyMonitorEntry entry) {
+        transactionContext.execute(() -> {
+            var transferProcess = transferProcessService.findById(entry.getId());
+            if (transferProcess == null) {
+                var message = "TransferProcess %s does not exist".formatted(entry.getId());
+                entry.transitionToFailed(message);
+                update(entry);
+                return;
+            }
+
+            if (transferProcess.getState() >= TransferProcessStates.COMPLETING.code()) {
+                entry.transitionToCompleted();
+                update(entry);
+                return;
+            }
+
+            var contractAgreement = contractAgreementService.findById(entry.getContractId());
+            if (contractAgreement == null) {
+                var message = "ContractAgreement %s does not exist".formatted(entry.getContractId());
+                entry.transitionToFailed(message);
+                update(entry);
+                return;
+            }
+
+            var policy = contractAgreement.getPolicy();
+            var policyContext = new PolicyMonitorContext(Instant.now(clock), contractAgreement);
+
+            var result = policyEngine.evaluate(policy, policyContext);
+            if (result.failed()) {
+                monitor.debug(() -> "Policy evaluation for TP %s failed: %s".formatted(entry.getId(), result.getFailureDetail()));
+                var command = new TerminateTransferCommand(entry.getId(), result.getFailureDetail());
+                var terminationResult = transferProcessService.terminate(command);
+                if (terminationResult.succeeded()) {
+                    entry.transitionToCompleted();
+                    update(entry);
+                    return;
+                } else {
+                    monitor.severe("Cannot terminate Transfer %s because: %s".formatted(entry.getId(), terminationResult.getFailureDetail()));
+                }
+            }
+
+            entry.updateStateTimestamp();
+            store.save(entry);
+        });
+    }
+
+    private void update(PolicyMonitorEntry entry) {
+        store.save(entry).onSuccess(it -> {
+            var error = entry.getErrorDetail() == null ? "" : ". errorDetail: " + entry.getErrorDetail();
+            monitor.debug(() -> "PolicyMonitorEntry %s is now in state %s%s"
+                    .formatted(entry.getId(), entry.stateAsString(), error));
+        });
+    }
+}

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImpl.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImpl.java
@@ -14,145 +14,103 @@
 
 package org.eclipse.edc.connector.policy.monitor.manager;
 
-import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.ContractAgreementService;
-import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.TerminateTransferCommand;
-import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorContext;
+import org.eclipse.edc.connector.policy.monitor.PolicyMonitorConfiguration;
 import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntry;
-import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates;
 import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorManager;
 import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorStore;
-import org.eclipse.edc.policy.engine.spi.PolicyEngine;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.Criterion;
-import org.eclipse.edc.spi.response.StatusResult;
-import org.eclipse.edc.statemachine.AbstractStateEntityManager;
-import org.eclipse.edc.statemachine.Processor;
-import org.eclipse.edc.statemachine.ProcessorImpl;
-import org.eclipse.edc.statemachine.StateMachineManager;
+import org.eclipse.edc.spi.system.ExecutorInstrumentation;
+import org.jetbrains.annotations.NotNull;
 
-import java.time.Instant;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
+import java.time.Clock;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.STARTED;
 import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
 
 /**
- * Implementation of the {@link PolicyMonitorManager}
+ * Implementation of the {@link PolicyMonitorManager}.
+ * <p>
+ * Acts as a watchdog: on a fixed schedule it queries all active policy monitor entries and
+ * evaluates their policies, terminating the associated transfer process when a policy is no
+ * longer satisfied.
  */
-public class PolicyMonitorManagerImpl extends AbstractStateEntityManager<PolicyMonitorEntry, PolicyMonitorStore>
-        implements PolicyMonitorManager {
+public class PolicyMonitorManagerImpl implements PolicyMonitorManager {
 
-    private PolicyEngine policyEngine;
-    private TransferProcessService transferProcessService;
-    private ContractAgreementService contractAgreementService;
+    private final PolicyMonitorStore store;
+    private final Monitor monitor;
+    private final ExecutorInstrumentation executorInstrumentation;
+    private final PolicyMonitor policyMonitor;
+    private final PolicyMonitorConfiguration configuration;
 
-    private PolicyMonitorManagerImpl() {
+    private ScheduledExecutorService scheduler;
+    private final Clock clock;
 
+    public PolicyMonitorManagerImpl(PolicyMonitor policyMonitor, PolicyMonitorConfiguration configuration,
+                                    ExecutorInstrumentation executorInstrumentation, Monitor monitor,
+                                    PolicyMonitorStore store, Clock clock) {
+        this.policyMonitor = policyMonitor;
+        this.configuration = configuration;
+        this.executorInstrumentation = executorInstrumentation;
+        this.monitor = monitor.withPrefix(getClass().getSimpleName());
+        this.store = store;
+        this.clock = clock;
+        scheduler = executorInstrumentation.instrument(
+                Executors.newSingleThreadScheduledExecutor(r -> {
+                    var thread = Executors.defaultThreadFactory().newThread(r);
+                    thread.setName("policy-monitor-watchdog");
+                    return thread;
+                }), "policy-monitor");
     }
 
     @Override
-    public void startMonitoring(String transferProcessId, String contractId) {
-        var entry = PolicyMonitorEntry.Builder.newInstance()
-                .id(transferProcessId)
-                .contractId(contractId)
-                .traceContext(telemetry.getCurrentTraceContext())
-                .build();
+    public void start() {
+        scheduler = executorInstrumentation.instrument(
+                Executors.newSingleThreadScheduledExecutor(r -> {
+                    var thread = Executors.defaultThreadFactory().newThread(r);
+                    thread.setName("policy-monitor-watchdog");
+                    return thread;
+                }), "policy-monitor");
 
-        entry.transitionToStarted();
-
-        update(entry);
+        scheduler.schedule(this::checkPolicies, 0, TimeUnit.SECONDS);
     }
 
     @Override
-    protected StateMachineManager.Builder configureStateMachineManager(StateMachineManager.Builder builder) {
-        return builder
-                .processor(processEntriesInState(STARTED, this::processMonitoring));
-    }
-
-    private CompletableFuture<StatusResult<Void>> processMonitoring(PolicyMonitorEntry entry) {
-        var transferProcess = transferProcessService.findById(entry.getId());
-        if (transferProcess == null) {
-            var message = "TransferProcess %s does not exist".formatted(entry.getId());
-            entry.transitionToFailed(message);
-            update(entry);
-            return CompletableFuture.completedFuture(StatusResult.fatalError(message));
-        }
-
-        if (transferProcess.getState() >= TransferProcessStates.COMPLETING.code()) {
-            entry.transitionToCompleted();
-            update(entry);
-            return CompletableFuture.completedFuture(StatusResult.success());
-        }
-
-        var contractAgreement = contractAgreementService.findById(entry.getContractId());
-        if (contractAgreement == null) {
-            var message = "ContractAgreement %s does not exist".formatted(entry.getContractId());
-            entry.transitionToFailed(message);
-            update(entry);
-            return CompletableFuture.completedFuture(StatusResult.fatalError(message));
-        }
-
-        var policy = contractAgreement.getPolicy();
-        var policyContext = new PolicyMonitorContext(Instant.now(clock), contractAgreement);
-
-        var result = policyEngine.evaluate(policy, policyContext);
-        if (result.failed()) {
-            monitor.debug(() -> "[policy-monitor] Policy evaluation for TP %s failed: %s".formatted(entry.getId(), result.getFailureDetail()));
-            var command = new TerminateTransferCommand(entry.getId(), result.getFailureDetail());
-            var terminationResult = transferProcessService.terminate(command);
-            if (terminationResult.succeeded()) {
-                entry.transitionToCompleted();
-                update(entry);
-                return CompletableFuture.completedFuture(StatusResult.success());
+    public void stop() {
+        if (scheduler != null) {
+            scheduler.shutdown();
+            try {
+                if (!scheduler.awaitTermination(10, TimeUnit.SECONDS)) {
+                    scheduler.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                monitor.severe("PolicyMonitorManager await termination failed", e);
+                scheduler.shutdownNow();
+                Thread.currentThread().interrupt();
             }
         }
-
-        // we update the state timestamp ensure fairness on polling on  `STARTED` state
-        entry.updateStateTimestamp();
-        store.save(entry);
-        return CompletableFuture.completedFuture(StatusResult.success());
     }
 
-    private Processor processEntriesInState(PolicyMonitorEntryStates state, Function<PolicyMonitorEntry, CompletableFuture<StatusResult<Void>>> function) {
-        var filter = new Criterion[]{ hasState(state.code()) };
-        return ProcessorImpl.Builder.newInstance(() -> store.nextNotLeased(batchSize, filter), entityRetryProcessConfiguration, clock, monitor)
-                .process(telemetry.contextPropagationMiddleware(function))
-                .onNotProcessed(this::breakLease)
-                .build();
+    private void checkPolicies() {
+        var count = 0;
+        List<PolicyMonitorEntry> entries;
+        do {
+            entries = store.nextNotLeased(configuration.batchSize(), hasState(STARTED.code()), notYetProcessed());
+            entries.forEach(policyMonitor::monitor);
+            count += entries.size();
+        } while (entries.size() >= configuration.batchSize());
+
+        var period = configuration.period();
+        scheduler.schedule(this::checkPolicies, period.getSeconds(), TimeUnit.SECONDS);
+        monitor.debug("watchdog completed: %d entries evaluated. Next execution in %s".formatted(count, period));
     }
 
-    public static class Builder
-            extends AbstractStateEntityManager.Builder<PolicyMonitorEntry, PolicyMonitorStore, PolicyMonitorManagerImpl, Builder> {
-
-        private Builder() {
-            super(new PolicyMonitorManagerImpl());
-        }
-
-        public static Builder newInstance() {
-            return new Builder();
-        }
-
-        public Builder contractAgreementService(ContractAgreementService contractAgreementService) {
-            manager.contractAgreementService = contractAgreementService;
-            return this;
-        }
-
-        public Builder policyEngine(PolicyEngine policyEngine) {
-            manager.policyEngine = policyEngine;
-            return this;
-        }
-
-        public Builder transferProcessService(TransferProcessService transferProcessService) {
-            manager.transferProcessService = transferProcessService;
-            return this;
-        }
-
-        @Override
-        public Builder self() {
-            return this;
-        }
+    private @NotNull Criterion notYetProcessed() {
+        return criterion("updatedAt", "<", clock.millis() - configuration.period().toMillis());
     }
-
 }

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/store/InMemoryPolicyMonitorStore.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/store/InMemoryPolicyMonitorStore.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2026 Think-it GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,11 +8,11 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Think-it GmbH - initial API and implementation
  *
  */
 
-package org.eclipse.edc.connector.policy.monitor.store.sql;
+package org.eclipse.edc.connector.policy.monitor.store;
 
 import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntry;
 import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates;

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/subscriber/StartMonitoring.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/subscriber/StartMonitoring.java
@@ -15,7 +15,7 @@
 package org.eclipse.edc.connector.policy.monitor.subscriber;
 
 import org.eclipse.edc.connector.controlplane.transfer.spi.event.TransferProcessStarted;
-import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorManager;
+import org.eclipse.edc.connector.policy.monitor.manager.PolicyMonitor;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventSubscriber;
@@ -27,16 +27,16 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
  */
 public class StartMonitoring implements EventSubscriber {
 
-    private final PolicyMonitorManager manager;
+    private final PolicyMonitor policyMonitor;
 
-    public StartMonitoring(PolicyMonitorManager manager) {
-        this.manager = manager;
+    public StartMonitoring(PolicyMonitor policyMonitor) {
+        this.policyMonitor = policyMonitor;
     }
 
     @Override
     public <E extends Event> void on(EventEnvelope<E> event) {
         if (event.getPayload() instanceof TransferProcessStarted started && PROVIDER.name().equals(started.getType())) {
-            manager.startMonitoring(started.getTransferProcessId(), started.getContractId());
+            policyMonitor.start(started.getTransferProcessId(), started.getContractId());
         }
     }
 }

--- a/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImplTest.java
+++ b/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorManagerImplTest.java
@@ -14,222 +14,66 @@
 
 package org.eclipse.edc.connector.policy.monitor.manager;
 
-import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
-import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.ContractAgreementService;
-import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
-import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
-import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorContext;
+import org.eclipse.edc.connector.policy.monitor.PolicyMonitorConfiguration;
 import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntry;
-import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorManager;
 import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorStore;
-import org.eclipse.edc.policy.engine.spi.PolicyContext;
-import org.eclipse.edc.policy.engine.spi.PolicyEngine;
-import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.query.Criterion;
-import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.result.ServiceResult;
-import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.system.ExecutorInstrumentation;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
+import java.time.Clock;
+import java.time.Duration;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
-import static org.assertj.core.api.Assertions.assertThat;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
-import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.COMPLETED;
-import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.FAILED;
-import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.STARTED;
-import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
-import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class PolicyMonitorManagerImplTest {
 
+    public static final int BATCH_SIZE = 2;
     private final PolicyMonitorStore store = mock();
-    private final ContractAgreementService contractAgreementService = mock();
-    private final TransferProcessService transferProcessService = mock();
-    private final PolicyEngine policyEngine = mock();
-    private PolicyMonitorManager manager;
-
-    @BeforeEach
-    void setUp() {
-        when(store.save(any())).thenReturn(StoreResult.success());
-        manager = PolicyMonitorManagerImpl.Builder.newInstance()
-                .executorInstrumentation(ExecutorInstrumentation.noop())
-                .monitor(mock())
-                .clock(mock())
-                .contractAgreementService(contractAgreementService)
-                .policyEngine(policyEngine)
-                .transferProcessService(transferProcessService)
-                .store(store)
-                .build();
-    }
+    private final PolicyMonitor policyMonitor = mock();
+    private final Clock clock = mock();
+    private final ExecutorInstrumentation executorInstrumentation = ExecutorInstrumentation.noop();
+    private final PolicyMonitorManagerImpl manager = new PolicyMonitorManagerImpl(policyMonitor,
+            new PolicyMonitorConfiguration(BATCH_SIZE, Duration.ofSeconds(4)), executorInstrumentation, mock(), store, clock);
 
     @Test
-    void startMonitoring() {
-        manager.startMonitoring("transferProcessId", "contractId");
-
-        var captor = ArgumentCaptor.forClass(PolicyMonitorEntry.class);
-        verify(store).save(captor.capture());
-        var entry = captor.getValue();
-        assertThat(entry.getId()).isEqualTo("transferProcessId");
-        assertThat(entry.getContractId()).isEqualTo("contractId");
-        assertThat(entry.getState()).isEqualTo(STARTED.code());
-    }
-
-    @Test
-    void started_shouldTerminateTransferAndTransitionToComplete_whenPolicyIsNotValid() {
-        var entry = PolicyMonitorEntry.Builder.newInstance()
-                .id("transferProcessId")
-                .contractId("contractId")
-                .state(STARTED.code())
-                .build();
-        var policy = Policy.Builder.newInstance().build();
-        var contractAgreement = createContractAgreement(policy);
-        when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
-        when(transferProcessService.findById(entry.getId()))
-                .thenReturn(TransferProcess.Builder.newInstance().state(TransferProcessStates.STARTED.code()).build());
-        when(contractAgreementService.findById(any())).thenReturn(contractAgreement);
-        when(policyEngine.evaluate(any(), isA(PolicyContext.class))).thenReturn(Result.failure("policy is not valid"));
-        when(transferProcessService.terminate(any())).thenReturn(ServiceResult.success());
+    void shouldStopProcessing_whenNoItemsAreReturned() {
+        when(store.nextNotLeased(anyInt(), any(), any())).thenReturn(emptyList());
 
         manager.start();
 
-        await().untilAsserted(() -> {
-            verify(contractAgreementService).findById("contractId");
-            var captor = ArgumentCaptor.forClass(PolicyMonitorContext.class);
-            verify(policyEngine).evaluate(same(policy), captor.capture());
-            var policyContext = captor.getValue();
-            assertThat(policyContext.contractAgreement()).isSameAs(contractAgreement);
-            verify(transferProcessService).terminate(argThat(c -> c.getEntityId().equals("transferProcessId")));
-            verify(store).save(argThat(it -> it.getState() == COMPLETED.code()));
+        await().pollDelay(1, SECONDS).untilAsserted(() -> {
+            verify(store, only()).nextNotLeased(eq(BATCH_SIZE), any(), any());
+            verifyNoInteractions(policyMonitor);
         });
     }
 
     @Test
-    void started_shouldNotTransitionToComplete_whenTransferProcessTerminationFails() {
-        var entry = PolicyMonitorEntry.Builder.newInstance()
-                .id("transferProcessId")
-                .contractId("contractId")
-                .state(STARTED.code())
-                .build();
-        var policy = Policy.Builder.newInstance().build();
-        when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
-        when(transferProcessService.findById(entry.getId()))
-                .thenReturn(TransferProcess.Builder.newInstance().state(TransferProcessStates.STARTED.code()).build());
-        when(contractAgreementService.findById(any())).thenReturn(createContractAgreement(policy));
-        when(policyEngine.evaluate(any(), isA(PolicyContext.class))).thenReturn(Result.failure("policy is not valid"));
-        when(transferProcessService.terminate(any())).thenReturn(ServiceResult.conflict("failure"));
+    void shouldProcessUntilItemsAreReturned() {
+        when(store.nextNotLeased(anyInt(), any(), any()))
+                .thenReturn(List.of(entry(), entry()))
+                .thenReturn(List.of(entry()));
 
         manager.start();
 
-        await().untilAsserted(() -> {
-            verify(store).save(argThat(it -> it.getState() == STARTED.code()));
+        await().pollDelay(1, SECONDS).untilAsserted(() -> {
+            verify(store, times(2)).nextNotLeased(eq(BATCH_SIZE), any(), any());
+            verify(policyMonitor, times(3)).monitor(any());
         });
     }
 
-    @Test
-    void started_shouldDoNothing_whenPolicyIsValid() {
-        var entry = PolicyMonitorEntry.Builder.newInstance()
-                .id("transferProcessId")
-                .contractId("contractId")
-                .state(STARTED.code())
-                .build();
-        var policy = Policy.Builder.newInstance().build();
-
-        var stateTimestamp = entry.getStateTimestamp();
-        when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
-        when(transferProcessService.findById(entry.getId()))
-                .thenReturn(TransferProcess.Builder.newInstance().state(TransferProcessStates.STARTED.code()).build());
-        when(contractAgreementService.findById(any())).thenReturn(createContractAgreement(policy));
-        when(policyEngine.evaluate(any(), isA(PolicyContext.class))).thenReturn(Result.success());
-
-        manager.start();
-
-        await().untilAsserted(() -> {
-            verify(transferProcessService, never()).terminate(any());
-            verify(store).save(argThat(it -> it.getState() == STARTED.code() && stateTimestamp < it.getStateTimestamp()));
-        });
-    }
-
-    @Test
-    void started_shouldTransitionToCompleted_whenTransferProcessIsAlreadyCompletedOrTerminated() {
-        var entry = PolicyMonitorEntry.Builder.newInstance()
-                .id("transferProcessId")
-                .contractId("contractId")
-                .state(STARTED.code())
-                .build();
-        when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
-        when(transferProcessService.findById(entry.getId()))
-                .thenReturn(TransferProcess.Builder.newInstance().state(TransferProcessStates.COMPLETED.code()).build());
-
-        manager.start();
-
-        await().untilAsserted(() -> {
-            verifyNoInteractions(policyEngine, contractAgreementService);
-            verify(store).save(argThat(it -> it.getState() == COMPLETED.code()));
-        });
-    }
-
-    @Test
-    void started_shouldTransitionToFailed_whenTransferProcessNotFound() {
-        var entry = PolicyMonitorEntry.Builder.newInstance()
-                .id("transferProcessId")
-                .contractId("contractId")
-                .state(STARTED.code())
-                .build();
-        when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
-        when(transferProcessService.findById(any())).thenReturn(null);
-
-        manager.start();
-
-        await().untilAsserted(() -> {
-            verifyNoInteractions(policyEngine, contractAgreementService);
-            verify(store).save(argThat(it -> it.getState() == FAILED.code()));
-        });
-    }
-
-    @Test
-    void started_shouldTransitionToFailed_whenContractAgreementNotFound() {
-        var entry = PolicyMonitorEntry.Builder.newInstance()
-                .id("transferProcessId")
-                .contractId("contractId")
-                .state(STARTED.code())
-                .build();
-        when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
-        when(contractAgreementService.findById(any())).thenReturn(null);
-
-        manager.start();
-
-        await().untilAsserted(() -> {
-            verifyNoInteractions(policyEngine);
-            verify(store).save(argThat(it -> it.getState() == FAILED.code()));
-        });
-    }
-
-    private ContractAgreement createContractAgreement(Policy policy) {
-        return ContractAgreement.Builder.newInstance()
-                .providerId("providerId")
-                .consumerId("consumerId")
-                .assetId("assetIt")
-                .policy(policy)
-                .build();
-    }
-
-    private Criterion[] stateIs(int state) {
-        return aryEq(new Criterion[]{ hasState(state) });
+    private PolicyMonitorEntry entry() {
+        return PolicyMonitorEntry.Builder.newInstance().build();
     }
 }

--- a/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorTest.java
+++ b/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/manager/PolicyMonitorTest.java
@@ -1,0 +1,236 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.policy.monitor.manager;
+
+import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
+import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.ContractAgreementService;
+import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
+import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorContext;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntry;
+import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorStore;
+import org.eclipse.edc.policy.engine.spi.PolicyContext;
+import org.eclipse.edc.policy.engine.spi.PolicyEngine;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.time.Clock;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.COMPLETED;
+import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.FAILED;
+import static org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorEntryStates.STARTED;
+import static org.eclipse.edc.spi.persistence.StateEntityStore.hasState;
+import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class PolicyMonitorTest {
+
+    private final PolicyMonitorStore store = mock();
+    private final TransferProcessService transferProcessService = mock();
+    private final ContractAgreementService contractAgreementService = mock();
+    private final PolicyEngine policyEngine = mock();
+    private final Monitor monitor = Mockito.mock();
+
+    private PolicyMonitor policyMonitor;
+
+    @BeforeEach
+    void setUp() {
+        when(monitor.withPrefix(any())).thenReturn(monitor);
+        when(store.save(any())).thenReturn(StoreResult.success());
+
+        policyMonitor = new PolicyMonitor(store, mock(), transferProcessService,
+                contractAgreementService, policyEngine, monitor, Clock.systemDefaultZone(), new NoopTransactionContext());
+    }
+
+    @Nested
+    class Start {
+
+        @Test
+        void startMonitoring() {
+            policyMonitor.start("transferProcessId", "contractId");
+
+            var captor = ArgumentCaptor.forClass(PolicyMonitorEntry.class);
+            verify(store).save(captor.capture());
+            var entry = captor.getValue();
+            assertThat(entry.getId()).isEqualTo("transferProcessId");
+            assertThat(entry.getContractId()).isEqualTo("contractId");
+            assertThat(entry.getState()).isEqualTo(STARTED.code());
+        }
+
+    }
+
+    @Nested
+    class MonitorPolicy {
+
+        @Test
+        void started_shouldTerminateTransferAndTransitionToComplete_whenPolicyIsNotValid() {
+            var entry = PolicyMonitorEntry.Builder.newInstance()
+                    .id("transferProcessId")
+                    .contractId("contractId")
+                    .state(STARTED.code())
+                    .build();
+            var policy = Policy.Builder.newInstance().build();
+            var contractAgreement = createContractAgreement(policy);
+            when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
+            when(transferProcessService.findById(entry.getId()))
+                    .thenReturn(TransferProcess.Builder.newInstance().state(TransferProcessStates.STARTED.code()).build());
+            when(contractAgreementService.findById(any())).thenReturn(contractAgreement);
+            when(policyEngine.evaluate(any(), isA(PolicyContext.class))).thenReturn(Result.failure("policy is not valid"));
+            when(transferProcessService.terminate(any())).thenReturn(ServiceResult.success());
+
+            policyMonitor.monitor(entry);
+
+            verify(contractAgreementService).findById("contractId");
+            var captor = ArgumentCaptor.forClass(PolicyMonitorContext.class);
+            verify(policyEngine).evaluate(same(policy), captor.capture());
+            var policyContext = captor.getValue();
+            assertThat(policyContext.contractAgreement()).isSameAs(contractAgreement);
+            verify(transferProcessService).terminate(argThat(c -> c.getEntityId().equals("transferProcessId")));
+            verify(store).save(argThat(it -> it.getState() == COMPLETED.code()));
+        }
+
+        @Test
+        void started_shouldNotTransitionToComplete_whenTransferProcessTerminationFails() {
+            var entry = PolicyMonitorEntry.Builder.newInstance()
+                    .id("transferProcessId")
+                    .contractId("contractId")
+                    .state(STARTED.code())
+                    .build();
+            var policy = Policy.Builder.newInstance().build();
+            when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
+            when(transferProcessService.findById(entry.getId()))
+                    .thenReturn(TransferProcess.Builder.newInstance().state(TransferProcessStates.STARTED.code()).build());
+            when(contractAgreementService.findById(any())).thenReturn(createContractAgreement(policy));
+            when(policyEngine.evaluate(any(), isA(PolicyContext.class))).thenReturn(Result.failure("policy is not valid"));
+            when(transferProcessService.terminate(any())).thenReturn(ServiceResult.conflict("failure"));
+
+            policyMonitor.monitor(entry);
+
+            verify(store, never()).save(argThat(it -> it.getState() == COMPLETED.code()));
+            verify(store).save(any());
+            verify(monitor).severe(anyString());
+        }
+
+        @Test
+        void started_shouldDoNothing_whenPolicyIsValid() {
+            var entry = PolicyMonitorEntry.Builder.newInstance()
+                    .id("transferProcessId")
+                    .contractId("contractId")
+                    .state(STARTED.code())
+                    .build();
+            var policy = Policy.Builder.newInstance().build();
+
+            when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
+            when(transferProcessService.findById(entry.getId()))
+                    .thenReturn(TransferProcess.Builder.newInstance().state(TransferProcessStates.STARTED.code()).build());
+            when(contractAgreementService.findById(any())).thenReturn(createContractAgreement(policy));
+            when(policyEngine.evaluate(any(), isA(PolicyContext.class))).thenReturn(Result.success());
+
+            policyMonitor.monitor(entry);
+
+            verify(transferProcessService, never()).terminate(any());
+            verify(store).save(any());
+        }
+
+        @Test
+        void started_shouldTransitionToCompleted_whenTransferProcessIsAlreadyCompletedOrTerminated() {
+            var entry = PolicyMonitorEntry.Builder.newInstance()
+                    .id("transferProcessId")
+                    .contractId("contractId")
+                    .state(STARTED.code())
+                    .build();
+            when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
+            when(transferProcessService.findById(entry.getId()))
+                    .thenReturn(TransferProcess.Builder.newInstance().state(TransferProcessStates.COMPLETED.code()).build());
+
+            policyMonitor.monitor(entry);
+
+            verifyNoInteractions(policyEngine, contractAgreementService);
+            verify(store).save(argThat(it -> it.getState() == COMPLETED.code()));
+        }
+
+        @Test
+        void started_shouldTransitionToFailed_whenTransferProcessNotFound() {
+            var entry = PolicyMonitorEntry.Builder.newInstance()
+                    .id("transferProcessId")
+                    .contractId("contractId")
+                    .state(STARTED.code())
+                    .build();
+            when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
+            when(transferProcessService.findById(any())).thenReturn(null);
+
+            policyMonitor.monitor(entry);
+
+            verifyNoInteractions(policyEngine, contractAgreementService);
+            verify(store).save(argThat(it -> it.getState() == FAILED.code()));
+        }
+
+        @Test
+        void started_shouldTransitionToFailed_whenContractAgreementNotFound() {
+            var entry = PolicyMonitorEntry.Builder.newInstance()
+                    .id("transferProcessId")
+                    .contractId("contractId")
+                    .state(STARTED.code())
+                    .build();
+            when(store.nextNotLeased(anyInt(), stateIs(STARTED.code()))).thenReturn(List.of(entry)).thenReturn(emptyList());
+            when(transferProcessService.findById(any()))
+                    .thenReturn(TransferProcess.Builder.newInstance().state(TransferProcessStates.STARTED.code()).build());
+            when(contractAgreementService.findById(any())).thenReturn(null);
+
+            policyMonitor.monitor(entry);
+
+            verifyNoInteractions(policyEngine);
+            verify(store).save(argThat(it -> it.getState() == FAILED.code()));
+        }
+
+        private ContractAgreement createContractAgreement(Policy policy) {
+            return ContractAgreement.Builder.newInstance()
+                    .providerId("providerId")
+                    .consumerId("consumerId")
+                    .assetId("assetIt")
+                    .policy(policy)
+                    .build();
+        }
+
+        private Criterion[] stateIs(int state) {
+            return aryEq(new Criterion[]{ hasState(state) });
+        }
+    }
+
+}

--- a/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/store/sql/InMemoryPolicyMonitorStoreTest.java
+++ b/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/store/sql/InMemoryPolicyMonitorStoreTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.connector.policy.monitor.store.sql;
 
 import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorStore;
 import org.eclipse.edc.connector.policy.monitor.spi.testfixtures.store.PolicyMonitorStoreTestBase;
+import org.eclipse.edc.connector.policy.monitor.store.InMemoryPolicyMonitorStore;
 import org.eclipse.edc.query.CriterionOperatorRegistryImpl;
 
 import java.time.Clock;

--- a/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/subscriber/StartMonitoringTest.java
+++ b/core/policy-monitor/policy-monitor-core/src/test/java/org/eclipse/edc/connector/policy/monitor/subscriber/StartMonitoringTest.java
@@ -15,7 +15,7 @@
 package org.eclipse.edc.connector.policy.monitor.subscriber;
 
 import org.eclipse.edc.connector.controlplane.transfer.spi.event.TransferProcessStarted;
-import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorManager;
+import org.eclipse.edc.connector.policy.monitor.manager.PolicyMonitor;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.junit.jupiter.api.Test;
 
@@ -30,11 +30,11 @@ import static org.mockito.Mockito.verifyNoInteractions;
 class StartMonitoringTest {
 
     private long now;
-    private final PolicyMonitorManager manager = mock();
+    private final PolicyMonitor policyMonitor = mock();
 
     @Test
     void shouldStartMonitoring_whenTransferProcessIsProvider() {
-        var subscriber = new StartMonitoring(manager);
+        var subscriber = new StartMonitoring(policyMonitor);
         now = Instant.now().toEpochMilli();
         var event = TransferProcessStarted.Builder.newInstance()
                 .transferProcessId("transferProcessId")
@@ -44,12 +44,12 @@ class StartMonitoringTest {
 
         subscriber.on(envelope(event));
 
-        verify(manager).startMonitoring("transferProcessId", "contractId");
+        verify(policyMonitor).start("transferProcessId", "contractId");
     }
 
     @Test
     void shouldNotStartMonitoring_whenTransferProcessIsConsumer() {
-        var subscriber = new StartMonitoring(manager);
+        var subscriber = new StartMonitoring(policyMonitor);
         now = Instant.now().toEpochMilli();
         var event = TransferProcessStarted.Builder.newInstance()
                 .transferProcessId("transferProcessId")
@@ -59,7 +59,7 @@ class StartMonitoringTest {
 
         subscriber.on(envelope(event));
 
-        verifyNoInteractions(manager);
+        verifyNoInteractions(policyMonitor);
     }
 
 

--- a/spi/policy-monitor/policy-monitor-spi/src/main/java/org/eclipse/edc/connector/policy/monitor/spi/PolicyMonitorManager.java
+++ b/spi/policy-monitor/policy-monitor-spi/src/main/java/org/eclipse/edc/connector/policy/monitor/spi/PolicyMonitorManager.java
@@ -21,11 +21,4 @@ import org.eclipse.edc.spi.entity.StateEntityManager;
  */
 public interface PolicyMonitorManager extends StateEntityManager {
 
-    /**
-     * Start to monitor a transfer process to ensure that
-     *
-     * @param transferProcessId the transfer process id
-     * @param contractId the contract id
-     */
-    void startMonitoring(String transferProcessId, String contractId);
 }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Runtimes.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/Runtimes.java
@@ -67,6 +67,7 @@ public interface Runtimes {
                     put("edc.negotiation.state-machine.iteration-wait-millis", "50");
                     put("edc.data.plane.selector.state-machine.iteration-wait-millis", "100");
                     put("edc.core.retry.retries.max", "1");
+                    put("edc.policy.monitor.period", "PT2S");
                 }
             });
         }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -54,11 +53,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static java.time.Duration.ofDays;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
-import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.inForceDatePolicy;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.STARTED;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.SUSPENDED;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATED;
@@ -218,38 +215,6 @@ class TransferPullEndToEndTest {
             // check that transfer is available again
             provider.awaitTransferToBeInState(providerTransferProcessId, STARTED);
             assertConsumerCanAccessData(consumer, consumerTransferProcessId);
-        }
-
-        @Test
-        void shouldTerminateTransfer_whenContractExpires_fixedInForcePeriod(@Runtime(CONSUMER_CP) TransferEndToEndParticipant consumer,
-                                                                            @Runtime(PROVIDER_CP) TransferEndToEndParticipant provider) {
-            var assetId = UUID.randomUUID().toString();
-            var now = Instant.now();
-            // contract was valid from t-10d to t-5d, so "now" it is expired
-            var contractPolicy = inForceDatePolicy("gteq", now.minus(ofDays(10)), "lteq", now.minus(ofDays(5)));
-            createResourcesOnProvider(provider, assetId, contractPolicy, httpSourceDataAddress());
-
-            var transferProcessId = consumer.requestAssetFrom(assetId, provider)
-                    .withTransferType("HttpData-PULL")
-                    .execute();
-
-            consumer.awaitTransferToBeInState(transferProcessId, TERMINATED);
-        }
-
-        @Test
-        void shouldTerminateTransfer_whenContractExpires_durationInForcePeriod(@Runtime(CONSUMER_CP) TransferEndToEndParticipant consumer,
-                                                                               @Runtime(PROVIDER_CP) TransferEndToEndParticipant provider) {
-            var assetId = UUID.randomUUID().toString();
-            var now = Instant.now();
-            // contract was valid from t-10d to t-5d, so "now" it is expired
-            var contractPolicy = inForceDatePolicy("gteq", now.minus(ofDays(10)), "lteq", "contractAgreement+1s");
-            createResourcesOnProvider(provider, assetId, contractPolicy, httpSourceDataAddress());
-
-            var transferProcessId = consumer.requestAssetFrom(assetId, provider)
-                    .withTransferType("HttpData-PULL")
-                    .execute();
-
-            consumer.awaitTransferToBeInState(transferProcessId, TERMINATED);
         }
 
         @Test

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/policy/PolicyMonitorEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/policy/PolicyMonitorEndToEndTest.java
@@ -1,0 +1,261 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.policy;
+
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.junit.annotations.Runtime;
+import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.utils.Endpoints;
+import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
+import org.eclipse.edc.test.e2e.Runtimes;
+import org.eclipse.edc.test.e2e.TransferEndToEndParticipant;
+import org.eclipse.edc.test.e2e.dataplane.DataPlaneSignalingClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static java.time.Duration.ofSeconds;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_TYPE_TERM;
+import static org.eclipse.edc.connector.controlplane.test.system.utils.Participant.MANAGEMENT_V4;
+import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.inForceDatePolicy;
+import static org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures.noConstraintPolicy;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.STARTED;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATED;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
+import static org.eclipse.edc.test.e2e.TransferEndToEndTestBase.CONSUMER_CP;
+import static org.eclipse.edc.test.e2e.TransferEndToEndTestBase.CONSUMER_DP;
+import static org.eclipse.edc.test.e2e.TransferEndToEndTestBase.CONSUMER_ID;
+import static org.eclipse.edc.test.e2e.TransferEndToEndTestBase.PROVIDER_CP;
+import static org.eclipse.edc.test.e2e.TransferEndToEndTestBase.PROVIDER_DP;
+import static org.eclipse.edc.test.e2e.TransferEndToEndTestBase.PROVIDER_ID;
+
+public interface PolicyMonitorEndToEndTest {
+
+    @BeforeAll
+    static void beforeAll(@Runtime(PROVIDER_CP) TransferEndToEndParticipant provider,
+                          @Runtime(CONSUMER_CP) TransferEndToEndParticipant consumer,
+                          @Runtime(PROVIDER_DP) DataPlaneSignalingClient providerDataPlane,
+                          @Runtime(CONSUMER_DP) DataPlaneSignalingClient consumerDataPlane) {
+
+        provider.registerDataPlane(providerDataPlane.getDataPlaneRegistrationMessage());
+        consumer.registerDataPlane(consumerDataPlane.getDataPlaneRegistrationMessage());
+
+    }
+
+    @Test
+    default void shouldTerminateTransfer_whenContractExpires_fixedInForcePeriod(
+            @Runtime(PROVIDER_CP) TransferEndToEndParticipant provider,
+            @Runtime(CONSUMER_CP) TransferEndToEndParticipant consumer,
+            @Runtime(PROVIDER_DP) DataPlaneSignalingClient providerDataPlane,
+            @Runtime(CONSUMER_DP) DataPlaneSignalingClient consumerDataPlane) {
+
+        var now = Instant.now();
+        // contract is valid from t-10s to t+10s, so it will be expired after some seconds
+        var contractPolicy = inForceDatePolicy("gteq", now.minus(ofSeconds(10)), "lteq", now.plus(ofSeconds(10)));
+        var contractPolicyId = provider.createPolicyDefinition(contractPolicy);
+        var assetId = createOffer(provider, contractPolicyId);
+        var consumerTransferProcessId = consumer.requestAssetFrom(assetId, provider)
+                .withTransferType("NonFinite-PULL").execute();
+
+        consumer.awaitTransferToBeInState(consumerTransferProcessId, STARTED);
+        var providerTransferProcessId = provider.getTransferProcessIdGivenCounterPartyOne(consumerTransferProcessId);
+        consumerDataPlane.awaitFlowToBe(consumerTransferProcessId, "STARTED");
+        providerDataPlane.awaitFlowToBe(providerTransferProcessId, "STARTED");
+
+        // policy monitor should terminate the transfer
+
+        consumer.awaitTransferToBeInState(consumerTransferProcessId, TERMINATED);
+        provider.awaitTransferToBeInState(providerTransferProcessId, TERMINATED);
+        consumerDataPlane.awaitFlowToBe(consumerTransferProcessId, "TERMINATED");
+        providerDataPlane.awaitFlowToBe(providerTransferProcessId, "TERMINATED");
+    }
+
+    @Test
+    default void shouldTerminateTransfer_whenContractExpires_durationInForcePeriod(
+            @Runtime(PROVIDER_CP) TransferEndToEndParticipant provider,
+            @Runtime(CONSUMER_CP) TransferEndToEndParticipant consumer,
+            @Runtime(PROVIDER_DP) DataPlaneSignalingClient providerDataPlane,
+            @Runtime(CONSUMER_DP) DataPlaneSignalingClient consumerDataPlane) {
+
+        var now = Instant.now();
+        // contract is valid until 5s after agreement
+        var contractPolicy = inForceDatePolicy("gteq", now.minus(ofSeconds(10)), "lteq", "contractAgreement+5s");
+        var contractPolicyId = provider.createPolicyDefinition(contractPolicy);
+        var assetId = createOffer(provider, contractPolicyId);
+        var consumerTransferProcessId = consumer.requestAssetFrom(assetId, provider)
+                .withTransferType("NonFinite-PULL").execute();
+
+        consumer.awaitTransferToBeInState(consumerTransferProcessId, STARTED);
+        var providerTransferProcessId = provider.getTransferProcessIdGivenCounterPartyOne(consumerTransferProcessId);
+        consumerDataPlane.awaitFlowToBe(consumerTransferProcessId, "STARTED");
+        providerDataPlane.awaitFlowToBe(providerTransferProcessId, "STARTED");
+
+        // policy monitor should terminate the transfer
+
+        consumer.awaitTransferToBeInState(consumerTransferProcessId, TERMINATED);
+        provider.awaitTransferToBeInState(providerTransferProcessId, TERMINATED);
+        consumerDataPlane.awaitFlowToBe(consumerTransferProcessId, "TERMINATED");
+        providerDataPlane.awaitFlowToBe(providerTransferProcessId, "TERMINATED");
+    }
+
+    private String createOffer(TransferEndToEndParticipant provider, String contractPolicyId) {
+        var createAssetRequestBody = createObjectBuilder()
+                .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                .add(TYPE, EDC_ASSET_TYPE_TERM)
+                .add("properties", createObjectBuilder()
+                        .add("name", "test-asset"))
+                .build();
+
+        var noConstraintPolicyId = provider.createPolicyDefinition(noConstraintPolicy());
+        var assetId = provider.createAsset(createAssetRequestBody);
+        provider.createContractDefinition(assetId, UUID.randomUUID().toString(), noConstraintPolicyId, contractPolicyId);
+        return assetId;
+    }
+
+    @Nested
+    @EndToEndTest
+    class InMemoryTest implements PolicyMonitorEndToEndTest {
+
+        static final Endpoints CONSUMER_ENDPOINTS = Runtimes.ControlPlane.ENDPOINTS.build();
+        static final Endpoints PROVIDER_ENDPOINTS = Runtimes.ControlPlane.ENDPOINTS.build();
+
+        @RegisterExtension
+        @Order(0)
+        static final RuntimeExtension CONSUMER_CONTROL_PLANE = ComponentRuntimeExtension.Builder.newInstance()
+                .name(CONSUMER_CP)
+                .modules(Runtimes.ControlPlane.SIGNALING_MODULES)
+                .endpoints(CONSUMER_ENDPOINTS)
+                .configurationProvider(() -> Runtimes.ControlPlane.config(CONSUMER_ID))
+                .paramProvider(TransferEndToEndParticipant.class, ctx -> TransferEndToEndParticipant.newInstance(ctx)
+                        .managementVersionBasePath(MANAGEMENT_V4)
+                        .build())
+                .build();
+
+        @RegisterExtension
+        @Order(0)
+        static final RuntimeExtension PROVIDER_CONTROL_PLANE = ComponentRuntimeExtension.Builder.newInstance()
+                .name(PROVIDER_CP)
+                .modules(Runtimes.ControlPlane.SIGNALING_MODULES)
+                .endpoints(PROVIDER_ENDPOINTS)
+                .configurationProvider(() -> Runtimes.ControlPlane.config(PROVIDER_ID))
+                .paramProvider(TransferEndToEndParticipant.class, ctx -> TransferEndToEndParticipant.newInstance(ctx)
+                        .managementVersionBasePath(MANAGEMENT_V4)
+                        .build())
+                .build();
+
+        @RegisterExtension
+        @Order(1)
+        static final RuntimeExtension PROVIDER_DATA_PLANE = ComponentRuntimeExtension.Builder.newInstance()
+                .name(PROVIDER_DP)
+                .modules(Runtimes.SignalingDataPlane.MODULES)
+                .endpoints(Runtimes.SignalingDataPlane.ENDPOINTS.build())
+                .configurationProvider(Runtimes.SignalingDataPlane::config)
+                .paramProvider(DataPlaneSignalingClient.class, DataPlaneSignalingClient::new)
+                .build();
+
+        @RegisterExtension
+        @Order(1)
+        static final RuntimeExtension CONSUMER_DATA_PLANE = ComponentRuntimeExtension.Builder.newInstance()
+                .name(CONSUMER_DP)
+                .modules(Runtimes.SignalingDataPlane.MODULES)
+                .endpoints(Runtimes.SignalingDataPlane.ENDPOINTS.build())
+                .configurationProvider(Runtimes.SignalingDataPlane::config)
+                .paramProvider(DataPlaneSignalingClient.class, DataPlaneSignalingClient::new)
+                .build();
+    }
+
+    @Nested
+    @PostgresqlIntegrationTest
+    class PostgresTest implements PolicyMonitorEndToEndTest {
+
+        static final String CONSUMER_DB = "consumer";
+        static final String PROVIDER_DB = "provider";
+
+        @Order(0)
+        @RegisterExtension
+        static final PostgresqlEndToEndExtension POSTGRESQL_EXTENSION = new PostgresqlEndToEndExtension();
+
+        @Order(1)
+        @RegisterExtension
+        static final BeforeAllCallback CREATE_DATABASES = context -> {
+            POSTGRESQL_EXTENSION.createDatabase(CONSUMER_DB);
+            POSTGRESQL_EXTENSION.createDatabase(PROVIDER_DB);
+        };
+
+        static final Endpoints CONSUMER_ENDPOINTS = Runtimes.ControlPlane.ENDPOINTS.build();
+        static final Endpoints PROVIDER_ENDPOINTS = Runtimes.ControlPlane.ENDPOINTS.build();
+
+        @RegisterExtension
+        @Order(2)
+        static final RuntimeExtension CONSUMER_CONTROL_PLANE = ComponentRuntimeExtension.Builder.newInstance()
+                .name(CONSUMER_CP)
+                .modules(Runtimes.ControlPlane.SIGNALING_MODULES)
+                .modules(Runtimes.ControlPlane.SQL_MODULES)
+                .endpoints(CONSUMER_ENDPOINTS)
+                .configurationProvider(() -> Runtimes.ControlPlane.config(CONSUMER_ID))
+                .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(CONSUMER_DB))
+                .paramProvider(TransferEndToEndParticipant.class, ctx -> TransferEndToEndParticipant.newInstance(ctx)
+                        .managementVersionBasePath(MANAGEMENT_V4)
+                        .build())
+                .build();
+
+        @RegisterExtension
+        @Order(2)
+        static final RuntimeExtension PROVIDER_CONTROL_PLANE = ComponentRuntimeExtension.Builder.newInstance()
+                .name(PROVIDER_CP)
+                .modules(Runtimes.ControlPlane.SIGNALING_MODULES)
+                .modules(Runtimes.ControlPlane.SQL_MODULES)
+                .endpoints(PROVIDER_ENDPOINTS)
+                .configurationProvider(() -> Runtimes.ControlPlane.config(PROVIDER_ID))
+                .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(PROVIDER_DB))
+                .paramProvider(TransferEndToEndParticipant.class, ctx -> TransferEndToEndParticipant.newInstance(ctx)
+                        .managementVersionBasePath(MANAGEMENT_V4)
+                        .build())
+                .build();
+
+        @RegisterExtension
+        @Order(3)
+        static final RuntimeExtension CONSUMER_DATA_PLANE = ComponentRuntimeExtension.Builder.newInstance()
+                .name(CONSUMER_DP)
+                .modules(Runtimes.SignalingDataPlane.MODULES)
+                .endpoints(Runtimes.SignalingDataPlane.ENDPOINTS.build())
+                .configurationProvider(Runtimes.SignalingDataPlane::config)
+                .paramProvider(DataPlaneSignalingClient.class, DataPlaneSignalingClient::new)
+                .build();
+
+        @RegisterExtension
+        @Order(3)
+        static final RuntimeExtension PROVIDER_DATA_PLANE = ComponentRuntimeExtension.Builder.newInstance()
+                .name(PROVIDER_DP)
+                .modules(Runtimes.SignalingDataPlane.MODULES)
+                .endpoints(Runtimes.SignalingDataPlane.ENDPOINTS.build())
+                .configurationProvider(Runtimes.SignalingDataPlane::config)
+                .paramProvider(DataPlaneSignalingClient.class, DataPlaneSignalingClient::new)
+                .build();
+    }
+
+}


### PR DESCRIPTION
## What this PR changes/adds

Switch `PolicyMonitorManager` implementation from state machine manager to "watch dog".

## Why it does that

Avoid CPU unnecessary load

## Further notes
- added a `edc.policy.monitor.period` configuration in ISO-8601 format that will be parsed in `Duration` during configuration injection, to support this I made a little change in the injection mechanism. By default it is 1hr as there's no point in production to check the policies more often.
- removed an unused `declaringClass` field in `SettingInjectionPoint`
- given that the configuration changed completely (from the "state machine" pattern to the watch dog one) I added an exception in case the old settings are used with a brief explanation on how to upgrade.
- moved the current "policy monitor e2e tests" from the current `TransferPullEndToEndTest` to a new dedicated class using the new data-plane signaling protocol so they won't need any upgrade when the legacy one will be removed.


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #4319

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
