### PR TITLE
fix: add @context to QuerySpec, Criterion, IdResponse OpenAPI schemas

### DIFF
--- a/core/common/lib/api-lib/src/main/java/org/eclipse/edc/api/model/ApiCoreSchema.java
+++ b/core/common/lib/api-lib/src/main/java/org/eclipse/edc/api/model/ApiCoreSchema.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 import java.util.List;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.query.Criterion.CRITERION_TYPE;
@@ -30,6 +31,8 @@ public interface ApiCoreSchema {
 
     @Schema(name = "Criterion", example = CriterionSchema.CRITERION_EXAMPLE)
     record CriterionSchema(
+            @Schema(name = CONTEXT)
+            Object context,
             @Schema(name = TYPE, example = CRITERION_TYPE)
             String type,
             @Schema(requiredMode = REQUIRED)
@@ -52,6 +55,8 @@ public interface ApiCoreSchema {
 
     @Schema(name = "QuerySpec", example = QuerySpecSchema.QUERY_SPEC_EXAMPLE)
     record QuerySpecSchema(
+            @Schema(name = CONTEXT)
+            Object context,
             @Schema(name = TYPE, example = EDC_QUERY_SPEC_TYPE)
             String type,
             int offset,
@@ -75,6 +80,8 @@ public interface ApiCoreSchema {
 
     @Schema(name = "IdResponse", example = IdResponseSchema.ID_RESPONSE_EXAMPLE)
     record IdResponseSchema(
+            @Schema(name = CONTEXT)
+            Object context,
             @Schema(name = ID)
             String id,
             long createdAt

--- a/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
+++ b/extensions/common/api/control-api-configuration/src/main/resources/control-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "2.1.4",
     "urlPath": "/v1",
-    "lastUpdated": "2026-04-09T12:00:01Z",
+    "lastUpdated": "2026-04-25T09:00:00Z",
     "maturity": "stable"
   }
 ]

--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -14,7 +14,7 @@
   {
     "version": "5.0.0-beta",
     "urlPath": "/v5beta",
-    "lastUpdated": "2026-04-24T09:00:00Z",
+    "lastUpdated": "2026-04-25T09:00:00Z",
     "maturity": "beta"
   }
 ]


### PR DESCRIPTION
Closes #5690.

## Why

`QuerySpecSchema` in `core/common/lib/api-lib/src/main/java/org/eclipse/edc/api/model/ApiCoreSchema.java` declares the fields used by springdoc to generate the OpenAPI definition for `QuerySpec`. The example string for that record includes `@context`, but the record fields themselves don't — so OpenAPI generators don't emit `@context` as a property and clients leave it out of the request body.

The reporter's symptom is consistent with that: posting a body without `@context` falls through the JSON-LD context expansion in the management API and the `limit` / `offset` never reach the database layer. The endpoint then returns the configured default of 50 rows regardless of what the caller asked for. Adding `"@context": {}` to the body fixes the response, which confirms the diagnosis the issue points at.

## Change

Adds an `Object context` field to the `QuerySpecSchema` record annotated with `@Schema(name = CONTEXT)`, where `CONTEXT` is the existing `JsonLdKeywords.CONTEXT` constant (`"@context"`). This mirrors the existing pattern for `TYPE` on the same record.

I left it non-required (no `requiredMode = REQUIRED`) — the issue's proposed YAML diff lists it under `properties` only, not under `required`, so generators describe it as a property without forcing every existing client to send it.

`CriterionSchema` has the same example-vs-properties asymmetry but the issue scopes the fix to `QuerySpec`, so this PR does too. Happy to add the same field to `CriterionSchema` in a follow-up if maintainers want them aligned.

## Verification

The generated OpenAPI YAML is built from this Java source via springdoc, so I cannot regenerate it without the full build toolchain locally. The change is structurally identical to the `@Schema(name = TYPE) String type` field directly above it, which produces the `@type` property in the published OpenAPI.