### PR TITLE
feat: permit JWT parsing without signature verification

### DIFF
--- a/core/common/lib/token-lib/src/main/java/org/eclipse/edc/token/TokenValidationServiceImpl.java
+++ b/core/common/lib/token-lib/src/main/java/org/eclipse/edc/token/TokenValidationServiceImpl.java
@@ -81,7 +81,12 @@ public class TokenValidationServiceImpl implements TokenValidationService {
             return publicKeyResolutionResult.mapFailure();
         }
 
-        var verifierCreationResult = CryptoConverter.createVerifierFor(publicKeyResolutionResult.getContent());
+        var publicKey = publicKeyResolutionResult.getContent();
+        if (publicKey == null) {
+            return Result.success();
+        }
+
+        var verifierCreationResult = CryptoConverter.createVerifierFor(publicKey);
 
         try {
             var result = jwt.verify(verifierCreationResult);

--- a/core/common/token-core/src/test/java/org/eclipse/edc/jwt/TokenValidationServiceImplTest.java
+++ b/core/common/token-core/src/test/java/org/eclipse/edc/jwt/TokenValidationServiceImplTest.java
@@ -119,10 +119,22 @@ class TokenValidationServiceImplTest {
         assertThat(result.getFailureMessages()).containsExactlyInAnyOrder("test-failure1", "test-failure2");
     }
 
+    @Test
+    void shouldNotVerifySignature_whenPublicKeyIsNull() throws JOSEException {
+        var claims = createClaims(now);
+
+        var result = tokenValidationService.validate(createJwt(publicKeyId, claims, key.toPrivateKey()), id -> Result.success(null));
+
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent().getClaims())
+                .containsEntry("foo", "bar")
+                .hasEntrySatisfying(EXPIRATION_TIME, value -> assertThat((Date) value).isCloseTo(now, 1000));
+    }
+
     private String createJwt(String publicKeyId, JWTClaimsSet claimsSet, PrivateKey pk) {
         var header = new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(publicKeyId).build();
         try {
-            SignedJWT jwt = new SignedJWT(header, claimsSet);
+            var jwt = new SignedJWT(header, claimsSet);
             jwt.sign(new RSASSASigner(pk));
             return jwt.serialize();
         } catch (JOSEException e) {

--- a/data-protocols/data-plane-signaling/data-plane-signaling-oauth2/build.gradle.kts
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-oauth2/build.gradle.kts
@@ -21,7 +21,5 @@ dependencies {
     api(project(":spi:common:oauth2-spi"))
     api(project(":data-protocols:data-plane-signaling:data-plane-signaling-spi"))
 
-    implementation(libs.nimbus.jwt)
-
     testImplementation(project(":core:common:junit"))
 }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-oauth2/src/main/java/org/eclipse/edc/signaling/oauth2/DataPlaneSignalingOauth2Extension.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-oauth2/src/main/java/org/eclipse/edc/signaling/oauth2/DataPlaneSignalingOauth2Extension.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.signaling.oauth2.logic.Oauth2CredentialsSignalingAuthoriz
 import org.eclipse.edc.signaling.spi.authorization.SignalingAuthorizationRegistry;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.token.spi.TokenValidationService;
 
 public class DataPlaneSignalingOauth2Extension implements ServiceExtension {
 
@@ -27,9 +28,11 @@ public class DataPlaneSignalingOauth2Extension implements ServiceExtension {
     private SignalingAuthorizationRegistry signalingAuthorizationRegistry;
     @Inject
     private Oauth2Client oauth2Client;
+    @Inject
+    private TokenValidationService tokenValidationService;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        signalingAuthorizationRegistry.register(new Oauth2CredentialsSignalingAuthorization(oauth2Client));
+        signalingAuthorizationRegistry.register(new Oauth2CredentialsSignalingAuthorization(oauth2Client, tokenValidationService));
     }
 }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-oauth2/src/main/java/org/eclipse/edc/signaling/oauth2/logic/Oauth2CredentialsSignalingAuthorization.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-oauth2/src/main/java/org/eclipse/edc/signaling/oauth2/logic/Oauth2CredentialsSignalingAuthorization.java
@@ -14,15 +14,14 @@
 
 package org.eclipse.edc.signaling.oauth2.logic;
 
-import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.AuthorizationProfile;
 import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
 import org.eclipse.edc.iam.oauth2.spi.client.SharedSecretOauth2CredentialsRequest;
 import org.eclipse.edc.signaling.spi.authorization.Header;
 import org.eclipse.edc.signaling.spi.authorization.SignalingAuthorization;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.token.spi.TokenValidationService;
 
-import java.text.ParseException;
 import java.util.function.Function;
 
 /**
@@ -55,9 +54,11 @@ public class Oauth2CredentialsSignalingAuthorization implements SignalingAuthori
 
     private static final String BEARER = "Bearer ";
     private final Oauth2Client oauth2Client;
+    private final TokenValidationService tokenValidationService;
 
-    public Oauth2CredentialsSignalingAuthorization(Oauth2Client oauth2Client) {
+    public Oauth2CredentialsSignalingAuthorization(Oauth2Client oauth2Client, TokenValidationService tokenValidationService) {
         this.oauth2Client = oauth2Client;
+        this.tokenValidationService = tokenValidationService;
     }
 
     /**
@@ -87,16 +88,17 @@ public class Oauth2CredentialsSignalingAuthorization implements SignalingAuthori
 
         var token = authorization.substring(BEARER.length());
 
-        try {
-            var jwt = SignedJWT.parse(token);
-            var sub = jwt.getJWTClaimsSet().getClaims().get("sub");
-            if (sub instanceof String callerId) {
-                return Result.success(callerId);
-            }
-            return Result.failure("JWT sub claim %s is not a string".formatted(sub));
-        } catch (ParseException e) {
-            return Result.failure("JWT cannot be parsed correctly");
+        var tokenValidation = tokenValidationService.validate(token, i -> Result.success(null));
+        if (tokenValidation.failed()) {
+            return tokenValidation.mapFailure();
         }
+        var claimToken = tokenValidation.getContent();
+
+        var sub = claimToken.getStringClaim("sub");
+        if (sub == null) {
+            return Result.failure("No 'sub' claim exists in the token");
+        }
+        return Result.success(sub);
     }
 
     /**

--- a/data-protocols/data-plane-signaling/data-plane-signaling-oauth2/src/test/java/org/eclipse/edc/signaling/oauth2/logic/Oauth2CredentialsSignalingAuthorizationTest.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-oauth2/src/test/java/org/eclipse/edc/signaling/oauth2/logic/Oauth2CredentialsSignalingAuthorizationTest.java
@@ -15,28 +15,25 @@
 package org.eclipse.edc.signaling.oauth2.logic;
 
 import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.AuthorizationProfile;
 import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
+import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.token.spi.TokenValidationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,12 +41,13 @@ import static org.mockito.Mockito.when;
 class Oauth2CredentialsSignalingAuthorizationTest {
 
     private final Oauth2Client oauth2Client = mock();
+    private final TokenValidationService tokenValidationService = mock();
     private Oauth2CredentialsSignalingAuthorization authorization;
     private RSAKey signingKey;
 
     @BeforeEach
     void setUp() throws JOSEException {
-        authorization = new Oauth2CredentialsSignalingAuthorization(oauth2Client);
+        authorization = new Oauth2CredentialsSignalingAuthorization(oauth2Client, tokenValidationService);
         signingKey = new RSAKeyGenerator(2048)
                 .keyUse(KeyUse.SIGNATURE)
                 .keyID(UUID.randomUUID().toString())
@@ -65,14 +63,38 @@ class Oauth2CredentialsSignalingAuthorizationTest {
     class IsAuthorized {
 
         @Test
-        void shouldReturnSuccess_whenValidJwtWithSubClaim() throws JOSEException {
+        void shouldReturnSuccess_whenValidJwtWithSubClaim() {
             var callerId = "test-caller-id";
-            var token = createSignedJwt(Map.of("sub", callerId));
+            var token = "token";
+            var claimToken = ClaimToken.Builder.newInstance().claim("sub", callerId).build();
+            when(tokenValidationService.validate(any(), any())).thenReturn(Result.success(claimToken));
 
             var result = authorization.isAuthorized(header -> "Bearer " + token);
 
             assertThat(result.succeeded()).isTrue();
             assertThat(result.getContent()).isEqualTo(callerId);
+            verify(tokenValidationService).validate(eq(token), any());
+        }
+
+        @Test
+        void shouldReturnFailure_whenSubClaimIsNotThere() {
+            var token = "token";
+            var claimToken = ClaimToken.Builder.newInstance().claim("sub", null).build();
+            when(tokenValidationService.validate(any(), any())).thenReturn(Result.success(claimToken));
+
+            var result = authorization.isAuthorized(header -> "Bearer " + token);
+
+            assertThat(result.failed()).isTrue();
+        }
+
+        @Test
+        void shouldReturnFailure_whenTokenValidationFails() {
+            when(tokenValidationService.validate(any(), any())).thenReturn(Result.failure("validation error"));
+
+            var result = authorization.isAuthorized(header -> "Bearer token");
+
+            assertThat(result.failed()).isTrue();
+            assertThat(result.getFailureDetail()).contains("validation error");
         }
 
         @Test
@@ -97,22 +119,6 @@ class Oauth2CredentialsSignalingAuthorizationTest {
             assertThat(result.failed()).isTrue();
         }
 
-        @Test
-        void shouldFail_whenTokenIsNotValidJwt() {
-            var result = authorization.isAuthorized(header -> "Bearer not-a-jwt");
-
-            assertThat(result.failed()).isTrue();
-            assertThat(result.getFailureMessages()).anyMatch(msg -> msg.contains("parsed"));
-        }
-
-        @Test
-        void shouldFail_whenSubClaimIsMissing() throws JOSEException {
-            var token = createSignedJwt(Map.of());
-
-            var result = authorization.isAuthorized(header -> "Bearer " + token);
-
-            assertThat(result.failed()).isTrue();
-        }
     }
 
     @Nested
@@ -171,18 +177,4 @@ class Oauth2CredentialsSignalingAuthorizationTest {
         }
     }
 
-    private String createSignedJwt(Map<String, Object> claims) throws JOSEException {
-        var signer = new RSASSASigner(signingKey);
-        var claimsBuilder = new JWTClaimsSet.Builder()
-                .issuer("test-issuer")
-                .issueTime(new Date())
-                .expirationTime(new Date(System.currentTimeMillis() + 60_000));
-        claims.forEach(claimsBuilder::claim);
-        var signedJwt = new SignedJWT(
-                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(signingKey.getKeyID()).build(),
-                claimsBuilder.build()
-        );
-        signedJwt.sign(signer);
-        return signedJwt.serialize();
-    }
 }

--- a/spi/common/keys-spi/src/main/java/org/eclipse/edc/keys/spi/PublicKeyResolver.java
+++ b/spi/common/keys-spi/src/main/java/org/eclipse/edc/keys/spi/PublicKeyResolver.java
@@ -26,7 +26,10 @@ import java.security.PublicKey;
 public interface PublicKeyResolver {
 
     /**
-     * Resolves the key or return null if not found.
+     * Resolves the public key.
+     *
+     * @param id the key id
+     * @return success with the key, it could be null if the key absence is not an issue. Failure if the key cannot be resolved.
      */
     Result<PublicKey> resolveKey(String id);
 }

--- a/spi/common/token-spi/src/main/java/org/eclipse/edc/token/spi/TokenValidationService.java
+++ b/spi/common/token-spi/src/main/java/org/eclipse/edc/token/spi/TokenValidationService.java
@@ -28,17 +28,6 @@ import java.util.List;
  */
 @FunctionalInterface
 public interface TokenValidationService {
-    /**
-     * Validates the token and offers possibility for additional information for validations.
-     *
-     * @param tokenRepresentation A token representation including the token to verify.
-     * @param publicKeyResolver   A {@link PublicKeyResolver} to obtain the public key with which to verify the token
-     * @param rules               token validation rules that apply to the token
-     * @return Result of the validation.
-     */
-    default Result<ClaimToken> validate(TokenRepresentation tokenRepresentation, PublicKeyResolver publicKeyResolver, TokenValidationRule... rules) {
-        return validate(tokenRepresentation, publicKeyResolver, Arrays.asList(rules));
-    }
 
     /**
      * Validates the token and offers possibility for additional information for validations.
@@ -77,6 +66,6 @@ public interface TokenValidationService {
         var tokenRepresentation = TokenRepresentation.Builder.newInstance()
                 .token(token)
                 .build();
-        return validate(tokenRepresentation, publicKeyResolver, rules);
+        return validate(tokenRepresentation, publicKeyResolver, Arrays.asList(rules));
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Make `TokenValidationService` not validate signature if the key returned by `PublicKeyResolver` is null.
That case is a really particular one because all the `PublicKeyResolver` implementations return either the valid publicKey or a failure. The `success(null)` case is a particular case that has been properly documented in the `PublicKeyResolver` interface.

## Why it does that

permit to avoid signature validation in the case no JWKS gets set on the DPS AuthorizationProfile.

## Further notes
- this feature could have been implemented in a more elegant way but it would require a deep refactoring, will create some issues in order to tidy up stuff a little.


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5654

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
