### PR TITLE
feat: reduce crawler logs on ConnectException

### DIFF
--- a/core/common/lib/http-lib/src/test/java/org/eclipse/edc/http/client/EdcHttpClientImplTest.java
+++ b/core/common/lib/http-lib/src/test/java/org/eclipse/edc/http/client/EdcHttpClientImplTest.java
@@ -25,10 +25,12 @@ import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -209,83 +211,89 @@ class EdcHttpClientImplTest {
                 .matches(it -> !it.contains("AuthTest"));
     }
 
-    @Test
-    void executeAsync_fallback_shouldRetryIfStatusIsNotSuccessful() {
-        var client = clientWith(RetryPolicy.<Response>builder().withMaxAttempts(2).build());
+    @Nested
+    class ExecuteAsync {
 
-        var request = new Request.Builder()
-                .url("http://localhost:" + server.getPort())
-                .build();
+        @Test
+        void fallback_shouldRetryIfStatusIsNotSuccessful() {
+            var client = clientWith(RetryPolicy.<Response>builder().withMaxAttempts(2).build());
 
-        server.stubFor(get(anyUrl()).willReturn(aResponse().withStatus(500)));
+            var request = new Request.Builder()
+                    .url("http://localhost:" + server.getPort())
+                    .build();
 
-        var result = client.executeAsync(request, List.of(retryWhenStatusNot2xxOr4xx())).thenApply(handleResponse());
+            server.stubFor(get(anyUrl()).willReturn(aResponse().withStatus(500)));
 
-        assertThat(result).failsWithin(5, TimeUnit.SECONDS);
-        server.verify(2, getRequestedFor(anyUrl()));
+            var result = client.executeAsync(request, List.of(retryWhenStatusNot2xxOr4xx())).thenApply(handleResponse());
+
+            assertThat(result).failsWithin(5, TimeUnit.SECONDS);
+            server.verify(2, getRequestedFor(anyUrl()));
+        }
+
+        @Test
+        void fallback_shouldRetryIfStatusIs4xx() {
+            var client = clientWith(RetryPolicy.<Response>builder().withMaxAttempts(2).build());
+
+            var request = new Request.Builder()
+                    .url("http://localhost:" + server.getPort())
+                    .build();
+
+
+            server.stubFor(get(anyUrl()).willReturn(aResponse().withStatus(500)));
+
+            var result = client.executeAsync(request, List.of(retryWhenStatusNot2xxOr4xx())).thenApply(handleResponse());
+
+            assertThat(result).failsWithin(5, TimeUnit.SECONDS);
+            server.verify(2, getRequestedFor(anyUrl()));
+        }
+
+        @Test
+        void fallback_shouldNotRetryIfStatusIsExpected() {
+            var client = clientWith(RetryPolicy.<Response>builder().withMaxAttempts(2).build());
+
+            var request = new Request.Builder()
+                    .url("http://localhost:" + server.getPort())
+                    .build();
+
+            server.stubFor(get(anyUrl()).willReturn(aResponse().withStatus(404)));
+
+            var result = client.executeAsync(request, List.of(retryWhenStatusNot2xxOr4xx())).thenApply(handleResponse());
+
+            assertThat(result).succeedsWithin(5, TimeUnit.SECONDS);
+            server.verify(1, getRequestedFor(anyUrl()));
+        }
+
+        @Test
+        void fallback_shouldRetryIfStatusIsNotAsExpected() {
+            var client = clientWith(RetryPolicy.<Response>builder().withMaxAttempts(2).build());
+
+            var request = new Request.Builder()
+                    .url("http://localhost:" + server.getPort())
+                    .build();
+
+            server.stubFor(get(anyUrl()).willReturn(ok()));
+
+            var result = client.executeAsync(request, List.of(retryWhenStatusIsNot(204))).thenApply(handleResponse());
+
+            assertThat(result).failsWithin(5, TimeUnit.SECONDS);
+            server.verify(2, getRequestedFor(anyUrl()));
+        }
+
+        @Test
+        void fallback_shouldFailAfterAttemptsExpired_whenServerIsDown() {
+            var client = clientWith(RetryPolicy.<Response>builder().withMaxAttempts(1).build());
+
+            var request = new Request.Builder()
+                    .url("http://localhost:" + getFreePort())
+                    .build();
+
+            var result = client.executeAsync(request, emptyList()).thenApply(handleResponse());
+
+            assertThat(result).failsWithin(5, TimeUnit.SECONDS).withThrowableThat()
+                    .havingCause().isInstanceOf(ConnectException.class);
+        }
     }
 
-    @Test
-    void executeAsync_fallback_shouldRetryIfStatusIs4xx() {
-        var client = clientWith(RetryPolicy.<Response>builder().withMaxAttempts(2).build());
-
-        var request = new Request.Builder()
-                .url("http://localhost:" + server.getPort())
-                .build();
-
-
-        server.stubFor(get(anyUrl()).willReturn(aResponse().withStatus(500)));
-
-        var result = client.executeAsync(request, List.of(retryWhenStatusNot2xxOr4xx())).thenApply(handleResponse());
-
-        assertThat(result).failsWithin(5, TimeUnit.SECONDS);
-        server.verify(2, getRequestedFor(anyUrl()));
-    }
-
-    @Test
-    void executeAsync_fallback_shouldNotRetryIfStatusIsExpected() {
-        var client = clientWith(RetryPolicy.<Response>builder().withMaxAttempts(2).build());
-
-        var request = new Request.Builder()
-                .url("http://localhost:" + server.getPort())
-                .build();
-
-        server.stubFor(get(anyUrl()).willReturn(aResponse().withStatus(404)));
-
-        var result = client.executeAsync(request, List.of(retryWhenStatusNot2xxOr4xx())).thenApply(handleResponse());
-
-        assertThat(result).succeedsWithin(5, TimeUnit.SECONDS);
-        server.verify(1, getRequestedFor(anyUrl()));
-    }
-
-    @Test
-    void executeAsync_fallback_shouldRetryIfStatusIsNotAsExpected() {
-        var client = clientWith(RetryPolicy.<Response>builder().withMaxAttempts(2).build());
-
-        var request = new Request.Builder()
-                .url("http://localhost:" + server.getPort())
-                .build();
-
-        server.stubFor(get(anyUrl()).willReturn(ok()));
-
-        var result = client.executeAsync(request, List.of(retryWhenStatusIsNot(204))).thenApply(handleResponse());
-
-        assertThat(result).failsWithin(5, TimeUnit.SECONDS);
-        server.verify(2, getRequestedFor(anyUrl()));
-    }
-
-    @Test
-    void executeAsync_fallback_shouldFailAfterAttemptsExpired_whenServerIsDown() {
-        var client = clientWith(RetryPolicy.<Response>builder().withMaxAttempts(2).build());
-
-        var request = new Request.Builder()
-                .url("http://localhost:" + getFreePort())
-                .build();
-
-        var result = client.executeAsync(request, emptyList()).thenApply(handleResponse());
-
-        assertThat(result).failsWithin(5, TimeUnit.SECONDS);
-    }
 
     @NotNull
     private Function<Response, Result<String>> handleResponse() {

--- a/core/crawler-core/src/main/java/org/eclipse/edc/catalog/cache/ExecutionManager.java
+++ b/core/crawler-core/src/main/java/org/eclipse/edc/catalog/cache/ExecutionManager.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.crawler.spi.model.ExecutionPlan;
 import org.eclipse.edc.crawler.spi.model.UpdateRequest;
 import org.eclipse.edc.spi.monitor.Monitor;
 
+import java.net.ConnectException;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Executors;
@@ -109,8 +110,14 @@ public class ExecutionManager {
         if (throwable == null) {
             monitor.debug(format("WorkItem [%s] is done", item.getId()));
         } else {
+
+            if (throwable.getCause() instanceof ConnectException connectException) {
+                monitor.info("Cannot connect to node %s: " + connectException.getMessage());
+            } else {
+                monitor.severe("Unexpected exception occurred while crawling: " + item.getId(), throwable);
+            }
+
             item.error(throwable.getMessage());
-            monitor.severe("Unexpected exception occurred while crawling: " + item.getId(), throwable);
             if (item.getErrors().size() > configuration.maxRetries()) {
                 monitor.severe(format("The following WorkItem has errored out more than %d times. We'll discard it now: [%s]", configuration.maxRetries(), item));
             } else {

--- a/core/crawler-core/src/test/java/org/eclipse/edc/catalog/cache/ExecutionManagerTest.java
+++ b/core/crawler-core/src/test/java/org/eclipse/edc/catalog/cache/ExecutionManagerTest.java
@@ -27,6 +27,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.net.ConnectException;
 import java.util.List;
 import java.util.concurrent.CompletionException;
 
@@ -137,6 +138,21 @@ class ExecutionManagerTest {
 
         verifyNoInteractions(successHandler);
         verify(monitorMock, atLeastOnce()).severe(anyString(), isA(CompletionException.class));
+    }
+
+    @Test
+    void shouldLogInfo_whenQueryReturnsConnectException() {
+        when(nodeDirectoryMock.getAll()).thenReturn(List.of(createNode()));
+        when(crawlerActionRegistry.findForProtocol(TEST_PROTOCOL)).thenReturn(List.of(queryAdapterMock));
+        when(queryAdapterMock.apply(any())).thenReturn(failedFuture(new ConnectException("cannot connect")));
+
+        manager.executePlan(simplePlan());
+
+        var inOrder = inOrder(preExecutionTaskMock, queryAdapterMock, successHandler);
+        inOrder.verify(preExecutionTaskMock).run();
+        inOrder.verify(queryAdapterMock).apply(any());
+
+        verify(monitorMock, atLeastOnce()).info(anyString());
     }
 
     @Test

--- a/spi/common/http-spi/src/main/java/org/eclipse/edc/http/spi/EdcHttpClient.java
+++ b/spi/common/http-spi/src/main/java/org/eclipse/edc/http/spi/EdcHttpClient.java
@@ -74,7 +74,8 @@ public interface EdcHttpClient {
      *
      * @param request the {@link Request}.
      * @param fallbacks a list of fallbacks to be applied.
-     * @return a {@link CompletableFuture} containing the {@link Response} instance.
+     * @return a {@link CompletableFuture} containing the {@link Response} instance. If the server isn't available,
+     *         fails with a {@link java.net.ConnectException}.
      */
     CompletableFuture<Response> executeAsync(Request request, List<FallbackFactory> fallbacks);
 

--- a/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/java/org/eclipse/edc/catalog/ControlPlaneCrawlerComponentTest.java
+++ b/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/java/org/eclipse/edc/catalog/ControlPlaneCrawlerComponentTest.java
@@ -47,6 +47,7 @@ import java.util.UUID;
 import static java.lang.String.valueOf;
 import static java.time.Duration.ofSeconds;
 import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.catalog.TestFunctions.catalogBuilder;
@@ -68,7 +69,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Component test that validates the federated catalog crawler running inside a standard
+ * Component test that validates the catalog crawler running inside a standard
  * control plane runtime (controlplane-base-bom), as opposed to a standalone federated
  * catalog runtime (federatedcatalog-base-bom).
  */
@@ -190,11 +191,11 @@ public class ControlPlaneCrawlerComponentTest {
 
         var catalogId = "test-catalog-id";
         when(dispatcher.dispatch(any(), eq(byte[].class), isA(CatalogRequestMessage.class)))
-                .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(toBytes(ttr, catalogBuilder().id(catalogId).datasets(new ArrayList<>(List.of(
+                .thenReturn(completedFuture(toBytes(ttr, catalogBuilder().id(catalogId).datasets(new ArrayList<>(List.of(
                         createDataset("offer1"), createDataset("offer2"), createDataset("offer3")
                 ))).build())))
                 .thenReturn(emptyCatalog(catalog -> toBytes(ttr, catalog), catalogId))
-                .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(toBytes(ttr, catalogBuilder().id(catalogId).datasets(new ArrayList<>(List.of(
+                .thenReturn(completedFuture(toBytes(ttr, catalogBuilder().id(catalogId).datasets(new ArrayList<>(List.of(
                         createDataset("offer1"), createDataset("offer2")
                 ))).build())));
 

--- a/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/java/org/eclipse/edc/catalog/TestFunctions.java
+++ b/system-tests/e2e-federatedcatalog-tests/component-tests/src/test/java/org/eclipse/edc/catalog/TestFunctions.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.catalog;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
@@ -27,6 +26,7 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.DataService;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Dataset;
 import org.eclipse.edc.connector.controlplane.catalog.spi.Distribution;
 import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.policy.model.Policy;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.response.StatusResult;
@@ -45,13 +45,16 @@ import static io.restassured.RestAssured.given;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.stream.Collectors.toList;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 
 public class TestFunctions {
+
+    public static final ObjectMapper OBJECT_MAPPER = JacksonJsonLd.createObjectMapper();
     public static final String MANAGEMENT_BASE_PATH = "/api/management";
     public static final int MANAGEMENT_PORT = getFreePort();
-    private static final String PATH = "/v3/catalogs/request";
     private static final TypeReference<List<Map<String, Object>>> MAP_TYPE = new TypeReference<>() {
     };
 
@@ -92,15 +95,17 @@ public class TestFunctions {
     }
 
     public static List<Catalog> queryCatalogApi(JsonLd jsonLd, Function<JsonObject, Catalog> transformerFunction) {
-        var objectMapper = new ObjectMapper();
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         var body = baseRequest()
-                .body(TestFunctions.createEmptyQuery())
-                .post(PATH)
+                .body(Json.createObjectBuilder()
+                        .add(CONTEXT, EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2)
+                        .add(TYPE, QuerySpec.EDC_QUERY_SPEC_TYPE_TERM)
+                        .build()
+                )
+                .post("/v4/catalogs/request")
                 .body();
 
         try {
-            var maps = objectMapper.readValue(body.asString(), MAP_TYPE);
+            var maps = OBJECT_MAPPER.readValue(body.asString(), MAP_TYPE);
             return maps.stream().map(map -> Json.createObjectBuilder(map).build())
                     .map(jsonLd::expand)
                     .map(Result::getContent)
@@ -109,12 +114,6 @@ public class TestFunctions {
         } catch (JsonProcessingException e) {
             throw new AssertionError(e);
         }
-    }
-
-    public static JsonObject createEmptyQuery() {
-        return Json.createObjectBuilder()
-                .add(TYPE, QuerySpec.EDC_QUERY_SPEC_TYPE)
-                .build();
     }
 
     public static Dataset createDataset(String dataset1) {


### PR DESCRIPTION
## What this PR changes/adds

Avoid to logs the whole exception stacktrace when the counter party connector is not available during catalog crawling

## Why it does that

_Briefly state why the change was necessary._

## Further notes
- 


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5706

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
