### PR TITLE
feat: validate JWKS for DPS Oauth2

### DIFF
--- a/core/common/lib/keys-lib/build.gradle.kts
+++ b/core/common/lib/keys-lib/build.gradle.kts
@@ -25,7 +25,9 @@ dependencies {
     implementation(libs.nimbus.jwt)
     implementation(libs.tink)
 
-    testImplementation(project(":core:common:junit-base"));
+    testImplementation(project(":core:common:junit"))
+    testImplementation(libs.awaitility)
+    testImplementation(libs.wiremock)
 
 }
 

--- a/core/common/lib/keys-lib/src/main/java/org/eclipse/edc/keys/resolver/JwksPublicKeyResolver.java
+++ b/core/common/lib/keys-lib/src/main/java/org/eclipse/edc/keys/resolver/JwksPublicKeyResolver.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2026 Think-it GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,11 +8,11 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Think-it GmbH - initial API and implementation
  *
  */
 
-package org.eclipse.edc.api.auth.delegated;
+package org.eclipse.edc.keys.resolver;
 
 import com.nimbusds.jose.KeySourceException;
 import com.nimbusds.jose.jwk.JWK;
@@ -51,6 +51,21 @@ public class JwksPublicKeyResolver implements PublicKeyResolver {
         this.keyParserRegistry = keyParserRegistry;
         this.monitor = monitor;
         this.jwkSource = jwkSource;
+    }
+
+    /**
+     * Creates a new resolver backed by the supplied {@link JWKSource}.
+     *
+     * <p>Use this overload when the caller manages the JWK source lifecycle directly — for example
+     * when using an {@code ImmutableJWKSet} for an inline key set, or when the source has already
+     * been constructed with custom caching or rate-limiting settings.
+     *
+     * @param keyParserRegistry Should contain all relevant key parsers. The minimum recommendation is adding a {@code JwkParser}.
+     * @param monitor           A monitor
+     * @param jwkSource         The pre-built JWK source to retrieve keys from.
+     */
+    public static JwksPublicKeyResolver create(KeyParserRegistry keyParserRegistry, Monitor monitor, JWKSource<SecurityContext> jwkSource) {
+        return new JwksPublicKeyResolver(keyParserRegistry, monitor, jwkSource);
     }
 
     /**
@@ -125,7 +140,7 @@ public class JwksPublicKeyResolver implements PublicKeyResolver {
             return Result.failure(msg);
         }
         if (keys.size() > 1) {
-            String msg = keyId == null ?
+            var msg = keyId == null ?
                     "JWKSet contained %d keys, but no keyId was specified. Please consider specifying a keyId.".formatted(keys.size()) :
                     "JWKSet contained %d matching keys (desired keyId: '%s'), where only 1 is expected. Will abort!".formatted(keys.size(), keyId);
             monitor.warning(msg);

--- a/core/common/lib/keys-lib/src/test/java/org/eclipse/edc/keys/resolver/JwksPublicKeyResolverTest.java
+++ b/core/common/lib/keys-lib/src/test/java/org/eclipse/edc/keys/resolver/JwksPublicKeyResolverTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2026 Think-it GmbH
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,16 +8,20 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Think-it GmbH - initial API and implementation
  *
  */
 
-package org.eclipse.edc.api.auth.delegated;
+package org.eclipse.edc.keys.resolver;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.keys.KeyParserRegistryImpl;
 import org.eclipse.edc.keys.keyparsers.JwkParser;
@@ -42,7 +46,6 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static com.nimbusds.jose.jwk.source.JWKSourceBuilder.DEFAULT_CACHE_TIME_TO_LIVE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
-import static org.eclipse.edc.api.auth.delegated.TestFunctions.generateKey;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.isA;
@@ -206,6 +209,14 @@ class JwksPublicKeyResolverTest {
         try {
             return mapper.writeValueAsString(m);
         } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static JWK generateKey(String keyId) {
+        try {
+            return new OctetKeyPairGenerator(Curve.Ed25519).keyID(keyId).keyUse(KeyUse.SIGNATURE).generate();
+        } catch (JOSEException e) {
             throw new RuntimeException(e);
         }
     }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/signaling/DataPlaneTransferAuthorizationFilter.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/signaling/DataPlaneTransferAuthorizationFilter.java
@@ -64,7 +64,7 @@ public class DataPlaneTransferAuthorizationFilter implements ContainerRequestFil
                     .formatted(dataPlaneId, authorizationProfile.type()));
         }
 
-        var callerDataPlaneId = authorization.isAuthorized(requestContext::getHeaderString)
+        var callerDataPlaneId = authorization.isAuthorized(requestContext::getHeaderString, authorizationProfile)
                 .orElseThrow(f -> new NotAuthorizedException("Not authorized"));
 
         if (!Objects.equals(dataPlaneId, callerDataPlaneId)) {

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/signaling/DataPlaneTransferApiControllerTest.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/signaling/DataPlaneTransferApiControllerTest.java
@@ -153,7 +153,7 @@ class DataPlaneTransferApiControllerTest extends RestControllerTestBase {
                     .authorizationProfile(new AuthorizationProfile("type", emptyMap())).build();
             when(dataPlaneSelectorService.findById(any())).thenReturn(ServiceResult.success(dataPlaneInstance));
             SignalingAuthorization authorization = mock();
-            when(authorization.isAuthorized(any())).thenReturn(Result.failure("not authorized"));
+            when(authorization.isAuthorized(any(), any())).thenReturn(Result.failure("not authorized"));
             when(signalingAuthorizationRegistry.findByType(any())).thenReturn(authorization);
             var transferId = UUID.randomUUID().toString();
             var message = DataFlowStatusMessage.Builder.newInstance().build();
@@ -167,7 +167,7 @@ class DataPlaneTransferApiControllerTest extends RestControllerTestBase {
                     .log().ifValidationFails()
                     .statusCode(401);
 
-            verify(authorization).isAuthorized(any());
+            verify(authorization).isAuthorized(any(), any());
         }
 
         @Test
@@ -179,7 +179,7 @@ class DataPlaneTransferApiControllerTest extends RestControllerTestBase {
                     .authorizationProfile(new AuthorizationProfile("type", emptyMap())).build();
             when(dataPlaneSelectorService.findById(any())).thenReturn(ServiceResult.success(dataPlaneInstance));
             SignalingAuthorization authorization = mock();
-            when(authorization.isAuthorized(any())).thenReturn(Result.success("dataPlaneId"));
+            when(authorization.isAuthorized(any(), any())).thenReturn(Result.success("dataPlaneId"));
             when(signalingAuthorizationRegistry.findByType(any())).thenReturn(authorization);
             var transferId = UUID.randomUUID().toString();
             var message = DataFlowStatusMessage.Builder.newInstance().build();
@@ -195,7 +195,7 @@ class DataPlaneTransferApiControllerTest extends RestControllerTestBase {
                     .log().ifValidationFails()
                     .statusCode(200);
 
-            verify(authorization).isAuthorized(any());
+            verify(authorization).isAuthorized(any(), any());
         }
 
         @Test
@@ -207,7 +207,7 @@ class DataPlaneTransferApiControllerTest extends RestControllerTestBase {
                     .authorizationProfile(new AuthorizationProfile("type", emptyMap())).build();
             when(dataPlaneSelectorService.findById(any())).thenReturn(ServiceResult.success(dataPlaneInstance));
             SignalingAuthorization authorization = mock();
-            when(authorization.isAuthorized(any())).thenReturn(Result.success("differentDataPlaneId"));
+            when(authorization.isAuthorized(any(), any())).thenReturn(Result.success("differentDataPlaneId"));
             when(signalingAuthorizationRegistry.findByType(any())).thenReturn(authorization);
             var transferId = UUID.randomUUID().toString();
             var message = DataFlowStatusMessage.Builder.newInstance().build();
@@ -221,7 +221,7 @@ class DataPlaneTransferApiControllerTest extends RestControllerTestBase {
                     .log().ifValidationFails()
                     .statusCode(401);
 
-            verify(authorization).isAuthorized(any());
+            verify(authorization).isAuthorized(any(), any());
         }
 
     }
@@ -381,7 +381,7 @@ class DataPlaneTransferApiControllerTest extends RestControllerTestBase {
                 .authorizationProfile(new AuthorizationProfile("type", emptyMap())).build();
         when(dataPlaneSelectorService.findById(any())).thenReturn(ServiceResult.success(dataPlaneInstance));
         SignalingAuthorization authorization = mock();
-        when(authorization.isAuthorized(any())).thenReturn(Result.success("dataPlaneId"));
+        when(authorization.isAuthorized(any(), any())).thenReturn(Result.success("dataPlaneId"));
         when(signalingAuthorizationRegistry.findByType(any())).thenReturn(authorization);
     }
 }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-oauth2/build.gradle.kts
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-oauth2/build.gradle.kts
@@ -19,9 +19,15 @@ plugins {
 dependencies {
     api(project(":spi:common:http-spi"))
     api(project(":spi:common:oauth2-spi"))
+    api(project(":spi:common:keys-spi"))
     api(project(":data-protocols:data-plane-signaling:data-plane-signaling-spi"))
 
+    implementation(project(":core:common:lib:keys-lib"))
     implementation(project(":core:common:lib:token-lib"))
+    implementation(libs.nimbus.jwt)
 
     testImplementation(project(":core:common:junit"))
+    testImplementation(project(":core:common:lib:keys-lib"))
+    testImplementation(project(":core:common:lib:crypto-common-lib"))
+    testImplementation(libs.wiremock)
 }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-oauth2/src/main/java/org/eclipse/edc/signaling/oauth2/DataPlaneSignalingOauth2Extension.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-oauth2/src/main/java/org/eclipse/edc/signaling/oauth2/DataPlaneSignalingOauth2Extension.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.signaling.oauth2;
 
 import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
 import org.eclipse.edc.jwt.validation.jti.JtiValidationStore;
+import org.eclipse.edc.keys.spi.KeyParserRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.signaling.oauth2.logic.Oauth2CredentialsSignalingAuthorization;
 import org.eclipse.edc.signaling.spi.authorization.SignalingAuthorizationRegistry;
@@ -45,6 +46,8 @@ public class DataPlaneSignalingOauth2Extension implements ServiceExtension {
     private Clock clock;
     @Inject
     private JtiValidationStore jtiValidationStore;
+    @Inject
+    private KeyParserRegistry keyParserRegistry;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
@@ -52,6 +55,6 @@ public class DataPlaneSignalingOauth2Extension implements ServiceExtension {
         tokenValidationRulesRegistry.addRule(VALIDATION_RULES_CONTEXT, new JtiValidationRule(jtiValidationStore, context.getMonitor().withPrefix(VALIDATION_RULES_CONTEXT)));
         tokenValidationRulesRegistry.addRule(VALIDATION_RULES_CONTEXT, new ExpirationIssuedAtValidationRule(clock, 0, false));
 
-        signalingAuthorizationRegistry.register(new Oauth2CredentialsSignalingAuthorization(oauth2Client, tokenValidationService, tokenValidationRulesRegistry));
+        signalingAuthorizationRegistry.register(new Oauth2CredentialsSignalingAuthorization(oauth2Client, tokenValidationService, tokenValidationRulesRegistry, keyParserRegistry, context.getMonitor()));
     }
 }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-oauth2/src/main/java/org/eclipse/edc/signaling/oauth2/logic/Oauth2CredentialsSignalingAuthorization.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-oauth2/src/main/java/org/eclipse/edc/signaling/oauth2/logic/Oauth2CredentialsSignalingAuthorization.java
@@ -14,16 +14,23 @@
 
 package org.eclipse.edc.signaling.oauth2.logic;
 
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.AuthorizationProfile;
 import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
 import org.eclipse.edc.iam.oauth2.spi.client.SharedSecretOauth2CredentialsRequest;
+import org.eclipse.edc.keys.resolver.JwksPublicKeyResolver;
+import org.eclipse.edc.keys.spi.KeyParserRegistry;
+import org.eclipse.edc.keys.spi.PublicKeyResolver;
 import org.eclipse.edc.signaling.oauth2.DataPlaneSignalingOauth2Extension;
 import org.eclipse.edc.signaling.spi.authorization.Header;
 import org.eclipse.edc.signaling.spi.authorization.SignalingAuthorization;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.token.spi.TokenValidationRulesRegistry;
 import org.eclipse.edc.token.spi.TokenValidationService;
 
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -58,11 +65,17 @@ public class Oauth2CredentialsSignalingAuthorization implements SignalingAuthori
     private final Oauth2Client oauth2Client;
     private final TokenValidationService tokenValidationService;
     private final TokenValidationRulesRegistry tokenValidationRulesRegistry;
+    private final KeyParserRegistry keyParserRegistry;
+    private final Monitor monitor;
 
-    public Oauth2CredentialsSignalingAuthorization(Oauth2Client oauth2Client, TokenValidationService tokenValidationService, TokenValidationRulesRegistry tokenValidationRulesRegistry) {
+    public Oauth2CredentialsSignalingAuthorization(Oauth2Client oauth2Client, TokenValidationService tokenValidationService,
+                                                   TokenValidationRulesRegistry tokenValidationRulesRegistry,
+                                                   KeyParserRegistry keyParserRegistry, Monitor monitor) {
         this.oauth2Client = oauth2Client;
         this.tokenValidationService = tokenValidationService;
         this.tokenValidationRulesRegistry = tokenValidationRulesRegistry;
+        this.keyParserRegistry = keyParserRegistry;
+        this.monitor = monitor;
     }
 
     /**
@@ -79,22 +92,33 @@ public class Oauth2CredentialsSignalingAuthorization implements SignalingAuthori
      * <p>Expects a {@code Bearer <jwt>} value. The JWT is parsed and its {@code sub} claim is
      * returned as the caller identity on success.
      *
-     * @param headerGetter a function that retrieves an HTTP header value by name
+     * <p>If the {@code authorizationProfile} contains a {@code jwksUri} property, signature
+     * verification is performed by fetching the JWKS from that URL. If it contains an inline
+     * {@code jwks} property (a {@link Map} representing a JWK Set), the keys are used directly.
+     * When neither is present the signature is not verified, as specified by the
+     * Data Plane Signaling protocol.
+     *
+     * @param headerGetter         a function that retrieves an HTTP header value by name
+     * @param authorizationProfile the authorization profile of the target Data Plane instance
      * @return a successful {@link Result} containing the {@code sub} claim string, or a failed
-     *         result if the header is absent/malformed or the JWT cannot be parsed
+     *         result if the header is absent/malformed or the JWT cannot be validated
      */
     @Override
-    public Result<String> isAuthorized(Function<String, String> headerGetter) {
+    public Result<String> isAuthorized(Function<String, String> headerGetter, AuthorizationProfile authorizationProfile) {
         var authorization = headerGetter.apply("Authorization");
         if (authorization == null || authorization.isBlank() || authorization.length() <= BEARER.length()) {
             return Result.failure("No valid Authorization header present");
         }
 
         var token = authorization.substring(BEARER.length());
-
         var rules = tokenValidationRulesRegistry.getRules(DataPlaneSignalingOauth2Extension.VALIDATION_RULES_CONTEXT);
 
-        var tokenValidation = tokenValidationService.validate(token, i -> Result.success(null), rules);
+        var resolverResult = buildPublicKeyResolver(authorizationProfile.properties());
+        if (resolverResult.failed()) {
+            return resolverResult.mapFailure();
+        }
+
+        var tokenValidation = tokenValidationService.validate(token, resolverResult.getContent(), rules);
         if (tokenValidation.failed()) {
             return tokenValidation.mapFailure();
         }
@@ -132,4 +156,34 @@ public class Oauth2CredentialsSignalingAuthorization implements SignalingAuthori
         return oauth2Client.requestToken(credentialsRequest)
                 .map(token -> new Header("Authorization", "Bearer " + token.getToken()));
     }
+
+    private Result<PublicKeyResolver> buildPublicKeyResolver(Map<String, Object> properties) {
+        var jwksUri = (String) properties.get("jwksUri");
+        if (jwksUri != null) {
+            try {
+                return Result.success(JwksPublicKeyResolver.create(keyParserRegistry, jwksUri, monitor));
+            } catch (Exception e) {
+                return Result.failure("Cannot create PublicKeyResolver for '" + jwksUri + "'. " + e.getMessage());
+            }
+        }
+
+        var jwks = properties.get("jwks");
+        if (jwks != null) {
+            return parseJwks(jwks)
+                    .map(ImmutableJWKSet::new)
+                    .map(jwkSource -> JwksPublicKeyResolver.create(keyParserRegistry, monitor, jwkSource));
+        }
+
+        return Result.success(keyId -> Result.success(null));
+    }
+
+    private Result<JWKSet> parseJwks(Object jwks) {
+        try {
+            var jwkSet = JWKSet.parse((Map<String, Object>) jwks);
+            return Result.success(jwkSet);
+        } catch (Exception e) {
+            return Result.failure("Failed to parse inline jwks: " + e.getMessage());
+        }
+    }
+
 }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-oauth2/src/test/java/org/eclipse/edc/signaling/oauth2/logic/Oauth2CredentialsSignalingAuthorizationTest.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-oauth2/src/test/java/org/eclipse/edc/signaling/oauth2/logic/Oauth2CredentialsSignalingAuthorizationTest.java
@@ -14,20 +14,39 @@
 
 package org.eclipse.edc.signaling.oauth2.logic;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.edc.connector.dataplane.selector.spi.instance.AuthorizationProfile;
 import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
+import org.eclipse.edc.keys.spi.KeyParserRegistry;
+import org.eclipse.edc.security.token.jwt.CryptoConverter;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.token.spi.TokenValidationRule;
 import org.eclipse.edc.token.spi.TokenValidationRulesRegistry;
 import org.eclipse.edc.token.spi.TokenValidationService;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.security.PublicKey;
 import java.util.List;
 import java.util.Map;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -43,8 +62,10 @@ class Oauth2CredentialsSignalingAuthorizationTest {
     private final Oauth2Client oauth2Client = mock();
     private final TokenValidationService tokenValidationService = mock();
     private final TokenValidationRulesRegistry tokenValidationRulesRegistry = mock();
+    private final KeyParserRegistry keyParserRegistry = mock();
+    private final Monitor monitor = mock();
     private final Oauth2CredentialsSignalingAuthorization authorization = new Oauth2CredentialsSignalingAuthorization(
-            oauth2Client, tokenValidationService, tokenValidationRulesRegistry);
+            oauth2Client, tokenValidationService, tokenValidationRulesRegistry, keyParserRegistry, monitor);
 
     @Test
     void getType_shouldReturnOauth2ClientCredentials() {
@@ -54,6 +75,11 @@ class Oauth2CredentialsSignalingAuthorizationTest {
     @Nested
     class IsAuthorized {
 
+        @RegisterExtension
+        static WireMockExtension jwksServer = WireMockExtension.newInstance()
+                .options(wireMockConfig().dynamicPort())
+                .build();
+
         @Test
         void shouldReturnSuccess_whenValidJwtWithSubClaim() {
             var callerId = "test-caller-id";
@@ -62,8 +88,9 @@ class Oauth2CredentialsSignalingAuthorizationTest {
             when(tokenValidationService.validate(anyString(), any(), anyList())).thenReturn(Result.success(claimToken));
             var validationRules = List.of(mock(TokenValidationRule.class));
             when(tokenValidationRulesRegistry.getRules(any())).thenReturn(validationRules);
+            var profile = new AuthorizationProfile("oauth2_client_credentials", Map.of());
 
-            var result = authorization.isAuthorized(header -> "Bearer " + token);
+            var result = authorization.isAuthorized(header -> "Bearer " + token, profile);
 
             assertThat(result.succeeded()).isTrue();
             assertThat(result.getContent()).isEqualTo(callerId);
@@ -75,8 +102,9 @@ class Oauth2CredentialsSignalingAuthorizationTest {
             var token = "token";
             var claimToken = ClaimToken.Builder.newInstance().claim("sub", null).build();
             when(tokenValidationService.validate(anyString(), any(), anyList())).thenReturn(Result.success(claimToken));
+            var profile = new AuthorizationProfile("oauth2_client_credentials", Map.of());
 
-            var result = authorization.isAuthorized(header -> "Bearer " + token);
+            var result = authorization.isAuthorized(header -> "Bearer " + token, profile);
 
             assertThat(result.failed()).isTrue();
         }
@@ -84,8 +112,9 @@ class Oauth2CredentialsSignalingAuthorizationTest {
         @Test
         void shouldReturnFailure_whenTokenValidationFails() {
             when(tokenValidationService.validate(anyString(), any(), anyList())).thenReturn(Result.failure("validation error"));
+            var profile = new AuthorizationProfile("oauth2_client_credentials", Map.of());
 
-            var result = authorization.isAuthorized(header -> "Bearer token");
+            var result = authorization.isAuthorized(header -> "Bearer token", profile);
 
             assertThat(result.failed()).isTrue();
             assertThat(result.getFailureDetail()).contains("validation error");
@@ -93,7 +122,9 @@ class Oauth2CredentialsSignalingAuthorizationTest {
 
         @Test
         void shouldFail_whenAuthorizationHeaderIsNull() {
-            var result = authorization.isAuthorized(header -> null);
+            var profile = new AuthorizationProfile("oauth2_client_credentials", Map.of());
+
+            var result = authorization.isAuthorized(header -> null, profile);
 
             assertThat(result.failed()).isTrue();
             assertThat(result.getFailureMessages()).anyMatch(msg -> msg.contains("Authorization"));
@@ -101,16 +132,96 @@ class Oauth2CredentialsSignalingAuthorizationTest {
 
         @Test
         void shouldFail_whenAuthorizationHeaderIsBlank() {
-            var result = authorization.isAuthorized(header -> "   ");
+            var profile = new AuthorizationProfile("oauth2_client_credentials", Map.of());
+
+            var result = authorization.isAuthorized(header -> "   ", profile);
 
             assertThat(result.failed()).isTrue();
         }
 
         @Test
         void shouldFail_whenAuthorizationHeaderIsTooShort() {
-            var result = authorization.isAuthorized(header -> "Bearer");
+            var profile = new AuthorizationProfile("oauth2_client_credentials", Map.of());
+
+            var result = authorization.isAuthorized(header -> "Bearer", profile);
 
             assertThat(result.failed()).isTrue();
+        }
+
+        @Test
+        void shouldFail_whenJwksUriIsMalformed() {
+            var profile = new AuthorizationProfile("oauth2_client_credentials", Map.of("jwksUri", "not a valid url"));
+
+            var result = authorization.isAuthorized(header -> "Bearer token", profile);
+
+            assertThat(result.failed()).isTrue();
+            assertThat(result.getFailureDetail()).contains("not a valid url");
+        }
+
+        @Test
+        void shouldFail_whenInlineJwksIsInvalid() {
+            var profile = new AuthorizationProfile("oauth2_client_credentials", Map.of("jwks", Map.of("invalid", "structure")));
+
+            var result = authorization.isAuthorized(header -> "Bearer token", profile);
+
+            assertThat(result.failed()).isTrue();
+            assertThat(result.getFailureDetail()).contains("Failed to parse inline jwks");
+        }
+
+        @Test
+        void shouldSkipSignatureVerification_whenNoJwksConfigured() {
+            var callerId = "test-caller-id";
+            var claimToken = ClaimToken.Builder.newInstance().claim("sub", callerId).build();
+            when(tokenValidationService.validate(anyString(), any(), anyList())).thenReturn(Result.success(claimToken));
+            when(tokenValidationRulesRegistry.getRules(any())).thenReturn(List.of());
+            var profile = new AuthorizationProfile("oauth2_client_credentials", Map.of());
+
+            var result = authorization.isAuthorized(header -> "Bearer token", profile);
+
+            assertThat(result.succeeded()).isTrue();
+        }
+
+        @Test
+        void shouldReturnSuccess_whenJwksUriIsConfiguredAndKeyMatches() {
+            var key = generateKey("test-key");
+            var token = createToken(key);
+            var callerId = "caller-from-jwks-uri";
+            var claimToken = ClaimToken.Builder.newInstance().claim("sub", callerId).build();
+
+            var jwksPath = "/.well-known/jwks.json";
+            jwksServer.stubFor(get(urlEqualTo(jwksPath))
+                    .willReturn(okJson(new JWKSet(key.toPublicJWK()).toString())));
+
+            when(keyParserRegistry.parse(any())).thenReturn(Result.success(mock(PublicKey.class)));
+            when(tokenValidationService.validate(eq(token), any(), anyList())).thenReturn(Result.success(claimToken));
+            when(tokenValidationRulesRegistry.getRules(any())).thenReturn(List.of());
+
+            var jwksUri = "http://localhost:%d%s".formatted(jwksServer.getPort(), jwksPath);
+            var profile = new AuthorizationProfile("oauth2_client_credentials", Map.of("jwksUri", jwksUri));
+
+            var result = authorization.isAuthorized(header -> "Bearer " + token, profile);
+
+            assertThat(result.succeeded()).isTrue();
+            assertThat(result.getContent()).isEqualTo(callerId);
+        }
+
+        @Test
+        void shouldReturnSuccess_whenInlineJwksIsConfiguredAndKeyMatches() {
+            var key = generateKey("inline-key");
+            var token = createToken(key);
+            var callerId = "caller-from-inline-jwks";
+            var claimToken = ClaimToken.Builder.newInstance().claim("sub", callerId).build();
+
+            when(keyParserRegistry.parse(any())).thenReturn(Result.success(mock(PublicKey.class)));
+            when(tokenValidationService.validate(eq(token), any(), anyList())).thenReturn(Result.success(claimToken));
+            when(tokenValidationRulesRegistry.getRules(any())).thenReturn(List.of());
+
+            var profile = new AuthorizationProfile("oauth2_client_credentials", Map.of("jwks", jwksMap(key.toPublicJWK())));
+
+            var result = authorization.isAuthorized(header -> "Bearer " + token, profile);
+
+            assertThat(result.succeeded()).isTrue();
+            assertThat(result.getContent()).isEqualTo(callerId);
         }
 
     }
@@ -169,6 +280,32 @@ class Oauth2CredentialsSignalingAuthorizationTest {
 
             verify(oauth2Client).requestToken(any());
         }
+    }
+
+    private JWK generateKey(String keyId) {
+        try {
+            return new OctetKeyPairGenerator(Curve.Ed25519).keyID(keyId).keyUse(KeyUse.SIGNATURE).generate();
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String createToken(JWK key) {
+        try {
+            var signer = CryptoConverter.createSigner(key);
+            var algorithm = CryptoConverter.getRecommendedAlgorithm(signer);
+            var header = new JWSHeader.Builder(algorithm).keyID(key.getKeyID()).build();
+            var claims = new JWTClaimsSet.Builder().subject("test-subject").build();
+            var jwt = new SignedJWT(header, claims);
+            jwt.sign(signer);
+            return jwt.serialize();
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Map<String, Object> jwksMap(JWK... keys) {
+        return Map.of("keys", java.util.Arrays.stream(keys).map(JWK::toJSONObject).toList());
     }
 
 }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-spi/src/main/java/org/eclipse/edc/signaling/spi/authorization/SignalingAuthorization.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-spi/src/main/java/org/eclipse/edc/signaling/spi/authorization/SignalingAuthorization.java
@@ -34,10 +34,11 @@ public interface SignalingAuthorization {
     /**
      * Verifies that an incoming request is authorized by inspecting its headers.
      *
-     * @param headerGetter a function that retrieves a header value by name
+     * @param headerGetter         a function that retrieves a header value by name
+     * @param authorizationProfile the authorization profile assigned to the target Data Plane instance
      * @return a successful {@link Result} containing a token or principal on success, or a failed result with an error message
      */
-    Result<String> isAuthorized(Function<String, String> headerGetter);
+    Result<String> isAuthorized(Function<String, String> headerGetter, AuthorizationProfile authorizationProfile);
 
     /**
      * Produces the outgoing authorization header value for a given {@link AuthorizationProfile}.

--- a/extensions/common/auth/auth-delegated/build.gradle.kts
+++ b/extensions/common/auth/auth-delegated/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     api(project(":spi:common:auth-spi"))
     api(project(":spi:common:token-spi"))
     implementation(project(":core:common:lib:crypto-common-lib"))
+    implementation(project(":core:common:lib:keys-lib"))
     implementation(project(":core:common:lib:token-lib"))
 
     implementation(libs.jakarta.rsApi)

--- a/extensions/common/auth/auth-delegated/src/main/java/org/eclipse/edc/api/auth/delegated/DelegatedAuthenticationExtension.java
+++ b/extensions/common/auth/auth-delegated/src/main/java/org/eclipse/edc/api/auth/delegated/DelegatedAuthenticationExtension.java
@@ -18,6 +18,7 @@ package org.eclipse.edc.api.auth.delegated;
 import org.eclipse.edc.api.auth.spi.ApiAuthenticationProvider;
 import org.eclipse.edc.api.auth.spi.AuthenticationService;
 import org.eclipse.edc.api.auth.spi.registry.ApiAuthenticationProviderRegistry;
+import org.eclipse.edc.keys.resolver.JwksPublicKeyResolver;
 import org.eclipse.edc.keys.spi.KeyParserRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;

--- a/extensions/common/auth/auth-delegated/src/test/java/org/eclipse/edc/api/auth/delegated/TestFunctions.java
+++ b/extensions/common/auth/auth-delegated/src/test/java/org/eclipse/edc/api/auth/delegated/TestFunctions.java
@@ -26,12 +26,8 @@ import org.eclipse.edc.security.token.jwt.CryptoConverter;
 
 public class TestFunctions {
     public static JWK generateKey() {
-        return generateKey("test-key");
-    }
-
-    public static JWK generateKey(String keyId) {
         try {
-            return new OctetKeyPairGenerator(Curve.Ed25519).keyID(keyId).keyUse(KeyUse.SIGNATURE).generate();
+            return new OctetKeyPairGenerator(Curve.Ed25519).keyID("test-key").keyUse(KeyUse.SIGNATURE).generate();
         } catch (JOSEException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## What this PR changes/adds

Add JWKS validation for Oauth2 authorization profile in DPS.
It makes use of the `JwksPublicKeyResolver` that was in `auth-delegated`, now moved in `keys-lib` so can be used by both modules.

## Why it does that

Validate JWKS

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5655

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
