### PR TITLE
refactor: OpenTelemetry instance as Supplier

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/ExtensionLoader.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/ExtensionLoader.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -50,11 +51,11 @@ public class ExtensionLoader {
         return new Telemetry(selectOpenTelemetryImpl(openTelemetries));
     }
 
-    static @NotNull OpenTelemetry selectOpenTelemetryImpl(List<OpenTelemetry> openTelemetries) {
+    static @NotNull Supplier<OpenTelemetry> selectOpenTelemetryImpl(List<OpenTelemetry> openTelemetries) {
         if (openTelemetries.size() > 1) {
             throw new IllegalStateException(String.format("Found %s OpenTelemetry implementations. Please provide only one OpenTelemetry service provider.", openTelemetries.size()));
         }
-        return openTelemetries.isEmpty() ? GlobalOpenTelemetry.get() : openTelemetries.get(0);
+        return openTelemetries.isEmpty() ? GlobalOpenTelemetry::get : () -> openTelemetries.get(0);
     }
 
     /**

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/ExtensionLoaderTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/ExtensionLoaderTest.java
@@ -125,7 +125,7 @@ class ExtensionLoaderTest {
     void selectOpenTelemetryImpl_whenNoOpenTelemetry() {
         var openTelemetry = ExtensionLoader.selectOpenTelemetryImpl(emptyList());
 
-        assertThat(openTelemetry).isEqualTo(GlobalOpenTelemetry.get());
+        assertThat(openTelemetry.get()).isEqualTo(GlobalOpenTelemetry.get());
     }
 
     @Test
@@ -134,7 +134,7 @@ class ExtensionLoaderTest {
 
         var openTelemetry = ExtensionLoader.selectOpenTelemetryImpl(List.of(customOpenTelemetry));
 
-        assertThat(openTelemetry).isSameAs(customOpenTelemetry);
+        assertThat(openTelemetry.get()).isSameAs(customOpenTelemetry);
     }
 
     @Test

--- a/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/telemetry/Telemetry.java
+++ b/spi/common/boot-spi/src/main/java/org/eclipse/edc/spi/telemetry/Telemetry.java
@@ -30,13 +30,13 @@ import java.util.function.Supplier;
  */
 public class Telemetry {
 
-    private final OpenTelemetry openTelemetry;
+    private final Supplier<OpenTelemetry> openTelemetry;
 
     public Telemetry() {
-        this.openTelemetry = OpenTelemetry.noop();
+        this.openTelemetry = OpenTelemetry::noop;
     }
 
-    public Telemetry(OpenTelemetry openTelemetry) {
+    public Telemetry(Supplier<OpenTelemetry> openTelemetry) {
         this.openTelemetry = openTelemetry;
     }
 
@@ -47,7 +47,7 @@ public class Telemetry {
      */
     public Map<String, String> getCurrentTraceContext() {
         Map<String, String> traceContext = new HashMap<>();
-        openTelemetry.getPropagators().getTextMapPropagator()
+        openTelemetry.get().getPropagators().getTextMapPropagator()
                 .inject(Context.current(), traceContext, Map::put);
         return traceContext;
     }
@@ -105,7 +105,7 @@ public class Telemetry {
     }
 
     private Scope propagateTraceContext(TraceCarrier carrier) {
-        Context extractedContext = openTelemetry.getPropagators().getTextMapPropagator()
+        Context extractedContext = openTelemetry.get().getPropagators().getTextMapPropagator()
                 .extract(Context.current(), carrier, new TraceCarrierTextMapGetter());
         return extractedContext.makeCurrent();
     }


### PR DESCRIPTION
## What this PR changes/adds

This PR changes the way we instantiate an `OpenTelemetry` instance from instance to a `Supplier`. This change happens transparently and should not affect client code. 

## Why it does that

We are using OTEL in the zero-code-instantiation way, i.e. via the `java-agent`. Thus, all configuration is provided externally through environment variables.

That way, the global OTEL instance is injected at some time during application startup, but that may not coincide with the time when _we_ are instantiating the `Telemetry` class in EDC.

The result is, that the `Telemetry` instance may hold a stale `GlobalOpenTelemetry` reference (the `noop` one), resulting in no traces and metrics being correlated.

## Further notes

Alternatively, we could just use static instances of `Telemetry` and make it not injectable, but that would have caused a significantly larger changeset for little gain, and would directly contradict our services model.


_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
