### PR TITLE
feat: log warning on DPS errored notification

### DIFF
--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingApiExtension.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingApiExtension.java
@@ -81,7 +81,8 @@ public class DataPlaneSignalingApiExtension implements ServiceExtension {
 
         webService.registerResource(ApiContext.MANAGEMENT, new DataPlaneRegistrationApiV4Controller(dataPlaneSelectorService));
         webService.registerResource(ApiContext.SIGNALING, new DataPlaneTransferAuthorizationFilter(signalingAuthorizationRegistry, transferProcessService, dataPlaneSelectorService));
-        webService.registerResource(ApiContext.SIGNALING, new DataPlaneTransferApiController(transferProcessService, typeTransformerRegistry));
+        webService.registerResource(ApiContext.SIGNALING, new DataPlaneTransferApiController(transferProcessService,
+                typeTransformerRegistry, context.getMonitor().withPrefix("DataPlaneTransferApiController")));
 
         try (var versionContent = getClass().getClassLoader().getResourceAsStream(API_VERSION_JSON_FILE)) {
             apiVersionService.registerVersionInfo(ApiContext.SIGNALING, versionContent);

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/DataPlaneTransferApi.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/DataPlaneTransferApi.java
@@ -64,5 +64,15 @@ public interface DataPlaneTransferApi {
     )
     Response completed(String transferId);
 
+    @Operation(
+            method = POST,
+            description = "Notify an errored transfer",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Errored notification delivered correctly"),
+                    @ApiResponse(responseCode = "404", description = "Transfer process does not exist",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    Response errored(String transferId, DataFlowStatusMessage message);
 
 }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/DataPlaneTransferApiController.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/DataPlaneTransferApiController.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.NotifyS
 import org.eclipse.edc.signaling.domain.DataFlowPrepareMessage;
 import org.eclipse.edc.signaling.domain.DataFlowStartMessage;
 import org.eclipse.edc.signaling.domain.DataFlowStatusMessage;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 
@@ -42,10 +43,12 @@ public class DataPlaneTransferApiController implements DataPlaneTransferApi {
 
     private final TransferProcessService transferProcessService;
     private final TypeTransformerRegistry typeTransformerRegistry;
+    private final Monitor monitor;
 
-    public DataPlaneTransferApiController(TransferProcessService transferProcessService, TypeTransformerRegistry typeTransformerRegistry) {
+    public DataPlaneTransferApiController(TransferProcessService transferProcessService, TypeTransformerRegistry typeTransformerRegistry, Monitor monitor) {
         this.transferProcessService = transferProcessService;
         this.typeTransformerRegistry = typeTransformerRegistry;
+        this.monitor = monitor;
     }
 
     @Path("/{transferId}/dataflow/prepared")
@@ -83,5 +86,16 @@ public class DataPlaneTransferApiController implements DataPlaneTransferApi {
         transferProcessService.complete(transferId).orElseThrow(exceptionMapper(TransferProcess.class, transferId));
         return Response.ok().build();
     }
+
+    @Path("/{transferId}/dataflow/errored")
+    @POST
+    @Override
+    public Response errored(@PathParam("transferId") String transferId, DataFlowStatusMessage message) {
+        monitor.warning("Errored DataFlow notification received about TransferProcess %s: %s".formatted(transferId, message.getError()));
+        return Response.ok().build();
+    }
+
+
+
 
 }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/DataPlaneTransferApiControllerTest.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/DataPlaneTransferApiControllerTest.java
@@ -39,6 +39,7 @@ import static io.restassured.RestAssured.given;
 import static java.util.Collections.emptyMap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -331,9 +332,35 @@ class DataPlaneTransferApiControllerTest extends RestControllerTestBase {
         }
     }
 
+    @Nested
+    class Errored {
+        @BeforeEach
+        void setUp() {
+            setupValidAuthorization();
+        }
+
+        @Test
+        void shouldLogWarning() {
+            var transferId = UUID.randomUUID().toString();
+            when(transferProcessService.complete(any())).thenReturn(ServiceResult.success());
+            var message = DataFlowStatusMessage.Builder.newInstance().error("data-plane error").build();
+
+            given()
+                    .port(port)
+                    .contentType(ContentType.JSON)
+                    .body(message)
+                    .post("/transfers/{transferId}/dataflow/errored", transferId)
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200);
+
+            verify(monitor).warning(contains("data-plane error"));
+        }
+    }
+
     @Override
     protected Object controller() {
-        return new DataPlaneTransferApiController(transferProcessService, typeTransformerRegistry);
+        return new DataPlaneTransferApiController(transferProcessService, typeTransformerRegistry, monitor);
     }
 
     @Override

--- a/data-protocols/data-plane-signaling/src/main/resources/signaling-api-version.json
+++ b/data-protocols/data-plane-signaling/src/main/resources/signaling-api-version.json
@@ -2,6 +2,6 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1",
-    "lastUpdated": "2026-04-13T14:00:01Z"
+    "lastUpdated": "2026-04-15T14:00:01Z"
   }
 ]


### PR DESCRIPTION
## What this PR changes/adds

Logs a warning every time an `errored` notification is received from the Data Plane

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5651

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
