### PR TITLE
feat: split api group documentation for DPS module

### DIFF
--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/build.gradle.kts
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("signaling-api")
+        apiGroup("signaling-api", "org.eclipse.edc.signaling.port.api.signaling")
+        apiGroup("management-api", "org.eclipse.edc.signaling.port.api.management")
     }
 }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingApiExtension.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingApiExtension.java
@@ -23,16 +23,15 @@ import org.eclipse.edc.participantcontext.spi.types.ParticipantResource;
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.signaling.port.api.DataPlaneRegistrationApiV4Controller;
-import org.eclipse.edc.signaling.port.api.DataPlaneTransferApiController;
-import org.eclipse.edc.signaling.port.api.DataPlaneTransferAuthorizationFilter;
-import org.eclipse.edc.signaling.port.api.v5.DataPlaneRegistrationApiV5Controller;
+import org.eclipse.edc.signaling.port.api.management.DataPlaneRegistrationApiV4Controller;
+import org.eclipse.edc.signaling.port.api.management.v5.DataPlaneRegistrationApiV5Controller;
+import org.eclipse.edc.signaling.port.api.signaling.DataPlaneTransferApiController;
+import org.eclipse.edc.signaling.port.api.signaling.DataPlaneTransferAuthorizationFilter;
 import org.eclipse.edc.signaling.port.transformer.DataAddressToDspDataAddressTransformer;
 import org.eclipse.edc.signaling.port.transformer.DataFlowStatusMessageToDataFlowResponseTransformer;
 import org.eclipse.edc.signaling.port.transformer.DspDataAddressToDataAddressTransformer;
 import org.eclipse.edc.signaling.spi.authorization.SignalingAuthorizationRegistry;
 import org.eclipse.edc.spi.EdcException;
-import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -78,9 +77,6 @@ public class DataPlaneSignalingApiExtension implements ServiceExtension {
 
     @Inject(required = false)
     private AuthorizationService authorizationService;
-
-    @Inject
-    private Monitor monitor;
 
     @Override
     public String name() {

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/management/DataPlaneRegistrationApiV4.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/management/DataPlaneRegistrationApiV4.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Think-it GmbH
+ *  Copyright (c) 2026 Think-it GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.signaling.port.api.v5;
+package org.eclipse.edc.signaling.port.api.management;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,16 +24,15 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.SecurityContext;
 import org.eclipse.edc.api.model.ApiCoreSchema;
 import org.eclipse.edc.signaling.domain.DataPlaneRegistrationMessage;
 
 import static jakarta.ws.rs.HttpMethod.DELETE;
 import static jakarta.ws.rs.HttpMethod.PUT;
 
-@OpenAPIDefinition(info = @Info(version = "v5"))
-@Tag(name = "Dataplane Signaling Registration v5beta")
-public interface DataPlaneRegistrationApiV5 {
+@OpenAPIDefinition(info = @Info(version = "v4"))
+@Tag(name = "Dataplane Signaling Registration v4")
+public interface DataPlaneRegistrationApiV4 {
 
     @Operation(
             method = PUT,
@@ -47,7 +46,7 @@ public interface DataPlaneRegistrationApiV5 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    Response registerV5(String participantContextId, DataPlaneRegistrationMessage registration, SecurityContext securityContext);
+    Response register(DataPlaneRegistrationMessage registration);
 
 
     @Operation(
@@ -59,6 +58,6 @@ public interface DataPlaneRegistrationApiV5 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    Response deleteV5(String participantContextId, String dataplaneId, SecurityContext securityContext);
+    Response delete(String dataplaneId);
 
 }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/management/DataPlaneRegistrationApiV4Controller.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/management/DataPlaneRegistrationApiV4Controller.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Think-it GmbH
+ *  Copyright (c) 2026 Think-it GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.signaling.port.api;
+package org.eclipse.edc.signaling.port.api.management;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/management/DataPlaneRegistrationApiV5.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/management/DataPlaneRegistrationApiV5.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Think-it GmbH
+ *  Copyright (c) 2026 Think-it GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.signaling.port.api;
+package org.eclipse.edc.signaling.port.api.management.v5;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,15 +24,16 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
 import org.eclipse.edc.api.model.ApiCoreSchema;
 import org.eclipse.edc.signaling.domain.DataPlaneRegistrationMessage;
 
 import static jakarta.ws.rs.HttpMethod.DELETE;
 import static jakarta.ws.rs.HttpMethod.PUT;
 
-@OpenAPIDefinition(info = @Info(version = "v4"))
-@Tag(name = "Dataplane Signaling Registration v4")
-public interface DataPlaneRegistrationApiV4 {
+@OpenAPIDefinition(info = @Info(version = "v5"))
+@Tag(name = "Dataplane Signaling Registration v5beta")
+public interface DataPlaneRegistrationApiV5 {
 
     @Operation(
             method = PUT,
@@ -46,7 +47,7 @@ public interface DataPlaneRegistrationApiV4 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    Response register(DataPlaneRegistrationMessage registration);
+    Response registerV5(String participantContextId, DataPlaneRegistrationMessage registration, SecurityContext securityContext);
 
 
     @Operation(
@@ -58,6 +59,6 @@ public interface DataPlaneRegistrationApiV4 {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiCoreSchema.ApiErrorDetailSchema.class))))
             }
     )
-    Response delete(String dataplaneId);
+    Response deleteV5(String participantContextId, String dataplaneId, SecurityContext securityContext);
 
 }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/management/DataPlaneRegistrationApiV5Controller.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/management/DataPlaneRegistrationApiV5Controller.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Think-it GmbH
+ *  Copyright (c) 2026 Think-it GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.signaling.port.api.v5;
+package org.eclipse.edc.signaling.port.api.management.v5;
 
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.Consumes;
@@ -41,7 +41,7 @@ import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMa
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
 @Path("/v5beta/participants/{participantContextId}/dataplanes")
-public class DataPlaneRegistrationApiV5Controller implements DataPlaneRegistrationApiV5 {
+public class DataPlaneRegistrationApiV5Controller implements org.eclipse.edc.signaling.port.api.management.v5.DataPlaneRegistrationApiV5 {
 
     private final DataPlaneSelectorService dataPlaneSelectorService;
     private final AuthorizationService authorizationService;

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/signaling/DataPlaneTransferApi.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/signaling/DataPlaneTransferApi.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Think-it GmbH
+ *  Copyright (c) 2026 Think-it GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.signaling.port.api;
+package org.eclipse.edc.signaling.port.api.signaling;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/signaling/DataPlaneTransferApiController.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/signaling/DataPlaneTransferApiController.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Think-it GmbH
+ *  Copyright (c) 2026 Think-it GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.signaling.port.api;
+package org.eclipse.edc.signaling.port.api.signaling;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/signaling/DataPlaneTransferAuthorizationFilter.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/signaling/DataPlaneTransferAuthorizationFilter.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.signaling.port.api;
+package org.eclipse.edc.signaling.port.api.signaling;
 
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotAuthorizedException;

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/resources/signaling-api-version.json
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/resources/signaling-api-version.json
@@ -2,6 +2,6 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1",
-    "lastUpdated": "2026-04-01T14:00:01Z"
+    "lastUpdated": "2026-04-17T14:00:01Z"
   }
 ]

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/management/DataPlaneRegistrationApiV4ControllerTest.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/management/DataPlaneRegistrationApiV4ControllerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Think-it GmbH
+ *  Copyright (c) 2026 Think-it GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,15 +12,15 @@
  *
  */
 
-package org.eclipse.edc.signaling.port.api.v5;
+package org.eclipse.edc.signaling.port.api.management;
 
 import io.restassured.http.ContentType;
-import org.eclipse.edc.api.auth.spi.AuthorizationService;
 import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
+import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.signaling.domain.DataPlaneRegistrationMessage;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -34,20 +34,16 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class DataPlaneRegistrationApiV5ControllerTest extends RestControllerTestBase {
+class DataPlaneRegistrationApiV4ControllerTest extends RestControllerTestBase {
 
-    protected final AuthorizationService authorizationService = mock();
     private final DataPlaneSelectorService dataPlaneSelectorService = mock();
-    private final String participantContextId = "test-participant-context-id";
+
+    private final SingleParticipantContextSupplier participantContextSupplier = () ->
+            ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId("participant-context-id").identity("identity").build());
 
     @Override
     protected Object controller() {
-        return new DataPlaneRegistrationApiV5Controller(dataPlaneSelectorService, authorizationService);
-    }
-
-    @BeforeEach
-    public void setup() {
-        when(authorizationService.authorize(any(), any(), any(), any())).thenReturn(ServiceResult.success());
+        return new DataPlaneRegistrationApiV4Controller(dataPlaneSelectorService, participantContextSupplier);
     }
 
     @Nested
@@ -62,7 +58,7 @@ class DataPlaneRegistrationApiV5ControllerTest extends RestControllerTestBase {
                     .port(port)
                     .contentType(ContentType.JSON)
                     .body(message)
-                    .put("/v5beta/participants/%s/dataplanes".formatted(participantContextId))
+                    .put("/v4/dataplanes")
                     .then()
                     .log().ifValidationFails()
                     .statusCode(200);
@@ -87,7 +83,7 @@ class DataPlaneRegistrationApiV5ControllerTest extends RestControllerTestBase {
                     .port(port)
                     .contentType(ContentType.JSON)
                     .body(message)
-                    .put("/v5beta/participants/%s/dataplanes".formatted(participantContextId))
+                    .put("/v4/dataplanes")
                     .then()
                     .log().ifValidationFails()
                     .statusCode(200);
@@ -107,7 +103,7 @@ class DataPlaneRegistrationApiV5ControllerTest extends RestControllerTestBase {
                     .port(port)
                     .contentType(ContentType.JSON)
                     .body(message)
-                    .put("/v5beta/participants/{participantContextId}/dataplanes", participantContextId)
+                    .put("/v4/dataplanes")
                     .then()
                     .log().ifValidationFails()
                     .statusCode(409);
@@ -124,7 +120,7 @@ class DataPlaneRegistrationApiV5ControllerTest extends RestControllerTestBase {
             given()
                     .port(port)
                     .contentType(ContentType.JSON)
-                    .delete("/v5beta/participants/{participantContextId}/dataplanes/{dataplaneId}", participantContextId, "dp-id")
+                    .delete("/v4/dataplanes/{dataplaneId}", "dp-id")
                     .then()
                     .log().ifValidationFails()
                     .statusCode(200);
@@ -139,7 +135,7 @@ class DataPlaneRegistrationApiV5ControllerTest extends RestControllerTestBase {
             given()
                     .port(port)
                     .contentType(ContentType.JSON)
-                    .delete("/v5beta/participants/{participantContextId}/dataplanes/{dataplaneId}", participantContextId, "dp-id")
+                    .delete("/v4/dataplanes/{dataplaneId}", "dp-id")
                     .then()
                     .log().ifValidationFails()
                     .statusCode(404);

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/management/v5/DataPlaneRegistrationApiV5ControllerTest.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/management/v5/DataPlaneRegistrationApiV5ControllerTest.java
@@ -12,15 +12,15 @@
  *
  */
 
-package org.eclipse.edc.signaling.port.api;
+package org.eclipse.edc.signaling.port.api.management.v5;
 
 import io.restassured.http.ContentType;
+import org.eclipse.edc.api.auth.spi.AuthorizationService;
 import org.eclipse.edc.connector.dataplane.selector.spi.DataPlaneSelectorService;
-import org.eclipse.edc.participantcontext.single.spi.SingleParticipantContextSupplier;
-import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.signaling.domain.DataPlaneRegistrationMessage;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -34,16 +34,20 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class DataPlaneRegistrationApiV4ControllerTest extends RestControllerTestBase {
+class DataPlaneRegistrationApiV5ControllerTest extends RestControllerTestBase {
 
+    protected final AuthorizationService authorizationService = mock();
     private final DataPlaneSelectorService dataPlaneSelectorService = mock();
-
-    private final SingleParticipantContextSupplier participantContextSupplier = () ->
-            ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId("participant-context-id").identity("identity").build());
+    private final String participantContextId = "test-participant-context-id";
 
     @Override
     protected Object controller() {
-        return new DataPlaneRegistrationApiV4Controller(dataPlaneSelectorService, participantContextSupplier);
+        return new org.eclipse.edc.signaling.port.api.management.v5.DataPlaneRegistrationApiV5Controller(dataPlaneSelectorService, authorizationService);
+    }
+
+    @BeforeEach
+    public void setup() {
+        when(authorizationService.authorize(any(), any(), any(), any())).thenReturn(ServiceResult.success());
     }
 
     @Nested
@@ -58,7 +62,7 @@ class DataPlaneRegistrationApiV4ControllerTest extends RestControllerTestBase {
                     .port(port)
                     .contentType(ContentType.JSON)
                     .body(message)
-                    .put("/v4/dataplanes")
+                    .put("/v5beta/participants/%s/dataplanes".formatted(participantContextId))
                     .then()
                     .log().ifValidationFails()
                     .statusCode(200);
@@ -83,7 +87,7 @@ class DataPlaneRegistrationApiV4ControllerTest extends RestControllerTestBase {
                     .port(port)
                     .contentType(ContentType.JSON)
                     .body(message)
-                    .put("/v4/dataplanes")
+                    .put("/v5beta/participants/%s/dataplanes".formatted(participantContextId))
                     .then()
                     .log().ifValidationFails()
                     .statusCode(200);
@@ -103,7 +107,7 @@ class DataPlaneRegistrationApiV4ControllerTest extends RestControllerTestBase {
                     .port(port)
                     .contentType(ContentType.JSON)
                     .body(message)
-                    .put("/v4/dataplanes")
+                    .put("/v5beta/participants/{participantContextId}/dataplanes", participantContextId)
                     .then()
                     .log().ifValidationFails()
                     .statusCode(409);
@@ -120,7 +124,7 @@ class DataPlaneRegistrationApiV4ControllerTest extends RestControllerTestBase {
             given()
                     .port(port)
                     .contentType(ContentType.JSON)
-                    .delete("/v4/dataplanes/{dataplaneId}", "dp-id")
+                    .delete("/v5beta/participants/{participantContextId}/dataplanes/{dataplaneId}", participantContextId, "dp-id")
                     .then()
                     .log().ifValidationFails()
                     .statusCode(200);
@@ -135,7 +139,7 @@ class DataPlaneRegistrationApiV4ControllerTest extends RestControllerTestBase {
             given()
                     .port(port)
                     .contentType(ContentType.JSON)
-                    .delete("/v4/dataplanes/{dataplaneId}", "dp-id")
+                    .delete("/v5beta/participants/{participantContextId}/dataplanes/{dataplaneId}", participantContextId, "dp-id")
                     .then()
                     .log().ifValidationFails()
                     .statusCode(404);

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/signaling/DataPlaneTransferApiControllerTest.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/signaling/DataPlaneTransferApiControllerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Think-it GmbH
+ *  Copyright (c) 2026 Think-it GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.signaling.port.api;
+package org.eclipse.edc.signaling.port.api.signaling;
 
 import io.restassured.http.ContentType;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;

--- a/data-protocols/data-plane-signaling/src/main/resources/signaling-api-version.json
+++ b/data-protocols/data-plane-signaling/src/main/resources/signaling-api-version.json
@@ -1,7 +1,0 @@
-[
-  {
-    "version": "1.0.0-alpha",
-    "urlPath": "/v1",
-    "lastUpdated": "2026-04-16T15:00:01Z"
-  }
-]

--- a/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-2025/dsp-catalog-2025/dsp-catalog-http-api-2025/build.gradle.kts
@@ -43,6 +43,6 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("dsp-api")
+        apiGroup("dsp-api")
     }
 }

--- a/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-2025/dsp-negotiation-2025/dsp-negotiation-http-api-2025/build.gradle.kts
@@ -42,6 +42,6 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("dsp-api")
+        apiGroup("dsp-api")
     }
 }

--- a/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/build.gradle.kts
+++ b/data-protocols/dsp/dsp-2025/dsp-transfer-process-2025/dsp-transfer-process-http-api-2025/build.gradle.kts
@@ -42,6 +42,6 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("dsp-api")
+        apiGroup("dsp-api")
     }
 }

--- a/data-protocols/dsp/dsp-version/dsp-version-http-api/build.gradle.kts
+++ b/data-protocols/dsp/dsp-version/dsp-version-http-api/build.gradle.kts
@@ -34,6 +34,6 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("dsp-api")
+        apiGroup("dsp-api")
     }
 }

--- a/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-catalog-http-api-2025-virtual/build.gradle.kts
+++ b/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-catalog-http-api-2025-virtual/build.gradle.kts
@@ -42,6 +42,6 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("dsp-api-virtual")
+        apiGroup("dsp-api-virtual")
     }
 }

--- a/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-negotiation-http-api-2025-virtual/build.gradle.kts
+++ b/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-negotiation-http-api-2025-virtual/build.gradle.kts
@@ -41,6 +41,6 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("dsp-api-virtual")
+        apiGroup("dsp-api-virtual")
     }
 }

--- a/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-transfer-process-http-api-2025-virtual/build.gradle.kts
+++ b/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-transfer-process-http-api-2025-virtual/build.gradle.kts
@@ -42,6 +42,6 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("dsp-api-virtual")
+        apiGroup("dsp-api-virtual")
     }
 }

--- a/data-protocols/dsp/dsp-virtual/dsp-metadata-http-api-virtual/build.gradle.kts
+++ b/data-protocols/dsp/dsp-virtual/dsp-metadata-http-api-virtual/build.gradle.kts
@@ -35,6 +35,6 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("dsp-api-virtual")
+        apiGroup("dsp-api-virtual")
     }
 }

--- a/extensions/common/api/api-observability/build.gradle.kts
+++ b/extensions/common/api/api-observability/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("observability-api")
+        apiGroup("observability-api")
     }
 }
 

--- a/extensions/common/api/management-api-configuration/build.gradle.kts
+++ b/extensions/common/api/management-api-configuration/build.gradle.kts
@@ -32,11 +32,3 @@ dependencies {
     testImplementation(project(":core:common:lib:json-ld-lib"))
     testImplementation(project(":extensions:common:json-ld"))
 }
-
-edcBuild {
-    swagger {
-        apiGroup.set("management-api")
-    }
-}
-
-

--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -8,7 +8,7 @@
   {
     "version": "4.0.0",
     "urlPath": "/v4",
-    "lastUpdated": "2026-04-09T09:43:01Z",
+    "lastUpdated": "2026-04-17T09:43:01Z",
     "maturity": "stable"
   },
   {

--- a/extensions/common/api/version-api/build.gradle.kts
+++ b/extensions/common/api/version-api/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("version-api")
+        apiGroup("version-api")
     }
 }
 

--- a/extensions/control-plane/api/control-plane-api/build.gradle.kts
+++ b/extensions/control-plane/api/control-plane-api/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("control-api")
+        apiGroup("control-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api-v5/asset-api-v5/build.gradle.kts
+++ b/extensions/control-plane/api/management-api-v5/asset-api-v5/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api-v5/catalog-api-v5/build.gradle.kts
+++ b/extensions/control-plane/api/management-api-v5/catalog-api-v5/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api-v5/cel-api-v5/build.gradle.kts
+++ b/extensions/control-plane/api/management-api-v5/cel-api-v5/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api-v5/contract-agreement-api-v5/build.gradle.kts
+++ b/extensions/control-plane/api/management-api-v5/contract-agreement-api-v5/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api-v5/contract-definition-api-v5/build.gradle.kts
+++ b/extensions/control-plane/api/management-api-v5/contract-definition-api-v5/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/build.gradle.kts
+++ b/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api-v5/participant-context-api-v5/build.gradle.kts
+++ b/extensions/control-plane/api/management-api-v5/participant-context-api-v5/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api-v5/participant-context-config-api-v5/build.gradle.kts
+++ b/extensions/control-plane/api/management-api-v5/participant-context-config-api-v5/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api-v5/policy-definition-api-v5/build.gradle.kts
+++ b/extensions/control-plane/api/management-api-v5/policy-definition-api-v5/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/build.gradle.kts
+++ b/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/build.gradle.kts
@@ -39,6 +39,6 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }

--- a/extensions/control-plane/api/management-api/asset-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/asset-api/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/build.gradle.kts
@@ -28,5 +28,3 @@ dependencies {
     api(project(":extensions:control-plane:api:management-api:policy-definition-api"))
     api(project(":extensions:control-plane:api:management-api:transfer-process-api"))
 }
-
-

--- a/extensions/control-plane/api/management-api/catalog-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/catalog-api/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api/contract-agreement-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api/contract-definition-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/contract-definition-api/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api/edr-cache-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/edr-cache-api/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api/policy-definition-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/policy-definition-api/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api/secrets-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/secrets-api/build.gradle.kts
@@ -15,7 +15,7 @@
 
 plugins {
     `java-library`
-    id("io.swagger.core.v3.swagger-gradle-plugin")
+    id(libs.plugins.swagger.get().pluginId)
 }
 
 dependencies {
@@ -41,7 +41,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/control-plane/api/management-api/transfer-process-api/build.gradle.kts
+++ b/extensions/control-plane/api/management-api/transfer-process-api/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/data-plane-selector/data-plane-selector-api/build.gradle.kts
+++ b/extensions/data-plane-selector/data-plane-selector-api/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/data-plane-selector/data-plane-selector-control-api/build.gradle.kts
+++ b/extensions/data-plane-selector/data-plane-selector-control-api/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("control-api")
+        apiGroup("control-api")
     }
 }
 

--- a/extensions/data-plane/data-plane-provision-http/build.gradle.kts
+++ b/extensions/data-plane/data-plane-provision-http/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }
 

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/build.gradle.kts
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-api/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 }
 edcBuild {
     swagger {
-        apiGroup.set("control-api")
+        apiGroup("control-api")
     }
 }
 

--- a/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/build.gradle.kts
+++ b/extensions/data-plane/data-plane-signaling/data-plane-signaling-transform/build.gradle.kts
@@ -29,10 +29,3 @@ dependencies {
     testImplementation(project(":core:common:junit"))
     testImplementation(project(":core:common:lib:json-ld-lib"))
 }
-edcBuild {
-    swagger {
-        apiGroup.set("control-api")
-    }
-}
-
-

--- a/extensions/federated-catalog/api/federated-catalog-api/build.gradle.kts
+++ b/extensions/federated-catalog/api/federated-catalog-api/build.gradle.kts
@@ -50,6 +50,6 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("management-api")
+        apiGroup("management-api")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -132,6 +132,6 @@ dsp-core = { module = "org.eclipse.dataspacetck.dsp:core", version.ref = "dcp-tc
 jackson = ["jackson-annotations", "jackson-databind"]
 
 [plugins]
-edc-build = { id = "org.eclipse.edc.edc-build", version = "1.4.0" }
+edc-build = { id = "org.eclipse.edc.edc-build", version = "1.5.1" }
 shadow = { id = "com.gradleup.shadow", version = "9.3.1" }
 swagger = { id = "io.swagger.core.v3.swagger-gradle-plugin", version.ref = "swagger" }

--- a/resources/openapi/signaling-api.version
+++ b/resources/openapi/signaling-api.version
@@ -1,1 +1,1 @@
-data-protocols/data-plane-signaling/src/main/resources/signaling-api-version.json
+data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/resources/signaling-api-version.json


### PR DESCRIPTION
## What this PR changes/adds

Correctly split DPS api documentation into management and signaling

## Why it does that

_Briefly state why the change was necessary._

## Further notes

- deleted duplicated `signaling-api-version.json` file


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #5323 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
