### PR TITLE
feat: store claims on agreement also on provider side

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -175,7 +175,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
         return transactionContext.execute(() -> getNegotiation(participantContext, message.getProcessId())
                 .compose(contractNegotiation -> verifyRequest(participantContext, tokenRepresentation, contractNegotiation.getLastContractOffer().getPolicy(), message)
                         .compose(agent -> validateRequest(agent, contractNegotiation)))
-                .compose(cn -> onMessageDo(participantContext, message, contractNegotiation -> verifiedAction(message, contractNegotiation))));
+                .compose(agent -> onMessageDo(participantContext, message, contractNegotiation -> verifiedAction(message, contractNegotiation, agent))));
     }
 
     @Override
@@ -280,12 +280,12 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     }
 
     @NotNull
-    private ServiceResult<Void> validateRequest(ParticipantAgent agent, ContractNegotiation negotiation) {
+    private ServiceResult<ParticipantAgent> validateRequest(ParticipantAgent agent, ContractNegotiation negotiation) {
         var result = validationService.validateRequest(agent, negotiation);
         if (result.failed()) {
             return ServiceResult.badRequest("Invalid client credentials: " + result.getFailureDetail());
         } else {
-            return ServiceResult.success();
+            return ServiceResult.success(agent);
         }
     }
 
@@ -323,10 +323,12 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
     }
 
     @NotNull
-    private ServiceResult<ContractNegotiation> verifiedAction(ContractAgreementVerificationMessage message, ContractNegotiation negotiation) {
+    private ServiceResult<ContractNegotiation> verifiedAction(ContractAgreementVerificationMessage message, ContractNegotiation negotiation, ParticipantAgent agent) {
         if (negotiation.getType().equals(PROVIDER) && negotiation.canBeVerifiedProvider()) {
             negotiation.protocolMessageReceived(message.getId());
             negotiation.transitionVerified();
+            var agreementWithClaims = negotiation.getContractAgreement().toBuilder().claims(agent.getClaims()).build();
+            negotiation.setContractAgreement(agreementWithClaims);
             update(negotiation);
             observable.invokeForEach(l -> l.verified(negotiation));
             return ServiceResult.success(negotiation);

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -163,12 +163,7 @@ class ContractNegotiationProtocolServiceImplTest {
             var participantAgent = new ParticipantAgent("counterPartyId", Map.of("claim", "value"), emptyMap());
             var tokenRepresentation = tokenRepresentation();
 
-            var contractAgreement = ContractAgreement.Builder.newInstance()
-                    .providerId("providerId")
-                    .consumerId("consumerId")
-                    .assetId("assetId")
-                    .policy(Policy.Builder.newInstance().build())
-                    .participantContextId("participantContextId")
+            var contractAgreement = createContractAgreementBuilder()
                     .build();
             var message = ContractAgreementMessage.Builder.newInstance()
                     .protocol("protocol")
@@ -189,9 +184,9 @@ class ContractNegotiationProtocolServiceImplTest {
             assertThat(result).isSucceeded();
             verify(store).findById("processId");
             verify(store).findByIdAndLease("processId");
-            ArgumentCaptor<ContractNegotiation> negotiationCaptor = ArgumentCaptor.forClass(ContractNegotiation.class);
+            var negotiationCaptor = ArgumentCaptor.forClass(ContractNegotiation.class);
             verify(store).save(negotiationCaptor.capture());
-            ContractNegotiation storedNegotiation = negotiationCaptor.getValue();
+            var storedNegotiation = negotiationCaptor.getValue();
             assertThat(storedNegotiation.stateAsString()).isEqualTo(AGREED.name());
             assertThat(storedNegotiation.getContractAgreement()).satisfies(storedAgreement -> {
                 assertThat(storedAgreement.getProviderId()).isEqualTo("providerId");
@@ -205,36 +200,46 @@ class ContractNegotiationProtocolServiceImplTest {
 
     }
 
-    @Test
-    void notifyVerified_shouldTransitionToVerified() {
-        var participantAgent = participantAgent();
-        var tokenRepresentation = tokenRepresentation();
-        var contractOffer = contractOffer();
-        var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(AGREED.code()).contractOffer(contractOffer).build();
-        when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
-        when(validationService.validateRequest(any(ParticipantAgent.class), any(ContractNegotiation.class))).thenReturn(Result.success());
-        var message = ContractAgreementVerificationMessage.Builder.newInstance()
-                .protocol("protocol")
-                .counterPartyAddress("http://any")
-                .processId("processId")
-                .consumerPid("consumerPid")
-                .providerPid("providerPid")
-                .build();
+    @Nested
+    class NotifyVerified {
 
-        when(protocolTokenValidator.verify(eq(participantContext), eq(tokenRepresentation), any(), any(), eq(message))).thenReturn(ServiceResult.success(participantAgent));
-        when(store.findById(any())).thenReturn(negotiation);
-        when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
-        when(validationService.validateRequest(any(ParticipantAgent.class), any(ContractNegotiation.class))).thenReturn(Result.success());
+        @Test
+        void shouldTransitionToVerifiedAndStoreClaimsInAgreement() {
+            Map<String, Object> claims = Map.of("claim", "value");
+            var participantAgent = new ParticipantAgent("counterPartyId", claims, emptyMap());
+            var tokenRepresentation = tokenRepresentation();
+            var negotiation = contractNegotiationBuilder().id("negotiationId").type(PROVIDER).state(AGREED.code())
+                    .contractOffer(contractOffer()).contractAgreement(createContractAgreementBuilder().claims(null).build())
+                    .build();
+            when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
+            when(validationService.validateRequest(any(ParticipantAgent.class), any(ContractNegotiation.class))).thenReturn(Result.success());
+            var message = ContractAgreementVerificationMessage.Builder.newInstance()
+                    .protocol("protocol")
+                    .counterPartyAddress("http://any")
+                    .processId("processId")
+                    .consumerPid("consumerPid")
+                    .providerPid("providerPid")
+                    .build();
 
-        var result = service.notifyVerified(participantContext, message, tokenRepresentation);
+            when(protocolTokenValidator.verify(eq(participantContext), eq(tokenRepresentation), any(), any(), eq(message))).thenReturn(ServiceResult.success(participantAgent));
+            when(store.findById(any())).thenReturn(negotiation);
+            when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
+            when(validationService.validateRequest(any(ParticipantAgent.class), any(ContractNegotiation.class))).thenReturn(Result.success());
 
-        assertThat(result).isSucceeded();
-        verify(store).findById("processId");
-        verify(store).findByIdAndLease("processId");
-        verify(store).save(argThat(n -> n.getState() == VERIFIED.code()));
-        verify(listener).verified(negotiation);
-        verify(validationService).validateRequest(same(participantAgent), any(ContractNegotiation.class));
-        verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
+            var result = service.notifyVerified(participantContext, message, tokenRepresentation);
+
+            assertThat(result).isSucceeded();
+            verify(store).findById("processId");
+            verify(store).findByIdAndLease("processId");
+            var captor = ArgumentCaptor.forClass(ContractNegotiation.class);
+            verify(store).save(captor.capture());
+            var storedNegotiation = captor.getValue();
+            assertThat(storedNegotiation.stateAsString()).isEqualTo(VERIFIED.name());
+            assertThat(storedNegotiation.getContractAgreement().getClaims()).isEqualTo(claims);
+            verify(listener).verified(negotiation);
+            verify(validationService).validateRequest(same(participantAgent), any(ContractNegotiation.class));
+            verify(transactionContext, atLeastOnce()).execute(any(TransactionContext.ResultTransactionBlock.class));
+        }
     }
 
     @Test
@@ -799,7 +804,8 @@ class ContractNegotiationProtocolServiceImplTest {
                                                                                   ContractNegotiation.Type type,
                                                                                   ContractNegotiationStates currentState) {
             var offer = contractOffer();
-            var negotiation = contractNegotiationBuilder().state(currentState.code()).type(type).contractOffer(offer).build();
+            var negotiation = contractNegotiationBuilder().state(currentState.code()).type(type).contractOffer(offer)
+                    .contractAgreement(createContractAgreementBuilder().build()).build();
             var validatableOffer = mock(ValidatableConsumerOffer.class);
 
             when(validatableOffer.getContractPolicy()).thenReturn(createPolicy());
@@ -840,6 +846,7 @@ class ContractNegotiationProtocolServiceImplTest {
                     .thenReturn(ServiceResult.success(participantAgent()));
             when(store.findById(any())).thenReturn(negotiation);
             when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(negotiation));
+            when(store.breakLease(any())).thenReturn(StoreResult.success());
             when(validationService.validateRequest(any(ParticipantAgent.class), any(ContractNegotiation.class))).thenReturn(Result.success());
             when(validationService.validateInitialOffer(any(ParticipantAgent.class), any(ValidatableConsumerOffer.class)))
                     .thenAnswer(i -> Result.success(new ValidatedConsumerOffer("any", offer)));
@@ -909,4 +916,14 @@ class ContractNegotiationProtocolServiceImplTest {
             verifyNoInteractions(listener);
         }
     }
+
+    private ContractAgreement.Builder createContractAgreementBuilder() {
+        return ContractAgreement.Builder.newInstance()
+                .providerId("providerId")
+                .consumerId("consumerId")
+                .assetId("assetId")
+                .policy(Policy.Builder.newInstance().build())
+                .participantContextId("participantContextId");
+    }
+
 }


### PR DESCRIPTION
## What this PR changes/adds

Store claims on consumer contract agreement provider side

## Why it does that

simmetry. In any case claims are already stored at the Transfer Process level

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5710 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
