### PR TITLE
fix: remove address validation from AssetService, fix metadata deserialization

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -181,7 +181,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
         var assetObservable = new AssetObservableImpl();
         assetObservable.registerListener(new AssetEventListener(eventRouter));
         return new AssetServiceImpl(assetIndex, contractNegotiationStore, transactionContext, assetObservable,
-                dataAddressValidator, new AssetQueryValidator());
+                new AssetQueryValidator());
     }
 
     @Provider

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/asset/AssetServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/asset/AssetServiceImpl.java
@@ -26,7 +26,6 @@ import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transaction.spi.TransactionContext;
-import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -41,17 +40,15 @@ public class AssetServiceImpl implements AssetService {
     private final ContractNegotiationStore contractNegotiationStore;
     private final TransactionContext transactionContext;
     private final AssetObservable observable;
-    private final DataAddressValidatorRegistry dataAddressValidator;
     private final QueryValidator queryValidator;
 
     public AssetServiceImpl(AssetIndex index, ContractNegotiationStore contractNegotiationStore,
                             TransactionContext transactionContext, AssetObservable observable,
-                            DataAddressValidatorRegistry dataAddressValidator, QueryValidator queryValidator) {
+                            QueryValidator queryValidator) {
         this.index = index;
         this.contractNegotiationStore = contractNegotiationStore;
         this.transactionContext = transactionContext;
         this.observable = observable;
-        this.dataAddressValidator = dataAddressValidator;
         this.queryValidator = queryValidator;
     }
 
@@ -73,13 +70,6 @@ public class AssetServiceImpl implements AssetService {
     public ServiceResult<Asset> create(Asset asset) {
         if (asset.hasDuplicatePropertyKeys()) {
             return ServiceResult.badRequest(DUPLICATED_KEYS_MESSAGE);
-        }
-
-        if (asset.getDataAddress() != null) {
-            var validDataAddress = dataAddressValidator.validateSource(asset.getDataAddress());
-            if (validDataAddress.failed()) {
-                return ServiceResult.badRequest(validDataAddress.getFailureMessages());
-            }
         }
 
         return transactionContext.execute(() -> {
@@ -116,11 +106,6 @@ public class AssetServiceImpl implements AssetService {
     public ServiceResult<Asset> update(Asset asset) {
         if (asset.hasDuplicatePropertyKeys()) {
             return ServiceResult.badRequest(DUPLICATED_KEYS_MESSAGE);
-        }
-
-        var validDataAddress = dataAddressValidator.validateSource(asset.getDataAddress());
-        if (validDataAddress.failed()) {
-            return ServiceResult.badRequest(validDataAddress.getFailureMessages());
         }
 
         return transactionContext.execute(() -> {

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/asset/AssetServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/asset/AssetServiceImplTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.controlplane.services.asset;
 
-import org.assertj.core.api.Assertions;
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
 import org.eclipse.edc.connector.controlplane.asset.spi.index.AssetIndex;
 import org.eclipse.edc.connector.controlplane.asset.spi.observe.AssetObservable;
@@ -28,13 +27,10 @@ import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceFailure;
-import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
-import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
-import org.eclipse.edc.validator.spi.ValidationResult;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -53,7 +49,6 @@ import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.BAD_REQUEST;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.CONFLICT;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
-import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -73,11 +68,10 @@ class AssetServiceImplTest {
     private final ContractNegotiationStore contractNegotiationStore = mock();
     private final TransactionContext dummyTransactionContext = new NoopTransactionContext();
     private final AssetObservable observable = mock();
-    private final DataAddressValidatorRegistry dataAddressValidator = mock();
     private final QueryValidator queryValidator = mock();
 
     private final AssetService service = new AssetServiceImpl(index, contractNegotiationStore, dummyTransactionContext,
-            observable, dataAddressValidator, queryValidator);
+            observable, queryValidator);
 
     @Test
     void findById_shouldRelyOnAssetIndex() {
@@ -115,7 +109,6 @@ class AssetServiceImplTest {
     class CreateAsset {
         @Test
         void shouldCreateAssetIfItDoesNotAlreadyExist() {
-            when(dataAddressValidator.validateSource(any())).thenReturn(ValidationResult.success());
             var assetId = "assetId";
             var asset = createAsset(assetId);
             when(index.create(asset)).thenReturn(StoreResult.success());
@@ -131,7 +124,6 @@ class AssetServiceImplTest {
 
         @Test
         void shouldCreateAsset_whenDataAddressIsNull() {
-            when(dataAddressValidator.validateSource(any())).thenReturn(ValidationResult.success());
             var assetId = "assetId";
             var asset = createAssetBuilder(assetId).dataAddress(null).build();
             when(index.create(asset)).thenReturn(StoreResult.success());
@@ -141,13 +133,11 @@ class AssetServiceImplTest {
             assertThat(inserted).isSucceeded().matches(hasId(assetId));
             verify(index).create(and(isA(Asset.class), argThat(it -> assetId.equals(it.getId()))));
             verifyNoMoreInteractions(index);
-            verifyNoInteractions(dataAddressValidator);
             verify(observable).invokeForEach(any());
         }
 
         @Test
         void shouldNotCreateAssetIfItAlreadyExists() {
-            when(dataAddressValidator.validateSource(any())).thenReturn(ValidationResult.success());
             var asset = createAsset("assetId");
             when(index.create(asset)).thenReturn(StoreResult.alreadyExists("test"));
 
@@ -157,20 +147,8 @@ class AssetServiceImplTest {
         }
 
         @Test
-        void shouldNotCreateAssetIfDataAddressInvalid() {
-            var asset = createAsset("assetId");
-            when(dataAddressValidator.validateSource(any())).thenReturn(ValidationResult.failure(violation("Data address is invalid", "path")));
-
-            var result = service.create(asset);
-
-            Assertions.assertThat(result).satisfies(ServiceResult::failed).extracting(ServiceResult::reason).isEqualTo(BAD_REQUEST);
-            verifyNoInteractions(index);
-        }
-
-        @Test
         void shouldFail_whenPropertiesAreDuplicated() {
             var asset = createAssetBuilder("assetId").property("property", "value").privateProperty("property", "other-value").build();
-            when(dataAddressValidator.validateSource(any())).thenReturn(ValidationResult.success());
 
             var result = service.create(asset);
 
@@ -271,7 +249,6 @@ class AssetServiceImplTest {
     @Test
     void updateAsset_shouldUpdateWhenExists() {
         var asset = createAsset("assetId");
-        when(dataAddressValidator.validateSource(any())).thenReturn(ValidationResult.success());
         when(index.updateAsset(asset)).thenReturn(StoreResult.success(asset));
 
         var updated = service.update(asset);
@@ -285,7 +262,6 @@ class AssetServiceImplTest {
     @Test
     void updateAsset_shouldReturnNotFound_whenNotExists() {
         var asset = createAsset("assetId");
-        when(dataAddressValidator.validateSource(any())).thenReturn(ValidationResult.success());
         when(index.updateAsset(eq(asset))).thenReturn(StoreResult.notFound("test"));
 
         var updated = service.update(asset);

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToDataplaneMetadataTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToDataplaneMetadataTransformer.java
@@ -14,12 +14,21 @@
 
 package org.eclipse.edc.connector.controlplane.transform.edc.to;
 
+import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata;
 import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.JSON;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
 public class JsonObjectToDataplaneMetadataTransformer extends AbstractJsonLdTransformer<JsonObject, DataplaneMetadata> {
 
@@ -33,21 +42,40 @@ public class JsonObjectToDataplaneMetadataTransformer extends AbstractJsonLdTran
 
         var labels = jsonObject.getJsonArray(DataplaneMetadata.EDC_DATAPLANE_METADATA_LABELS);
         if (labels != null) {
-            transformArray(labels, Object.class, context).forEach(label -> builder.label(label.toString()));
+            labels.stream()
+                    .map(this::nodeJsonValue)
+                    .map(value -> deserializeLabel(value, context))
+                    .filter(Objects::nonNull)
+                    .forEach(builder::label);
         }
 
         var properties = jsonObject.get(DataplaneMetadata.EDC_DATAPLANE_METADATA_PROPERTIES);
-        if (properties != null) {
-            var jsonValue = nodeJsonValue(properties);
-            if (jsonValue instanceof JsonObject json) {
-                visitProperties(json, (key, value) -> builder.property(key, transformGenericProperty(value, context)));
+        if (properties instanceof JsonArray propertiesArray && !propertiesArray.isEmpty()) {
+
+            var propertiesEntry = propertiesArray.get(0);
+            if (propertiesEntry instanceof JsonObject object) {
+                var map = Optional.ofNullable(object.getJsonString(TYPE))
+                        .map(JsonString::getString)
+                        .filter(it -> it.equals(JSON))
+                        .map(i -> nodeJsonValue(propertiesEntry).asJsonObject())
+                        .orElse(object);
+
+                visitProperties(map, (key, value) -> builder.property(key, transformGenericProperty(value, context)));
             } else {
                 context.reportProblem("Expected properties to be a JsonObject");
                 return null;
-
             }
         }
 
         return builder.build();
+    }
+
+    private @Nullable String deserializeLabel(JsonValue value, @NotNull TransformerContext context) {
+        if (value instanceof JsonString string) {
+            return string.getString();
+        }
+
+        context.reportProblem("DataplaneMetadata labels should be strings, but label '%s' is a '%s'".formatted(value, value.getValueType()));
+        return null;
     }
 }

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/TestInput.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/TestInput.java
@@ -14,10 +14,10 @@
 
 package org.eclipse.edc.connector.controlplane.transform;
 
-import com.apicatalog.jsonld.document.JsonDocument;
 import jakarta.json.JsonObject;
-
-import static com.apicatalog.jsonld.JsonLd.expand;
+import org.eclipse.edc.jsonld.CachedDocumentRegistry;
+import org.eclipse.edc.jsonld.TitaniumJsonLd;
+import org.eclipse.edc.spi.monitor.ConsoleMonitor;
 
 /**
  * Functions for shaping test input.
@@ -28,11 +28,11 @@ public class TestInput {
      * Expands test input as Json-ld is required to be in this form
      */
     public static JsonObject getExpanded(JsonObject message) {
-        try {
-            return expand(JsonDocument.of(message)).get().asJsonArray().getJsonObject(0);
-        } catch (Exception e) {
-            throw new AssertionError(e);
-        }
+        var jsonLd = new TitaniumJsonLd(new ConsoleMonitor());
+        CachedDocumentRegistry.getDocuments().forEach(result -> result
+                .onSuccess(c -> jsonLd.registerCachedDocument(c.url(), c.resource()))
+        );
+        return jsonLd.expand(message).orElseThrow(f -> new AssertionError(f.getFailureDetail()));
     }
 
     private TestInput() {

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformerTest.java
@@ -43,7 +43,6 @@ import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.PROP
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.PROPERTY_ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
-import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.JSON;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
@@ -90,8 +89,7 @@ class JsonObjectToAssetTransformerTest {
                         .add("labels", jsonFactory.createArrayBuilder().add("label"))
                         .add("properties",
                                 jsonFactory.createObjectBuilder()
-                                        .add(TYPE, JSON)
-                                        .add(VALUE, jsonFactory.createObjectBuilder().add("property", "value")))
+                                        .add("property", "value"))
                 )
                 .build();
 
@@ -105,7 +103,7 @@ class JsonObjectToAssetTransformerTest {
                     .containsEntry(PROPERTY_DESCRIPTION, TEST_ASSET_DESCRIPTION);
             assertThat(asset.getDataAddress()).isNotNull().extracting(DataAddress::getType).isEqualTo("address-type");
             assertThat(asset.getDataplaneMetadata().getLabels()).containsExactly("label");
-            assertThat(asset.getDataplaneMetadata().getProperties()).containsExactly(entry("property", "value"));
+            assertThat(asset.getDataplaneMetadata().getProperties()).containsExactly(entry(EDC_NAMESPACE + "property", "value"));
         });
 
     }

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToDataplaneMetadataTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToDataplaneMetadataTransformerTest.java
@@ -16,6 +16,8 @@ package org.eclipse.edc.connector.controlplane.transform.edc.to;
 
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -23,21 +25,29 @@ import org.eclipse.edc.transform.TypeTransformerRegistryImpl;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.transform.transformer.edc.to.JsonValueToGenericTypeTransformer;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata.EDC_DATAPLANE_METADATA_LABELS;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata.EDC_DATAPLANE_METADATA_PROPERTIES;
-import static org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata.EDC_DATAPLANE_METADATA_TYPE;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata.EDC_DATAPLANE_METADATA_SIMPLE_TYPE;
+import static org.eclipse.edc.connector.controlplane.transform.TestInput.getExpanded;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_PREFIX;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -57,39 +67,76 @@ class JsonObjectToDataplaneMetadataTransformerTest {
         when(typeManager.getMapper("test")).thenReturn(JacksonJsonLd.createObjectMapper());
     }
 
-    @Test
-    void shouldTransformToDataplaneMetadata() {
+    @ParameterizedTest
+    @ArgumentsSource(Contexts.class)
+    void shouldTransformToDataplaneMetadata(JsonValue context) {
         var jsonObj = jsonFactory.createObjectBuilder()
-                .add(CONTEXT, jsonFactory.createObjectBuilder().add(VOCAB, EDC_NAMESPACE).add(EDC_PREFIX, EDC_NAMESPACE).build())
-                .add(TYPE, EDC_DATAPLANE_METADATA_TYPE)
-                .add(EDC_DATAPLANE_METADATA_LABELS, jsonFactory.createArrayBuilder().add("label"))
-                .add(EDC_DATAPLANE_METADATA_PROPERTIES, jsonFactory.createObjectBuilder()
-                        .add(VALUE, jsonFactory.createObjectBuilder().add("property", "value")))
+                .add(CONTEXT, context)
+                .add(TYPE, EDC_DATAPLANE_METADATA_SIMPLE_TYPE)
+                .add("labels", jsonFactory.createArrayBuilder().add("label").add("label2"))
+                .add("properties", jsonFactory.createObjectBuilder()
+                        .add("property", "value")
+                )
                 .build();
 
-        var result = typeTransformerRegistry.transform(jsonObj, DataplaneMetadata.class);
+        var result = typeTransformerRegistry.transform(getExpanded(jsonObj), DataplaneMetadata.class);
 
         assertThat(result).isSucceeded().satisfies(metadata -> {
-            assertThat(metadata.getLabels()).containsExactly("label");
-            assertThat(metadata.getProperties()).hasEntrySatisfying("property", v -> {
-                // the generic transformer wraps primitive values in their Java types -> expect String
+            assertThat(metadata.getLabels()).containsExactly("label", "label2");
+            assertThat(metadata.getProperties()).hasSize(1).hasEntrySatisfying(prefix(context) + "property", v -> {
                 assertThat(v).isEqualTo("value");
             });
         });
     }
 
-    @Test
-    void transform_withInvalidProperties_shouldReportProblemAndReturnNull() {
+    @ParameterizedTest
+    @ArgumentsSource(Contexts.class)
+    void shouldNotFail_whenPropertiesIsEmpty(JsonValue context) {
         var jsonObj = jsonFactory.createObjectBuilder()
-                .add(CONTEXT, jsonFactory.createObjectBuilder().add(VOCAB, EDC_NAMESPACE).add(EDC_PREFIX, EDC_NAMESPACE).build())
-                .add(TYPE, EDC_DATAPLANE_METADATA_TYPE)
-                // properties value is a plain string (invalid), not an object
-                .add(EDC_DATAPLANE_METADATA_PROPERTIES, jsonFactory.createObjectBuilder().add(VALUE, "invalid-string"))
+                .add(CONTEXT, context)
+                .add(TYPE, EDC_DATAPLANE_METADATA_SIMPLE_TYPE)
+                .add(EDC_DATAPLANE_METADATA_PROPERTIES, jsonFactory.createArrayBuilder())
                 .build();
 
-        var result = typeTransformerRegistry.transform(jsonObj, DataplaneMetadata.class);
+        var result = typeTransformerRegistry.transform(getExpanded(jsonObj), DataplaneMetadata.class);
 
-        assertThat(result).isFailed().detail().contains("Expected properties to be a JsonObject");
+        assertThat(result).isSucceeded().satisfies(metadata -> {
+            assertThat(metadata.getProperties()).isEmpty();
+        });
     }
+
+    @ParameterizedTest
+    @ArgumentsSource(Contexts.class)
+    void shouldFail_whenLabelIsNotString(JsonValue context) {
+        var jsonObj = jsonFactory.createObjectBuilder()
+                .add(CONTEXT, context)
+                .add(TYPE, EDC_DATAPLANE_METADATA_SIMPLE_TYPE)
+                .add(EDC_DATAPLANE_METADATA_LABELS, jsonFactory.createArrayBuilder().add(1))
+                .build();
+
+        var result = typeTransformerRegistry.transform(getExpanded(jsonObj), DataplaneMetadata.class);
+
+        assertThat(result).isFailed();
+    }
+
+    private static String prefix(JsonValue context) {
+        if (context instanceof JsonObject jsonObject && jsonObject.containsKey(VOCAB)) {
+            return jsonObject.getJsonString(VOCAB).getString();
+        }
+        return "";
+    }
+
+    private static class Contexts implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
+            var jsonFactory = Json.createBuilderFactory(Map.of());
+            return Stream.of(
+                    arguments(jsonFactory.createObjectBuilder().add(VOCAB, EDC_NAMESPACE).add(EDC_PREFIX, EDC_NAMESPACE).build()),
+                    arguments(Json.createValue(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+            );
+        }
+    }
+
 }
 

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/dataplane-metadata-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/dataplane-metadata-schema.json
@@ -26,7 +26,8 @@
           "type": "object",
           "example": { "key": "value" }
         }
-      }
+      },
+      "required": ["@type"]
     }
   }
 }

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/model/AssetDto.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/model/AssetDto.java
@@ -29,6 +29,7 @@ public class AssetDto extends Typed {
     private final String id;
     private final Map<String, Object> properties;
     private final Map<String, Object> privateProperties;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private final Map<String, Object> dataplaneMetadata;
 
     public AssetDto(String id,
@@ -41,12 +42,16 @@ public class AssetDto extends Typed {
         this.dataplaneMetadata = dataplaneMetadata;
     }
 
-    public AssetDto(Map<String, Object> properties, Map<String, Object> dataplaneMetadata) {
-        this(null, properties, Map.of(), dataplaneMetadata);
+    public AssetDto() {
+        this(null, Map.of(), Map.of(), null);
     }
 
     public AssetDto(Map<String, Object> dataplaneMetadata) {
         this(null, Map.of(), Map.of(), dataplaneMetadata);
+    }
+
+    public AssetDto(Map<String, Object> properties, Map<String, Object> dataplaneMetadata) {
+        this(null, properties, Map.of(), dataplaneMetadata);
     }
 
     public String getId() {

--- a/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/assetindex/SqlAssetIndex.java
+++ b/extensions/control-plane/store/sql/asset-index-sql/src/main/java/org/eclipse/edc/connector/controlplane/store/sql/assetindex/SqlAssetIndex.java
@@ -154,7 +154,7 @@ public class SqlAssetIndex extends AbstractSqlStore implements AssetIndex {
                     queryExecutor.execute(connection, assetStatements.getUpdateAssetTemplate(),
                             toJson(asset.getProperties()),
                             toJson(asset.getPrivateProperties()),
-                            toJson(asset.getDataAddress().getProperties()),
+                            toJson(Optional.ofNullable(asset.getDataAddress()).map(DataAddress::getProperties).orElse(null)),
                             toJson(asset.getDataplaneMetadata()),
                             assetId
                     );

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/transformer/AbstractJsonLdTransformer.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/transformer/AbstractJsonLdTransformer.java
@@ -495,8 +495,8 @@ public abstract class AbstractJsonLdTransformer<INPUT, OUTPUT> implements JsonLd
      * Returns the @value of the JSON object of type @json.
      */
     protected JsonValue nodeJsonValue(JsonValue object) {
-        if (object instanceof JsonArray) {
-            return nodeJsonValue(object.asJsonArray().get(0));
+        if (object instanceof JsonArray jsonArray) {
+            return nodeJsonValue(jsonArray.get(0));
         } else {
             return object.asJsonObject().get(JsonLdKeywords.VALUE);
         }

--- a/spi/common/validator-spi/src/main/java/org/eclipse/edc/validator/spi/DataAddressValidatorRegistry.java
+++ b/spi/common/validator-spi/src/main/java/org/eclipse/edc/validator/spi/DataAddressValidatorRegistry.java
@@ -18,7 +18,10 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 
 /**
  * Registry service for DataAddress validation
+ *
+ * @deprecated DataAddress will be managed by the data-plane, no need to validate it in the control-plane
  */
+@Deprecated(since = "0.18.0")
 public interface DataAddressValidatorRegistry {
 
     /**

--- a/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/DataplaneMetadata.java
+++ b/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/DataplaneMetadata.java
@@ -28,7 +28,8 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 @JsonDeserialize(builder = DataplaneMetadata.Builder.class)
 public class DataplaneMetadata {
 
-    public static final String EDC_DATAPLANE_METADATA_TYPE = EDC_NAMESPACE + "DataplaneMetadata";
+    public static final String EDC_DATAPLANE_METADATA_SIMPLE_TYPE = "DataplaneMetadata";
+    public static final String EDC_DATAPLANE_METADATA_TYPE = EDC_NAMESPACE + EDC_DATAPLANE_METADATA_SIMPLE_TYPE;
     public static final String EDC_DATAPLANE_METADATA_LABELS = EDC_NAMESPACE + "labels";
     public static final String EDC_DATAPLANE_METADATA_PROPERTIES = EDC_NAMESPACE + "properties";
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualDcpTransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualDcpTransferPullEndToEndTest.java
@@ -168,7 +168,7 @@ class VirtualDcpTransferPullEndToEndTest {
         }
 
         private String setup(ManagementApiClientV5 connectorClient, Participants.Participant provider, PolicyDto policy) {
-            var asset = new AssetDto(Map.of());
+            var asset = new AssetDto();
             var policyDef = new PolicyDefinitionDto(policy);
 
             return connectorClient.setupResources(provider.contextId(), asset, policyDef, policyDef);

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualTransferEndToEndTestBase.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualTransferEndToEndTestBase.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static jakarta.json.Json.createArrayBuilder;
@@ -255,7 +254,7 @@ public abstract class VirtualTransferEndToEndTestBase {
     }
 
     private String setup(ManagementApiClientV5 connectorClient, Participants.Participant provider) {
-        var asset = new AssetDto(Map.of());
+        var asset = new AssetDto();
 
         var permissions = List.of(new PermissionDto());
         var policyDef = new PolicyDefinitionDto(new PolicyDto(permissions));

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
@@ -40,11 +40,10 @@ import java.util.UUID;
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
+import static org.assertj.core.api.InstanceOfAssertFactories.map;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
-import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.query.Criterion.criterion;
@@ -108,15 +107,14 @@ public class AssetApiV4EndToEndTest {
                     .add("privateProperties", createObjectBuilder()
                             .add("anotherProp", "anotherVal")
                             .build())
-                    .add("dataAddress", createObjectBuilder()
-                            .add(TYPE, "DataAddress")
-                            .add("type", "test-type")
-                            .add("complex", createObjectBuilder()
-                                    .add("simple", "value")
-                                    .add("nested", createObjectBuilder()
-                                            .add("innerValue", "value"))
-                                    .build())
-                            .build())
+                    .add("dataplaneMetadata", createObjectBuilder()
+                            .add(TYPE, "DataplaneMetadata")
+                            .add("properties", createObjectBuilder()
+                                    .add("key", "value")
+                                    .add("another-key", "another-value")
+                            )
+                            .add("labels", createArrayBuilder().add("label1").add("label2"))
+                    )
                     .build();
 
             context.baseRequest()
@@ -132,11 +130,9 @@ public class AssetApiV4EndToEndTest {
             assertThat(asset).isNotNull();
             assertThat(asset.isCatalog()).isTrue();
             assertThat(asset.getPrivateProperty(EDC_NAMESPACE + "anotherProp")).isEqualTo("anotherVal");
-            assertThat(asset.getDataAddress().getProperty("complex"))
-                    .asInstanceOf(MAP)
-                    .containsEntry(EDC_NAMESPACE + "simple", List.of(Map.of(VALUE, "value")))
-                    .containsEntry(EDC_NAMESPACE + "nested", List.of(Map.of(EDC_NAMESPACE + "innerValue", List.of(Map.of(VALUE, "value")))));
-
+            assertThat(asset.getDataplaneMetadata().getProperties()).containsExactlyInAnyOrderEntriesOf(
+                    Map.of("key", "value", "another-key", "another-value"));
+            assertThat(asset.getDataplaneMetadata().getLabels()).containsExactly("label1", "label2");
             assertThat(asset.getParticipantContextId()).isNotNull();
         }
 
@@ -364,10 +360,13 @@ public class AssetApiV4EndToEndTest {
                     .add(ID, asset.getId())
                     .add("properties", createPropertiesBuilder()
                             .add("some-new-property", "some-new-value").build())
-                    .add("dataAddress", createObjectBuilder()
-                            .add(TYPE, "DataAddress")
-                            .add("type", "addressType")
-                            .add("complex", createObjectBuilder().add("nested", "value").build()))
+                    .add("dataplaneMetadata", createObjectBuilder()
+                            .add(TYPE, "DataplaneMetadata")
+                            .add("labels", createArrayBuilder().add("updated-label"))
+                            .add("properties", createObjectBuilder()
+                               .add("complex", createObjectBuilder()
+                                       .add("nested", "value").build()))
+                    )
                     .build();
 
             context.baseRequest()
@@ -382,10 +381,13 @@ public class AssetApiV4EndToEndTest {
             var dbAsset = assetIndex.findById(asset.getId());
             assertThat(dbAsset).isNotNull();
             assertThat(dbAsset.getProperties()).containsEntry(EDC_NAMESPACE + "some-new-property", "some-new-value");
-            assertThat(dbAsset.getDataAddress().getType()).isEqualTo("addressType");
-            assertThat(dbAsset.getDataAddress().getProperty(EDC_NAMESPACE + "complex"))
-                    .asInstanceOf(MAP)
-                    .containsEntry(EDC_NAMESPACE + "nested", List.of(Map.of(VALUE, "value")));
+            assertThat(dbAsset.getDataplaneMetadata().getLabels()).containsExactly("updated-label");
+            assertThat(dbAsset.getDataplaneMetadata().getProperties())
+                    .containsKey("complex").extracting(m -> m.get("complex"))
+                    .satisfies(complex -> {
+                        assertThat(complex).asInstanceOf(map(String.class, Object.class))
+                                .containsEntry("nested", "value");
+                    });
 
             assertThat(dbAsset.getParticipantContextId()).isNotNull();
         }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TransferProcessApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/TransferProcessApiV4EndToEndTest.java
@@ -158,6 +158,7 @@ public class TransferProcessApiV4EndToEndTest {
                     .add("contractId", contractId)
                     .add("assetId", assetId)
                     .add("dataplaneMetadata", createObjectBuilder()
+                            .add(TYPE, "DataplaneMetadata")
                             .add("labels", createArrayBuilder().add("label"))
                             .add("properties", createObjectBuilder().add("key", "value"))
                     )

--- a/system-tests/protocol-2025-test/src/test/java/org/eclipse/edc/test/e2e/protocol/v2025/DspCatalogApi2025EndToEndTest.java
+++ b/system-tests/protocol-2025-test/src/test/java/org/eclipse/edc/test/e2e/protocol/v2025/DspCatalogApi2025EndToEndTest.java
@@ -26,7 +26,6 @@ import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.eclipse.edc.policy.model.Policy;
-import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.util.io.Ports;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -89,7 +88,7 @@ public class DspCatalogApi2025EndToEndTest {
         var assetIndex = runtime.getService(AssetIndex.class);
 
         range(0, 8)
-                .mapToObj(i -> Asset.Builder.newInstance().id(i + "").dataAddress(DataAddress.Builder.newInstance().type("any").build()).participantContextId("anonymous").build())
+                .mapToObj(i -> Asset.Builder.newInstance().id(i + "").participantContextId("anonymous").build())
                 .forEach(assetIndex::create);
         var policyDefinitionStore = runtime.getService(PolicyDefinitionStore.class);
         policyDefinitionStore.create(PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).participantContextId("anonymous").build())


### PR DESCRIPTION
## What this PR changes/adds

Remove `DataAddress` validation from `AssetService`, as asset should not be mandatory anymore.
Fixed also DataplaneMetadata deserialization

## Why it does that

fix bug

## Further notes
- I noticed that the `Asset.dataAddress` is still used for the `Catalog` creation, especially when the `Asset` is meant to point to another `Catalog`. that needs to be solved differently (a separate issue will be opened)


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5708

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
