### PR TITLE
feat: add v5beta dataplane registration api in management context

### DIFF
--- a/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/service/EmbeddedDataPlaneSelectorService.java
+++ b/core/data-plane-selector/data-plane-selector-core/src/main/java/org/eclipse/edc/connector/dataplane/selector/service/EmbeddedDataPlaneSelectorService.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.connector.dataplane.selector.spi.store.DataPlaneInstanceStore;
 import org.eclipse.edc.connector.dataplane.selector.spi.strategy.SelectionStrategyRegistry;
+import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.transaction.spi.TransactionContext;
@@ -50,6 +51,15 @@ public class EmbeddedDataPlaneSelectorService implements DataPlaneSelectorServic
     public ServiceResult<List<DataPlaneInstance>> getAll() {
         return transactionContext.execute(() -> {
             try (var stream = store.getAll()) {
+                return ServiceResult.success(stream.toList());
+            }
+        });
+    }
+
+    @Override
+    public ServiceResult<List<DataPlaneInstance>> search(QuerySpec querySpec) {
+        return transactionContext.execute(() -> {
+            try (var stream = store.query(querySpec)) {
                 return ServiceResult.success(stream.toList());
             }
         });

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/build.gradle.kts
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     api(project(":spi:common:json-ld-spi"))
     api(project(":spi:common:transform-spi"))
     api(project(":spi:common:web-spi"))
+    api(project(":spi:common:auth-spi"))
     api(project(":spi:common:participant-context-single-spi"))
     api(project(":spi:control-plane:contract-spi"))
     api(project(":spi:control-plane:control-plane-spi"))
@@ -31,6 +32,7 @@ dependencies {
     api(project(":data-protocols:data-plane-signaling:data-plane-signaling-spi"))
     implementation(project(":core:common:lib:api-lib"))
     implementation(project(":extensions:data-plane:data-plane-signaling:data-plane-signaling-transform"))
+    implementation(libs.jakarta.annotation)
 
     testImplementation(project(":core:common:junit"))
     testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingApiExtension.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingApiExtension.java
@@ -14,20 +14,26 @@
 
 package org.eclipse.edc.signaling;
 
+import org.eclipse.edc.api.auth.spi.AuthorizationService;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantResource;
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.signaling.port.api.DataPlaneRegistrationApiV4Controller;
 import org.eclipse.edc.signaling.port.api.DataPlaneTransferApiController;
 import org.eclipse.edc.signaling.port.api.DataPlaneTransferAuthorizationFilter;
+import org.eclipse.edc.signaling.port.api.v5.DataPlaneRegistrationApiV5Controller;
 import org.eclipse.edc.signaling.port.transformer.DataAddressToDspDataAddressTransformer;
 import org.eclipse.edc.signaling.port.transformer.DataFlowStatusMessageToDataFlowResponseTransformer;
 import org.eclipse.edc.signaling.port.transformer.DspDataAddressToDataAddressTransformer;
 import org.eclipse.edc.signaling.spi.authorization.SignalingAuthorizationRegistry;
+import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.apiversion.ApiVersionService;
@@ -39,6 +45,7 @@ import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
 
 import java.io.IOException;
 
+import static org.eclipse.edc.participantcontext.spi.types.ParticipantResource.queryByParticipantContextId;
 import static org.eclipse.edc.signaling.DataPlaneSignalingApiExtension.NAME;
 
 @Extension(NAME)
@@ -69,6 +76,9 @@ public class DataPlaneSignalingApiExtension implements ServiceExtension {
     @Inject(required = false)
     private SingleParticipantContextSupplier participantContextSupplier;
 
+    @Inject(required = false)
+    private AuthorizationService authorizationService;
+
     @Inject
     private Monitor monitor;
 
@@ -87,10 +97,17 @@ public class DataPlaneSignalingApiExtension implements ServiceExtension {
         typeTransformerRegistry.register(new DataFlowStatusMessageToDataFlowResponseTransformer());
         typeTransformerRegistry.register(new DspDataAddressToDataAddressTransformer());
 
+        // if running in single participant mode, the DataPlaneRegistrationApiV4Controller will be registered
         if (participantContextSupplier != null) {
             webService.registerResource(ApiContext.MANAGEMENT, new DataPlaneRegistrationApiV4Controller(dataPlaneSelectorService, participantContextSupplier));
         } else {
-            monitor.debug("Running in virtual mode registration of DataPlaneRegistrationApiV4Controller will be skipped");
+            // if multi participants mode the authorization service should be present
+            if (authorizationService != null) {
+                authorizationService.addLookupFunction(DataPlaneInstance.class, this::findDataPlaneInstance);
+                webService.registerResource(ApiContext.MANAGEMENT, new DataPlaneRegistrationApiV5Controller(dataPlaneSelectorService, authorizationService));
+            } else {
+                throw new EdcException("Missing AuthorizationService which is required when running in multi participant mode.");
+            }
         }
 
         webService.registerResource(ApiContext.SIGNALING, new DataPlaneTransferAuthorizationFilter(signalingAuthorizationRegistry, transferProcessService, dataPlaneSelectorService));
@@ -102,6 +119,15 @@ public class DataPlaneSignalingApiExtension implements ServiceExtension {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private ParticipantResource findDataPlaneInstance(String ownerId, String dataplaneId) {
+        return dataPlaneSelectorService.search(queryByParticipantContextId(ownerId)
+                        .filter(new Criterion("id", "=", dataplaneId))
+                        .build()
+                )
+                .map(it -> it.stream().findFirst().orElse(null))
+                .orElse(f -> null);
     }
 
 }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/DataPlaneRegistrationApiV4.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/DataPlaneRegistrationApiV4.java
@@ -51,7 +51,7 @@ public interface DataPlaneRegistrationApiV4 {
 
     @Operation(
             method = DELETE,
-            description = "Update a Dataplane instance",
+            description = "Delete a Dataplane instance",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Dataplane instance correctly deleted"),
                     @ApiResponse(responseCode = "404", description = "Not found",

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/DataPlaneRegistrationApiV4Controller.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/DataPlaneRegistrationApiV4Controller.java
@@ -49,13 +49,14 @@ public class DataPlaneRegistrationApiV4Controller implements DataPlaneRegistrati
     @Override
     public Response register(DataPlaneRegistrationMessage registration) {
         toAuthorizationProfile(registration.authorization());
-        
+
         participantContextSupplier.get().map(participantContext -> DataPlaneInstance.Builder.newInstance()
                         .id(registration.dataplaneId())
                         .url(registration.endpoint())
                         .allowedTransferType(registration.transferTypes())
                         .authorizationProfile(toAuthorizationProfile(registration.authorization()))
                         .participantContextId(participantContext.getParticipantContextId())
+                        .labels(registration.labels())
                         .build())
                 .compose(dataPlaneSelectorService::register)
                 .orElseThrow(it -> mapToException(it, DataPlaneInstance.class, registration.dataplaneId()));

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/v5/DataPlaneRegistrationApiV5.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/v5/DataPlaneRegistrationApiV5.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.signaling.port.api.v5;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+import org.eclipse.edc.api.model.ApiCoreSchema;
+import org.eclipse.edc.signaling.domain.DataPlaneRegistrationMessage;
+
+import static jakarta.ws.rs.HttpMethod.DELETE;
+import static jakarta.ws.rs.HttpMethod.PUT;
+
+@OpenAPIDefinition(info = @Info(version = "v5"))
+@Tag(name = "Dataplane Signaling Registration v5beta")
+public interface DataPlaneRegistrationApiV5 {
+
+    @Operation(
+            method = PUT,
+            description = "Register or update a Dataplane instance",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DataPlaneRegistrationMessage.class))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Dataplane instance correctly registered"),
+                    @ApiResponse(responseCode = "400", description = "Request was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "404", description = "Not found",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    Response registerV5(String participantContextId, DataPlaneRegistrationMessage registration, SecurityContext securityContext);
+
+
+    @Operation(
+            method = DELETE,
+            description = "Update a Dataplane instance",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Dataplane instance correctly deleted"),
+                    @ApiResponse(responseCode = "404", description = "Not found",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
+            }
+    )
+    Response deleteV5(String participantContextId, String dataplaneId, SecurityContext securityContext);
+
+}

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/v5/DataPlaneRegistrationApiV5.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/v5/DataPlaneRegistrationApiV5.java
@@ -52,7 +52,7 @@ public interface DataPlaneRegistrationApiV5 {
 
     @Operation(
             method = DELETE,
-            description = "Update a Dataplane instance",
+            description = "Delete a Dataplane instance",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Dataplane instance correctly deleted"),
                     @ApiResponse(responseCode = "404", description = "Not found",

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/v5/DataPlaneRegistrationApiV5Controller.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/v5/DataPlaneRegistrationApiV5Controller.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.signaling.port.api.v5;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+import org.eclipse.edc.api.auth.spi.AuthorizationService;
+import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
+import org.eclipse.edc.api.auth.spi.RequiredScope;
+import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.AuthorizationProfile;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.signaling.domain.DataPlaneRegistrationMessage;
+
+import java.util.Map;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
+
+@Produces(APPLICATION_JSON)
+@Consumes(APPLICATION_JSON)
+@Path("/v5beta/participants/{participantContextId}/dataplanes")
+public class DataPlaneRegistrationApiV5Controller implements DataPlaneRegistrationApiV5 {
+
+    private final DataPlaneSelectorService dataPlaneSelectorService;
+    private final AuthorizationService authorizationService;
+
+    public DataPlaneRegistrationApiV5Controller(DataPlaneSelectorService dataPlaneSelectorService, AuthorizationService authorizationService) {
+        this.dataPlaneSelectorService = dataPlaneSelectorService;
+        this.authorizationService = authorizationService;
+    }
+
+    @PUT
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN, ParticipantPrincipal.ROLE_PROVISIONER, ParticipantPrincipal.ROLE_PARTICIPANT})
+    @RequiredScope("management-api:write")
+    @Override
+    public Response registerV5(@PathParam("participantContextId") String participantContextId,
+                               DataPlaneRegistrationMessage registration,
+                               @Context SecurityContext securityContext) {
+
+        authorizationService.authorize(securityContext, participantContextId, participantContextId, ParticipantContext.class)
+                .orElseThrow(exceptionMapper(ParticipantContext.class, participantContextId));
+
+        var dataplaneInstance = DataPlaneInstance.Builder.newInstance()
+                .id(registration.dataplaneId())
+                .url(registration.endpoint())
+                .allowedTransferType(registration.transferTypes())
+                .authorizationProfile(toAuthorizationProfile(registration.authorization()))
+                .participantContextId(participantContextId)
+                .build();
+
+        dataPlaneSelectorService.register(dataplaneInstance)
+                .orElseThrow(exceptionMapper(DataPlaneInstance.class, registration.dataplaneId()));
+
+        return Response.ok().build();
+    }
+
+    @DELETE
+    @Path("/{dataplaneId}")
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN, ParticipantPrincipal.ROLE_PROVISIONER, ParticipantPrincipal.ROLE_PARTICIPANT})
+    @RequiredScope("management-api:write")
+    @Override
+    public Response deleteV5(@PathParam("participantContextId") String participantContextId,
+                             @PathParam("dataplaneId") String dataplaneId,
+                             @Context SecurityContext securityContext) {
+
+        authorizationService.authorize(securityContext, participantContextId, dataplaneId, DataPlaneInstance.class)
+                .orElseThrow(exceptionMapper(DataPlaneInstance.class, dataplaneId));
+
+        dataPlaneSelectorService.delete(dataplaneId)
+                .orElseThrow(exceptionMapper(DataPlaneInstance.class, dataplaneId));
+
+        return Response.ok().build();
+    }
+
+    private AuthorizationProfile toAuthorizationProfile(Map<String, Object> authorization) {
+        if (authorization == null) {
+            return null;
+        }
+
+        return new AuthorizationProfile((String) authorization.get("type"), authorization);
+    }
+
+}

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/v5/DataPlaneRegistrationApiV5Controller.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/v5/DataPlaneRegistrationApiV5Controller.java
@@ -68,6 +68,7 @@ public class DataPlaneRegistrationApiV5Controller implements DataPlaneRegistrati
                 .allowedTransferType(registration.transferTypes())
                 .authorizationProfile(toAuthorizationProfile(registration.authorization()))
                 .participantContextId(participantContextId)
+                .labels(registration.labels())
                 .build();
 
         dataPlaneSelectorService.register(dataplaneInstance)

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/DataPlaneRegistrationApiV4ControllerTest.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/DataPlaneRegistrationApiV4ControllerTest.java
@@ -52,7 +52,7 @@ class DataPlaneRegistrationApiV4ControllerTest extends RestControllerTestBase {
         @Test
         void shouldRegisterDataPlane() {
             when(dataPlaneSelectorService.register(any())).thenReturn(ServiceResult.success());
-            var message = new DataPlaneRegistrationMessage("dp-id", "http://dataplane/endpoint", Set.of("HttpData-PUSH"), Set.of(), null);
+            var message = new DataPlaneRegistrationMessage("dp-id", "http://dataplane/endpoint", Set.of("HttpData-PUSH"), Set.of("label"), null);
 
             given()
                     .port(port)
@@ -67,6 +67,7 @@ class DataPlaneRegistrationApiV4ControllerTest extends RestControllerTestBase {
                     instance.getId().equals("dp-id") &&
                             instance.getUrl().toString().equals("http://dataplane/endpoint") &&
                             instance.getAllowedTransferTypes().contains("HttpData-PUSH") &&
+                            instance.getLabels().contains("label") &&
                             instance.getAuthorizationProfile() == null
             ));
         }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/v5/DataPlaneRegistrationApiV5ControllerTest.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/v5/DataPlaneRegistrationApiV5ControllerTest.java
@@ -56,7 +56,7 @@ class DataPlaneRegistrationApiV5ControllerTest extends RestControllerTestBase {
         @Test
         void shouldRegisterDataPlane() {
             when(dataPlaneSelectorService.register(any())).thenReturn(ServiceResult.success());
-            var message = new DataPlaneRegistrationMessage("dp-id", "http://dataplane/endpoint", Set.of("HttpData-PUSH"), Set.of(), null);
+            var message = new DataPlaneRegistrationMessage("dp-id", "http://dataplane/endpoint", Set.of("HttpData-PUSH"), Set.of("label"), null);
 
             given()
                     .port(port)
@@ -71,6 +71,7 @@ class DataPlaneRegistrationApiV5ControllerTest extends RestControllerTestBase {
                     instance.getId().equals("dp-id") &&
                             instance.getUrl().toString().equals("http://dataplane/endpoint") &&
                             instance.getAllowedTransferTypes().contains("HttpData-PUSH") &&
+                            instance.getLabels().contains("label") &&
                             instance.getAuthorizationProfile() == null
             ));
         }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/v5/DataPlaneRegistrationApiV5ControllerTest.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/v5/DataPlaneRegistrationApiV5ControllerTest.java
@@ -1,0 +1,147 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.signaling.port.api.v5;
+
+import io.restassured.http.ContentType;
+import org.eclipse.edc.api.auth.spi.AuthorizationService;
+import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
+import org.eclipse.edc.signaling.domain.DataPlaneRegistrationMessage;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static io.restassured.RestAssured.given;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DataPlaneRegistrationApiV5ControllerTest extends RestControllerTestBase {
+
+    protected final AuthorizationService authorizationService = mock();
+    private final DataPlaneSelectorService dataPlaneSelectorService = mock();
+    private final String participantContextId = "test-participant-context-id";
+
+    @Override
+    protected Object controller() {
+        return new DataPlaneRegistrationApiV5Controller(dataPlaneSelectorService, authorizationService);
+    }
+
+    @BeforeEach
+    public void setup() {
+        when(authorizationService.authorize(any(), any(), any(), any())).thenReturn(ServiceResult.success());
+    }
+
+    @Nested
+    class Register {
+
+        @Test
+        void shouldRegisterDataPlane() {
+            when(dataPlaneSelectorService.register(any())).thenReturn(ServiceResult.success());
+            var message = new DataPlaneRegistrationMessage("dp-id", "http://dataplane/endpoint", Set.of("HttpData-PUSH"), Set.of(), null);
+
+            given()
+                    .port(port)
+                    .contentType(ContentType.JSON)
+                    .body(message)
+                    .put("/v5beta/participants/%s/dataplanes".formatted(participantContextId))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200);
+
+            verify(dataPlaneSelectorService).register(argThat(instance ->
+                    instance.getId().equals("dp-id") &&
+                            instance.getUrl().toString().equals("http://dataplane/endpoint") &&
+                            instance.getAllowedTransferTypes().contains("HttpData-PUSH") &&
+                            instance.getAuthorizationProfile() == null
+            ));
+        }
+
+        @Test
+        void shouldRegisterDataPlane_withAuthorizationProfile() {
+            when(dataPlaneSelectorService.register(any())).thenReturn(ServiceResult.success());
+            var authProfile = Map.<String, Object>of("type", "oauth2", "tokenUrl", "http://token-url");
+            var message = new DataPlaneRegistrationMessage("dp-id", "http://dataplane/endpoint",
+                    Set.of("HttpData-PUSH"), Set.of(), authProfile);
+
+            given()
+                    .port(port)
+                    .contentType(ContentType.JSON)
+                    .body(message)
+                    .put("/v5beta/participants/%s/dataplanes".formatted(participantContextId))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200);
+
+            verify(dataPlaneSelectorService).register(argThat(instance ->
+                    instance.getAuthorizationProfile() != null &&
+                            instance.getAuthorizationProfile().type().equals("oauth2")
+            ));
+        }
+
+        @Test
+        void shouldReturnError_whenServiceCallFails() {
+            when(dataPlaneSelectorService.register(any())).thenReturn(ServiceResult.conflict("already exists"));
+            var message = new DataPlaneRegistrationMessage("dp-id", "http://dataplane/endpoint", Set.of(), Set.of(), null);
+
+            given()
+                    .port(port)
+                    .contentType(ContentType.JSON)
+                    .body(message)
+                    .put("/v5beta/participants/{participantContextId}/dataplanes", participantContextId)
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(409);
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void shouldDeleteDataPlane() {
+            when(dataPlaneSelectorService.delete(any())).thenReturn(ServiceResult.success());
+
+            given()
+                    .port(port)
+                    .contentType(ContentType.JSON)
+                    .delete("/v5beta/participants/{participantContextId}/dataplanes/{dataplaneId}", participantContextId, "dp-id")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200);
+
+            verify(dataPlaneSelectorService).delete("dp-id");
+        }
+
+        @Test
+        void shouldReturnNotFound_whenDataPlaneDoesNotExist() {
+            when(dataPlaneSelectorService.delete(any())).thenReturn(ServiceResult.notFound("not found"));
+
+            given()
+                    .port(port)
+                    .contentType(ContentType.JSON)
+                    .delete("/v5beta/participants/{participantContextId}/dataplanes/{dataplaneId}", participantContextId, "dp-id")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(404);
+        }
+    }
+}

--- a/data-protocols/data-plane-signaling/src/main/resources/signaling-api-version.json
+++ b/data-protocols/data-plane-signaling/src/main/resources/signaling-api-version.json
@@ -2,6 +2,6 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1",
-    "lastUpdated": "2026-04-16T14:00:01Z"
+    "lastUpdated": "2026-04-16T15:00:01Z"
   }
 ]

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/ManagementApiClientV5.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/ManagementApiClientV5.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.Catal
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.CelExpressionApi;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.ContractDefApi;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.ContractNegotiationApi;
+import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.DataPlaneApi;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.ParticipantContextApi;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.ParticipantContextConfigApi;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.PolicyDefApi;
@@ -75,7 +76,7 @@ public class ManagementApiClientV5 {
     private final ContractNegotiationApi negotiations;
     private final TransferApi transfers;
     private final CelExpressionApi expressions;
-
+    private final DataPlaneApi dataplanes;
 
     public ManagementApiClientV5(OauthServer oauthServer,
                                  LazySupplier<URI> managementEndpoint) {
@@ -90,6 +91,7 @@ public class ManagementApiClientV5 {
         this.negotiations = new ContractNegotiationApi(this);
         this.transfers = new TransferApi(this);
         this.expressions = new CelExpressionApi(this);
+        this.dataplanes = new DataPlaneApi(this);
     }
 
     public static ManagementApiClientV5 forContext(ComponentRuntimeContext ctx, OauthServer authServer) {
@@ -133,6 +135,10 @@ public class ManagementApiClientV5 {
 
     public CelExpressionApi expressions() {
         return expressions;
+    }
+
+    public DataPlaneApi dataplanes() {
+        return dataplanes;
     }
 
     private String startTransferProcess(String participantContext, String contractAgreementId, String providerAddress, String transferType) {

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/DataPlaneApi.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/DataPlaneApi.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.test.system.utils.client.api;
+
+import org.eclipse.edc.connector.controlplane.test.system.utils.client.ManagementApiClientV5;
+import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.DataPlaneRegistrationDto;
+
+import static io.restassured.http.ContentType.JSON;
+
+/**
+ * API client for transfer-related operations.
+ */
+public class DataPlaneApi {
+    private final ManagementApiClientV5 connector;
+
+    public DataPlaneApi(ManagementApiClientV5 connector) {
+        this.connector = connector;
+    }
+
+    /**
+     * Registers a new data plane with the control plane using the provided registration details.
+     *
+     * @param participantContextId  the participant context ID
+     * @param dataPlaneRegistration the dataplane registration details
+     */
+    public void registerDataPlane(String participantContextId, DataPlaneRegistrationDto dataPlaneRegistration) {
+        connector.baseManagementRequest(participantContextId)
+                .contentType(JSON)
+                .body(dataPlaneRegistration)
+                .when()
+                .put("/v5beta/participants/%s/dataplanes".formatted(participantContextId))
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200);
+    }
+
+}

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/model/DataPlaneRegistrationDto.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/model/DataPlaneRegistrationDto.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2025 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model;
+
+import java.util.Map;
+import java.util.Set;
+
+public record DataPlaneRegistrationDto(
+        String dataplaneId,
+        String endpoint,
+        Set<String> transferTypes,
+        Set<String> labels,
+        Map<String, Object> authorization
+) {
+}

--- a/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorService.java
+++ b/extensions/data-plane-selector/data-plane-selector-client/src/main/java/org/eclipse/edc/connector/dataplane/selector/RemoteDataPlaneSelectorService.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.http.spi.ControlApiHttpClient;
 import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -41,6 +42,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 
+@Deprecated(since = "management-api:v3")
 public class RemoteDataPlaneSelectorService implements DataPlaneSelectorService {
 
     public static final MediaType TYPE_JSON = MediaType.parse("application/json");
@@ -85,6 +87,11 @@ public class RemoteDataPlaneSelectorService implements DataPlaneSelectorService 
     @Override
     public ServiceResult<DataPlaneInstance> selectFor(TransferProcess transferProcess) {
         return ServiceResult.unexpected("DataPlaneSelectorService.select can only be called as embedded in the control-plane");
+    }
+
+    @Override
+    public ServiceResult<List<DataPlaneInstance>> search(QuerySpec querySpec) {
+        return ServiceResult.unexpected("DataPlaneSelectorService.search can only be called as embedded in the control-plane");
     }
 
     @Override

--- a/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
+++ b/spi/data-plane-selector/data-plane-selector-spi/src/main/java/org/eclipse/edc/connector/dataplane/selector/spi/DataPlaneSelectorService.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstanceStates;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,10 +39,18 @@ public interface DataPlaneSelectorService {
     ServiceResult<List<DataPlaneInstance>> getAll();
 
     /**
+     * Search for {@link DataPlaneInstance}s that satisfy the query specification.
+     *
+     * @param querySpec the query specification.
+     * @return the list of data plane instances, empty otherwise.
+     */
+    ServiceResult<List<DataPlaneInstance>> search(QuerySpec querySpec);
+
+    /**
      * Select the {@link DataPlaneInstance} that satisfies the predicate using the selection strategy.
      *
      * @param selectionStrategy the selection strategy.
-     * @param filter the predicate.
+     * @param filter            the predicate.
      * @return the data plane, empty otherwise
      * @deprecated use {@link #selectFor(TransferProcess)} instead
      */

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualTransferEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualTransferEndToEndTest.java
@@ -57,8 +57,6 @@ class VirtualTransferEndToEndTest {
     static Config config() {
         return ConfigFactory.fromMap(new HashMap<>() {
             {
-                put("edc.transfer.proxy.token.signer.privatekey.alias", "private-key");
-                put("edc.transfer.proxy.token.verifier.publickey.alias", "public-key");
                 put("edc.iam.oauth2.jwks.url", "https://example.com/jwks");
                 put("edc.iam.oauth2.issuer", "test-issuer");
                 put("edc.encryption.strict", "false");

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualTransferEndToEndTestBase.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualTransferEndToEndTestBase.java
@@ -21,12 +21,11 @@ import org.eclipse.edc.connector.controlplane.test.system.utils.Participants;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.ManagementApiClientV5;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.AssetDto;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.DataAddressDto;
+import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.DataPlaneRegistrationDto;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.PermissionDto;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.PolicyDefinitionDto;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.PolicyDto;
-import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.AuthorizationProfile;
-import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
 import org.eclipse.edc.junit.annotations.Runtime;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.test.e2e.dataplane.DataPlaneSignalingClient;
@@ -36,6 +35,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
@@ -57,7 +57,6 @@ public abstract class VirtualTransferEndToEndTestBase {
                           Participants participants,
                           @Runtime(PROVIDER_DP) DataPlaneSignalingClient providerDataPlane,
                           @Runtime(CONSUMER_DP) DataPlaneSignalingClient consumerDataPlane,
-                          DataPlaneSelectorService dataPlaneSelectorService,
                           Oauth2Extension oauth2) {
         connectorClient.createParticipant(participants.consumer().contextId(), participants.consumer().id(), participants.consumer().config());
         connectorClient.createParticipant(participants.provider().contextId(), participants.provider().id(), participants.provider().config());
@@ -68,28 +67,24 @@ public abstract class VirtualTransferEndToEndTestBase {
         var providerControlPlaneOauth2Profile = oauth2.registerClient(participants.provider().contextId());
 
 
-        var consumerDp = DataPlaneInstance.Builder.newInstance()
-                .id(consumerDataPlane.dataPlaneId())
-                .url(consumerDataPlane.getDataFlowsEndpoint())
-                .allowedTransferType("NonFinite-PULL")
-                .authorizationProfile(toAuthorizationProfile(consumerControlPlaneOauth2Profile))
-                .participantContextId(participants.consumer().contextId())
-                .build();
+        var consumerDp = new DataPlaneRegistrationDto(
+                consumerDataPlane.dataPlaneId(),
+                consumerDataPlane.getDataFlowsEndpoint(),
+                Set.of("NonFinite-PULL"),
+                Set.of(),
+                toAuthorizationProfile(consumerControlPlaneOauth2Profile).properties()
+        );
+        connectorClient.dataplanes().registerDataPlane(participants.consumer().contextId(), consumerDp);
 
-        dataPlaneSelectorService.register(consumerDp)
-                .orElseThrow(f -> new EdcException("Failed to register data plane instance: " + f.getFailureDetail()));
+        var providerDp = new DataPlaneRegistrationDto(
+                providerDataPlane.dataPlaneId(),
+                providerDataPlane.getDataFlowsEndpoint(),
+                Set.of("NonFinite-PULL"),
+                Set.of(),
+                toAuthorizationProfile(providerControlPlaneOauth2Profile).properties()
+        );
 
-        var providerDp = DataPlaneInstance.Builder.newInstance()
-                .id(providerDataPlane.dataPlaneId())
-                .url(providerDataPlane.getDataFlowsEndpoint())
-                .allowedTransferType("NonFinite-PULL")
-                .authorizationProfile(toAuthorizationProfile(providerControlPlaneOauth2Profile))
-                .participantContextId(participants.provider().contextId())
-                .build();
-
-        dataPlaneSelectorService.register(providerDp)
-                .orElseThrow(f -> new EdcException("Failed to register data plane instance: " + f.getFailureDetail()));
-
+        connectorClient.dataplanes().registerDataPlane(participants.provider().contextId(), providerDp);
 
         providerDataPlane.registerControlPlane(createObjectBuilder()
                 .add("controlplaneId", participants.provider().contextId())

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/DataPlaneRegistrationApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/DataPlaneRegistrationApiV5EndToEndTest.java
@@ -1,0 +1,305 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi.v5;
+
+import io.restassured.http.ContentType;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.authentication.OauthServer;
+import org.eclipse.edc.api.authentication.OauthServerEndToEndExtension;
+import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
+import org.eclipse.edc.connector.dataplane.selector.spi.instance.DataPlaneInstance;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
+import org.eclipse.edc.test.e2e.managementapi.Runtimes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.test.e2e.managementapi.v5.TestFunction.createParticipant;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * DataPlaneRegistration v5alpha endpoints end-to-end tests
+ */
+public class DataPlaneRegistrationApiV5EndToEndTest {
+
+
+    @SuppressWarnings("JUnitMalformedDeclaration")
+    abstract static class Tests {
+
+        private static final String PARTICIPANT_CONTEXT_ID = "test-participant";
+
+        private String participantTokenJwt;
+
+        @BeforeEach
+        void setup(OauthServer authServer, ParticipantContextService participantContextService) {
+            createParticipant(participantContextService, PARTICIPANT_CONTEXT_ID);
+
+            participantTokenJwt = authServer.createToken(PARTICIPANT_CONTEXT_ID);
+
+        }
+
+        @AfterEach
+        void teardown(ParticipantContextService participantContextService) {
+            participantContextService.deleteParticipantContext(PARTICIPANT_CONTEXT_ID)
+                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+        }
+
+        @Test
+        void registerDataPlane(ManagementEndToEndV5TestContext context, DataPlaneSelectorService selectorService) {
+            var message = createDataPlaneRegistrationMessage("dataplane-1", null);
+
+            context.baseRequest(participantTokenJwt)
+                    .contentType(ContentType.JSON)
+                    .body(message)
+                    .put("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/dataplanes")
+                    .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body(notNullValue());
+
+            var dataPlaneInstance = selectorService.findById("dataplane-1")
+                    .orElseThrow((e) -> new AssertionError("Data plane instance not found"));
+
+            assertThat(dataPlaneInstance).isNotNull();
+            assertThat(dataPlaneInstance.getParticipantContextId()).isEqualTo(PARTICIPANT_CONTEXT_ID);
+        }
+
+
+        @Test
+        void registerDataPlane_tokenBearerDoesNotOwnResource(ManagementEndToEndV5TestContext context,
+                                                             OauthServer authServer,
+                                                             ParticipantContextService srv) {
+
+            var message = createDataPlaneRegistrationMessage("dataplane-1", null);
+
+            var otherParticipantId = UUID.randomUUID().toString();
+            createParticipant(srv, otherParticipantId);
+            var token = authServer.createToken(otherParticipantId);
+
+            context.baseRequest(token)
+                    .contentType(ContentType.JSON)
+                    .body(message)
+                    .put("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/dataplanes")
+                    .then()
+                    .log().all()
+                    .statusCode(403)
+                    .body(notNullValue());
+        }
+
+        @Test
+        void registerDataPlane_tokenLacksRequiredScope(ManagementEndToEndV5TestContext context,
+                                                       OauthServer authServer) {
+
+            var message = createDataPlaneRegistrationMessage("dataplane-1", null);
+            var token = authServer.createToken(PARTICIPANT_CONTEXT_ID, Map.of("scope", "management-api:read"));
+
+            context.baseRequest(token)
+                    .contentType(ContentType.JSON)
+                    .body(message)
+                    .put("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/dataplanes")
+                    .then()
+                    .log().all()
+                    .statusCode(403)
+                    .body(notNullValue());
+        }
+
+        @Test
+        void registerDataPlane_tokenBearerIsAdmin(ManagementEndToEndV5TestContext context,
+                                                  OauthServer authServer) {
+
+            var message = createDataPlaneRegistrationMessage("dataplane-1", null);
+
+            context.baseRequest(authServer.createAdminToken())
+                    .contentType(ContentType.JSON)
+                    .body(message)
+                    .put("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/dataplanes")
+                    .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body(notNullValue());
+        }
+
+        @Test
+        void registerDataPlane_tokenBearerIsProvisioner(ManagementEndToEndV5TestContext context,
+                                                        OauthServer authServer) {
+
+            var message = createDataPlaneRegistrationMessage("dataplane-1", null);
+
+            context.baseRequest(authServer.createProvisionerToken())
+                    .contentType(ContentType.JSON)
+                    .body(message)
+                    .put("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/dataplanes")
+                    .then()
+                    .log().all()
+                    .statusCode(200)
+                    .body(notNullValue());
+        }
+
+        @Test
+        void delete(ManagementEndToEndV5TestContext context, DataPlaneSelectorService selectorService) {
+
+            var instance = DataPlaneInstance.Builder.newInstance().id(UUID.randomUUID().toString())
+                    .participantContextId(PARTICIPANT_CONTEXT_ID)
+                    .url("http://example.com/dataflows")
+                    .build();
+            selectorService.register(instance).orElseThrow(f -> new AssertionError("Failed to register data plane instance for test setup: " + f.getFailureDetail()));
+
+
+            context.baseRequest(participantTokenJwt)
+                    .contentType(ContentType.JSON)
+                    .delete("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/dataplanes/" + instance.getId())
+                    .then()
+                    .log().all()
+                    .statusCode(200);
+        }
+
+        @Test
+        void delete_tokenBearerDoesNotOwnResource(ManagementEndToEndV5TestContext context,
+                                                  DataPlaneSelectorService selectorService,
+                                                  ParticipantContextService srv,
+                                                  OauthServer authServer) {
+
+
+            var instance = DataPlaneInstance.Builder.newInstance().id(UUID.randomUUID().toString())
+                    .participantContextId(PARTICIPANT_CONTEXT_ID)
+                    .url("http://example.com/dataflows")
+                    .build();
+            selectorService.register(instance).orElseThrow(f -> new AssertionError("Failed to register data plane instance for test setup: " + f.getFailureDetail()));
+
+            var otherParticipantId = UUID.randomUUID().toString();
+            createParticipant(srv, otherParticipantId);
+            var token = authServer.createToken(otherParticipantId);
+
+
+            context.baseRequest(token)
+                    .contentType(ContentType.JSON)
+                    .delete("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/dataplanes/" + instance.getId())
+                    .then()
+                    .log().all()
+                    .statusCode(403);
+        }
+
+        @Test
+        void delete_tokenLacksRequiredScope(ManagementEndToEndV5TestContext context, OauthServer authServer,
+                                            DataPlaneSelectorService selectorService) {
+
+            var instance = DataPlaneInstance.Builder.newInstance().id(UUID.randomUUID().toString())
+                    .participantContextId(PARTICIPANT_CONTEXT_ID)
+                    .url("http://example.com/dataflows")
+                    .build();
+            selectorService.register(instance).orElseThrow(f -> new AssertionError("Failed to register data plane instance for test setup: " + f.getFailureDetail()));
+
+            var token = authServer.createToken(PARTICIPANT_CONTEXT_ID, Map.of("scope", "management-api:read"));
+
+            context.baseRequest(token)
+                    .contentType(ContentType.JSON)
+                    .delete("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/dataplanes/" + instance.getId())
+                    .then()
+                    .log().all()
+                    .statusCode(403);
+        }
+
+        public JsonObject createDataPlaneRegistrationMessage(String dataPlaneId, JsonObject authorizationProfile) {
+            var builder = createObjectBuilder()
+                    .add("dataplaneId", dataPlaneId)
+                    .add("endpoint", "http://example.com/dataflows")
+                    .add("transferTypes", createArrayBuilder()
+                            .add("Finite-PUSH")
+                            .add("Finite-PULL")
+                            .add("NonFinite-PUSH")
+                            .add("NonFinite-PULL")
+                            .add("AsyncPrepare-PUSH")
+                            .add("AsyncStart-PULL")
+                    );
+
+            if (authorizationProfile != null) {
+                builder.add("authorization", authorizationProfile);
+            }
+
+            return builder.build();
+        }
+
+    }
+
+    @Nested
+    @EndToEndTest
+    class InMemory extends Tests {
+
+        @Order(0)
+        @RegisterExtension
+        static final OauthServerEndToEndExtension AUTH_SERVER_EXTENSION = OauthServerEndToEndExtension.Builder.newInstance().build();
+
+        @Order(1)
+        @RegisterExtension
+        static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()
+                .name(Runtimes.ControlPlane.NAME)
+                .modules(Runtimes.ControlPlane.VIRTUAL_MODULES)
+                .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
+                .configurationProvider(Runtimes.ControlPlane::config)
+                .configurationProvider(AUTH_SERVER_EXTENSION::getConfig)
+                .paramProvider(ManagementEndToEndV5TestContext.class, ManagementEndToEndV5TestContext::forContext)
+                .build();
+    }
+
+    @Nested
+    @PostgresqlIntegrationTest
+    class Postgres extends Tests {
+
+        @Order(0)
+        @RegisterExtension
+        static final OauthServerEndToEndExtension AUTH_SERVER_EXTENSION = OauthServerEndToEndExtension.Builder.newInstance().build();
+
+        @RegisterExtension
+        @Order(0)
+        static final PostgresqlEndToEndExtension POSTGRES_EXTENSION = new PostgresqlEndToEndExtension();
+
+        @Order(1)
+        @RegisterExtension
+        static final BeforeAllCallback SETUP = context -> {
+            POSTGRES_EXTENSION.createDatabase(Runtimes.ControlPlane.NAME.toLowerCase());
+        };
+
+
+        @Order(2)
+        @RegisterExtension
+        static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()
+                .name(Runtimes.ControlPlane.NAME)
+                .modules(Runtimes.ControlPlane.VIRTUAL_MODULES)
+                .modules(Runtimes.ControlPlane.SQL_MODULES)
+                .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
+                .configurationProvider(Runtimes.ControlPlane::config)
+                .configurationProvider(() -> POSTGRES_EXTENSION.configFor(Runtimes.ControlPlane.NAME.toLowerCase()))
+                .configurationProvider(AUTH_SERVER_EXTENSION::getConfig)
+                .paramProvider(ManagementEndToEndV5TestContext.class, ManagementEndToEndV5TestContext::forContext)
+                .build();
+
+    }
+
+}


### PR DESCRIPTION
## What this PR changes/adds

add v5beta dataplane registration api in management context. To not create additional modules the
controller v5beta has been placed together with the v4. The v5beta gets activated if not running in single
participant mode (backward compatibility) and the authorization service is injected.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5647 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
