### PR TITLE
feat: add OauthTokenProvider interface for management api client v5

### DIFF
--- a/extensions/common/auth/auth-authentication-oauth2-lib/src/testFixtures/java/org/eclipse/edc/api/authentication/OauthServer.java
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/src/testFixtures/java/org/eclipse/edc/api/authentication/OauthServer.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 
 import static com.nimbusds.jose.JWSAlgorithm.ES256;
 
-public class OauthServer {
+public class OauthServer implements OauthTokenProvider {
 
     private final ECKey oauthServerSigningKey;
     private final String issuer;

--- a/extensions/common/auth/auth-authentication-oauth2-lib/src/testFixtures/java/org/eclipse/edc/api/authentication/OauthTokenProvider.java
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/src/testFixtures/java/org/eclipse/edc/api/authentication/OauthTokenProvider.java
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.api.authentication;
+
+public interface OauthTokenProvider {
+    String createToken(String participantContextId, String role);
+}

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/ManagementApiClientV5.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/ManagementApiClientV5.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.connector.controlplane.test.system.utils.client;
 
 import io.restassured.specification.RequestSpecification;
 import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
-import org.eclipse.edc.api.authentication.OauthServer;
+import org.eclipse.edc.api.authentication.OauthTokenProvider;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.AssetsApi;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.CatalogApi;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.CelExpressionApi;
@@ -64,7 +64,7 @@ public class ManagementApiClientV5 {
     protected static final Duration TIMEOUT = Duration.ofSeconds(30);
     private static final String PROTOCOL = "dataspace-protocol-http:2025-1";
     private static final JsonLdNamespace NS = new JsonLdNamespace(EDC_NAMESPACE);
-    private final OauthServer oauthServer;
+    private final OauthTokenProvider oauthServer;
     private final LazySupplier<URI> managementEndpoint;
 
     private final AssetsApi assets;
@@ -78,7 +78,7 @@ public class ManagementApiClientV5 {
     private final CelExpressionApi expressions;
     private final DataPlaneApi dataplanes;
 
-    public ManagementApiClientV5(OauthServer oauthServer,
+    public ManagementApiClientV5(OauthTokenProvider oauthServer,
                                  LazySupplier<URI> managementEndpoint) {
         this.oauthServer = oauthServer;
         this.managementEndpoint = managementEndpoint;
@@ -94,7 +94,7 @@ public class ManagementApiClientV5 {
         this.dataplanes = new DataPlaneApi(this);
     }
 
-    public static ManagementApiClientV5 forContext(ComponentRuntimeContext ctx, OauthServer authServer) {
+    public static ManagementApiClientV5 forContext(ComponentRuntimeContext ctx, OauthTokenProvider authServer) {
         return new ManagementApiClientV5(
                 authServer,
                 ctx.getEndpoint("management")
@@ -260,7 +260,6 @@ public class ManagementApiClientV5 {
             return baseManagementRequest(null, ParticipantPrincipal.ROLE_ADMIN);
         } else {
             return baseManagementRequest(participantContextId, ParticipantPrincipal.ROLE_PARTICIPANT);
-
         }
     }
 


### PR DESCRIPTION
When using the `ManagementApiClientV5` for testing it might be useful to customize how the client fetches a token for API calls in testing. Currently it's hardcoded to a mock oauth implementation, in other scenario might be useful to plug a different strategy for token creation

## What this PR changes/adds

_Briefly describe WHAT your pr changes, which features it adds/modifies._

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
