### PR TITLE
fix: add missing breaklease on TransferProcess protocol service

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -100,8 +100,8 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     @WithSpan
     @NotNull
     public ServiceResult<TransferProcess> notifyRequested(ParticipantContext participantContext, TransferRequestMessage message, TokenRepresentation tokenRepresentation) {
-        return transactionContext.execute(() -> fetchNotifyRequestContext(participantContext, message)
-                .compose(context -> verifyRequest(participantContext, tokenRepresentation, context, message))
+        return transactionContext.execute(() -> fetchContractAgreement(participantContext, message)
+                .compose(contractAgreement -> verifyRequest(participantContext, tokenRepresentation, message, contractAgreement))
                 .compose(context -> validateRequestMessage(message, context))
                 .compose(context -> requestedAction(participantContext, message, context)));
     }
@@ -111,8 +111,9 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     @NotNull
     public ServiceResult<TransferProcess> notifyStarted(ParticipantContext participantContext, TransferStartMessage message, TokenRepresentation tokenRepresentation) {
         return transactionContext.execute(() -> fetchRequestContext(participantContext, message.getProcessId())
-                .compose(context -> verifyRequest(participantContext, tokenRepresentation, context, message))
-                .compose(context -> onMessageDo(participantContext, message, context, transferProcess -> startedAction(message, transferProcess)))
+                .compose(context -> verifyRequest(participantContext, tokenRepresentation, message, context.agreement())
+                        .compose(this::validateCounterParty))
+                .compose(context -> onMessageDo(participantContext, message, transferProcess -> startedAction(message, transferProcess)))
         );
     }
 
@@ -121,8 +122,9 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     @NotNull
     public ServiceResult<TransferProcess> notifyCompleted(ParticipantContext participantContext, TransferCompletionMessage message, TokenRepresentation tokenRepresentation) {
         return transactionContext.execute(() -> fetchRequestContext(participantContext, message.getProcessId())
-                .compose(context -> verifyRequest(participantContext, tokenRepresentation, context, message))
-                .compose(context -> onMessageDo(participantContext, message, context, transferProcess -> completedAction(message, transferProcess)))
+                .compose(context -> verifyRequest(participantContext, tokenRepresentation, message, context.agreement())
+                        .compose(this::validateCounterParty))
+                .compose(i -> onMessageDo(participantContext, message, transferProcess -> completedAction(message, transferProcess)))
         );
     }
 
@@ -131,8 +133,9 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     @NotNull
     public ServiceResult<TransferProcess> notifySuspended(ParticipantContext participantContext, TransferSuspensionMessage message, TokenRepresentation tokenRepresentation) {
         return transactionContext.execute(() -> fetchRequestContext(participantContext, message.getProcessId())
-                .compose(context -> verifyRequest(participantContext, tokenRepresentation, context, message))
-                .compose(context -> onMessageDo(participantContext, message, context, transferProcess -> suspendedAction(message, transferProcess)))
+                .compose(context -> verifyRequest(participantContext, tokenRepresentation, message, context.agreement())
+                        .compose(this::validateCounterParty))
+                .compose(i -> onMessageDo(participantContext, message, transferProcess -> suspendedAction(message, transferProcess)))
         );
     }
 
@@ -141,8 +144,9 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     @NotNull
     public ServiceResult<TransferProcess> notifyTerminated(ParticipantContext participantContext, TransferTerminationMessage message, TokenRepresentation tokenRepresentation) {
         return transactionContext.execute(() -> fetchRequestContext(participantContext, message.getProcessId())
-                .compose(context -> verifyRequest(participantContext, tokenRepresentation, context, message))
-                .compose(context -> onMessageDo(participantContext, message, context, transferProcess -> terminatedAction(message, transferProcess)))
+                .compose(context -> verifyRequest(participantContext, tokenRepresentation, message, context.agreement())
+                        .compose(this::validateCounterParty))
+                .compose(i -> onMessageDo(participantContext, message, transferProcess -> terminatedAction(message, transferProcess)))
         );
     }
 
@@ -152,9 +156,9 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     public ServiceResult<TransferProcess> findById(ParticipantContext participantContext, TransferProcessRequestMessage message, TokenRepresentation tokenRepresentation) {
 
         return transactionContext.execute(() -> fetchRequestContext(participantContext, message.getTransferProcessId())
-                .compose(context -> verifyRequest(participantContext, tokenRepresentation, context, message)
-                        .compose(claimTokenContext -> validateCounterParty(claimTokenContext.participantAgent(), claimTokenContext.agreement())
-                                .map(it -> context.transferProcess())))
+                .compose(context -> verifyRequest(participantContext, tokenRepresentation, message, context.agreement())
+                        .compose(this::validateCounterParty)
+                        .map(it -> context.transferProcess()))
         );
     }
 
@@ -293,20 +297,18 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
             return ServiceResult.conflict(format("Cannot process %s because %s", message.getClass().getSimpleName(), "agreement not found or not valid"));
         }
 
-
         return ServiceResult.success(context);
     }
 
-    private ServiceResult<TransferMessageContext> fetchNotifyRequestContext(ParticipantContext participantContext, TransferRequestMessage message) {
+    private ServiceResult<ContractAgreement> fetchContractAgreement(ParticipantContext participantContext, TransferRequestMessage message) {
         return Optional.ofNullable(findAgreement(participantContext, message.getContractId()))
                 .filter(agreement -> participantContext.getParticipantContextId().equals(agreement.getParticipantContextId()))
-                .map(contractAgreement -> new TransferMessageContext(contractAgreement, null))
                 .map(ServiceResult::success)
                 .orElseGet(() -> ServiceResult.notFound(format("Cannot process %s because %s", message.getClass().getSimpleName(), "agreement not found or not valid")));
     }
 
     private ServiceResult<TransferMessageContext> fetchRequestContext(ParticipantContext participantContext, String transferProcessId) {
-        return findTransferProcessById(participantContext, transferProcessId)
+        return findTransferProcessByIdReadOnly(participantContext, transferProcessId)
                 .compose(transferProcess -> {
                     var agreement = negotiationStore.findContractAgreement(transferProcess.getContractId());
                     if (agreement == null) {
@@ -316,34 +318,30 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
                 });
     }
 
-    private ServiceResult<ClaimTokenContext> verifyRequest(ParticipantContext participantContext, TokenRepresentation tokenRepresentation, TransferMessageContext context, RemoteMessage message) {
-        var result = protocolTokenValidator.verify(participantContext, tokenRepresentation, RequestTransferProcessPolicyContext::new, context.agreement().getPolicy(), message);
+    private ServiceResult<ClaimTokenContext> verifyRequest(ParticipantContext participantContext, TokenRepresentation tokenRepresentation, RemoteMessage message, ContractAgreement contractAgreement) {
+        var result = protocolTokenValidator.verify(participantContext, tokenRepresentation, RequestTransferProcessPolicyContext::new, contractAgreement.getPolicy(), message);
         if (result.failed()) {
             monitor.debug(() -> "Verification Failed: %s".formatted(result.getFailureDetail()));
             return ServiceResult.notFound("Not found");
         } else {
-            return ServiceResult.success(new ClaimTokenContext(result.getContent(), context.agreement()));
+            return ServiceResult.success(new ClaimTokenContext(result.getContent(), contractAgreement));
         }
     }
 
     private ServiceResult<TransferProcess> onMessageDo(ParticipantContext participantContext, TransferRemoteMessage message,
-                                                       ClaimTokenContext context,
                                                        Function<TransferProcess, ServiceResult<TransferProcess>> action) {
         return findAndLease(participantContext, message)
-                .compose(transferProcess -> validateCounterParty(context.participantAgent(), context.agreement())
-                        .map(it -> transferProcess)
-                        .compose(p -> {
-                            if (p.shouldIgnoreIncomingMessage(message.getId())) {
-                                return ServiceResult.success(p);
-                            } else {
-                                return action.apply(p);
-                            }
-                        })
-                        .onFailure(f -> breakLease(transferProcess)));
+                .compose(transferProcess -> {
+                    if (transferProcess.shouldIgnoreIncomingMessage(message.getId())) {
+                        return transferProcessStore.breakLease(transferProcess).flatMap(ServiceResult::from).map(it -> transferProcess);
+                    } else {
+                        return action.apply(transferProcess).onFailure(f -> transferProcessStore.breakLease(transferProcess));
+                    }
+                });
     }
 
-    private ServiceResult<Void> validateCounterParty(ParticipantAgent participantAgent, ContractAgreement agreement) {
-        var validation = contractValidationService.validateRequest(participantAgent, agreement);
+    private ServiceResult<Void> validateCounterParty(ClaimTokenContext claimTokenContext) {
+        var validation = contractValidationService.validateRequest(claimTokenContext.participantAgent(), claimTokenContext.agreement());
         if (validation.failed()) {
             return ServiceResult.badRequest(validation.getFailureMessages());
         }
@@ -376,22 +374,14 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
         }
     }
 
-    // read only access
-    private ServiceResult<TransferProcess> findTransferProcessById(ParticipantContext participantContext, String id) {
+    private ServiceResult<TransferProcess> findTransferProcessByIdReadOnly(ParticipantContext participantContext, String id) {
         return Optional.ofNullable(transferProcessStore.findById(id))
-                // or needed to maintain backward compatibility when there was no distinction between providerPid and consumerPid
-                .or(() -> Optional.ofNullable(transferProcessStore.findForCorrelationId(id)))
-                .filter(tp -> participantContext.getParticipantContextId().equals(tp.getParticipantContextId()))
-                .map(ServiceResult::success)
+                .map(tp -> filterByParticipantContext(participantContext, tp))
                 .orElseGet(() -> notFound(id));
     }
 
     private ServiceResult<TransferProcess> notFound(String transferProcessId) {
         return ServiceResult.notFound(format("No transfer process with id %s found", transferProcessId));
-    }
-
-    private void breakLease(TransferProcess process) {
-        transferProcessStore.save(process);
     }
 
     private StoreResult<Void> update(TransferProcess transferProcess) {

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -97,7 +97,6 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -571,8 +570,7 @@ class TransferProcessProtocolServiceImplTest {
             var result = service.notifyCompleted(participantContext, message, tokenRepresentation);
 
             assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(CONFLICT);
-            // state didn't change
-            verify(store, times(1)).save(argThat(tp -> tp.getState() == REQUESTED.code()));
+            verify(store).breakLease(transferProcess);
             verifyNoInteractions(listener);
         }
 
@@ -593,7 +591,6 @@ class TransferProcessProtocolServiceImplTest {
             var transferProcess = transferProcess(STARTED, "transferProcessId");
             when(protocolTokenValidator.verify(eq(participantContext), eq(tokenRepresentation), any(), any(), eq(message))).thenReturn(ServiceResult.success(participantAgent));
             when(store.findById("correlationId")).thenReturn(transferProcess);
-            when(store.findByIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
             when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
             when(validationService.validateRequest(participantAgent, agreement)).thenReturn(Result.failure("error"));
 
@@ -604,8 +601,7 @@ class TransferProcessProtocolServiceImplTest {
                     .extracting(ServiceFailure::getReason)
                     .isEqualTo(BAD_REQUEST);
 
-            verify(store, times(1)).save(any());
-
+            verify(store, never()).findByIdAndLease(anyString());
         }
     }
 
@@ -665,7 +661,7 @@ class TransferProcessProtocolServiceImplTest {
 
             assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(CONFLICT);
             // state didn't change
-            verify(store, times(1)).save(argThat(tp -> tp.getState() == DEPROVISIONING.code()));
+            verify(store).breakLease(transferProcess);
             verifyNoInteractions(listener);
         }
 
@@ -687,7 +683,6 @@ class TransferProcessProtocolServiceImplTest {
 
             when(protocolTokenValidator.verify(eq(participantContext), eq(tokenRepresentation), any(), any(), eq(message))).thenReturn(ServiceResult.success(participantAgent));
             when(store.findById("correlationId")).thenReturn(transferProcess);
-            when(store.findByIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
             when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
             when(validationService.validateRequest(participantAgent, agreement)).thenReturn(Result.failure("error"));
 
@@ -698,7 +693,7 @@ class TransferProcessProtocolServiceImplTest {
                     .extracting(ServiceFailure::getReason)
                     .isEqualTo(BAD_REQUEST);
 
-            verify(store, times(1)).save(any());
+            verify(store, never()).findByIdAndLease(anyString());
 
         }
     }
@@ -788,8 +783,7 @@ class TransferProcessProtocolServiceImplTest {
             var result = service.notifyStarted(participantContext, message, tokenRepresentation);
 
             assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(CONFLICT);
-            // state didn't change
-            verify(store, times(1)).save(argThat(tp -> tp.getState() == DEPROVISIONING.code()));
+            verify(store).breakLease(transferProcess);
             verifyNoInteractions(listener);
         }
 
@@ -810,7 +804,6 @@ class TransferProcessProtocolServiceImplTest {
             var transferProcess = transferProcess(REQUESTED, "transferProcessId");
             when(protocolTokenValidator.verify(eq(participantContext), eq(tokenRepresentation), any(), any(), eq(message))).thenReturn(ServiceResult.success(participantAgent));
             when(store.findById("correlationId")).thenReturn(transferProcess);
-            when(store.findByIdAndLease("correlationId")).thenReturn(StoreResult.success(transferProcess));
             when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
             when(validationService.validateRequest(participantAgent, agreement)).thenReturn(Result.failure("error"));
 
@@ -820,9 +813,7 @@ class TransferProcessProtocolServiceImplTest {
                     .isFailed()
                     .extracting(ServiceFailure::getReason)
                     .isEqualTo(BAD_REQUEST);
-
-            verify(store, times(1)).save(any());
-
+            verify(store, never()).findByIdAndLease(anyString());
         }
     }
 
@@ -977,6 +968,7 @@ class TransferProcessProtocolServiceImplTest {
             var result = service.notifyStarted(participantContext, message, tokenRepresentation);
 
             assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(CONFLICT);
+            verify(store).breakLease(transferProcess);
         }
     }
 
@@ -1036,7 +1028,7 @@ class TransferProcessProtocolServiceImplTest {
             var result = service.notifySuspended(participantContext, message, tokenRepresentation);
 
             assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(CONFLICT);
-            verify(store, times(1)).save(argThat(tp -> tp.getState() == REQUESTED.code()));
+            verify(store).breakLease(transferProcess);
             verifyNoInteractions(listener);
         }
 
@@ -1065,8 +1057,7 @@ class TransferProcessProtocolServiceImplTest {
             var result = service.notifySuspended(participantContext, message, tokenRepresentation);
 
             assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(CONFLICT);
-            // state didn't change
-            verify(store, times(1)).save(argThat(tp -> tp.getState() == DEPROVISIONING.code()));
+            verify(store).breakLease(transferProcess);
             verifyNoInteractions(listener);
         }
 
@@ -1088,7 +1079,6 @@ class TransferProcessProtocolServiceImplTest {
 
             when(protocolTokenValidator.verify(eq(participantContext), eq(tokenRepresentation), any(), any(), eq(message))).thenReturn(ServiceResult.success(participantAgent));
             when(store.findById(any())).thenReturn(transferProcess);
-            when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(transferProcess));
             when(negotiationStore.findContractAgreement(any())).thenReturn(agreement);
             when(validationService.validateRequest(participantAgent, agreement)).thenReturn(Result.failure("error"));
 
@@ -1099,7 +1089,7 @@ class TransferProcessProtocolServiceImplTest {
                     .extracting(ServiceFailure::getReason)
                     .isEqualTo(BAD_REQUEST);
 
-            verify(store, times(1)).save(any());
+            verify(store, never()).findByIdAndLease(anyString());
 
         }
     }
@@ -1140,6 +1130,7 @@ class TransferProcessProtocolServiceImplTest {
             when(protocolTokenValidator.verify(any(), any(), any(), any(), eq(message))).thenReturn(ServiceResult.success(participantAgent()));
             when(store.findById(any())).thenReturn(transferProcess);
             when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(transferProcess));
+            when(store.breakLease(any())).thenReturn(StoreResult.success());
             when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
             when(validationService.validateAgreement(any(ParticipantAgent.class), any())).thenAnswer(i -> Result.success(i.getArgument(1)));
             when(validationService.validateRequest(any(ParticipantAgent.class), isA(ContractAgreement.class))).thenReturn(Result.success());
@@ -1148,6 +1139,7 @@ class TransferProcessProtocolServiceImplTest {
 
             assertThat(result).isSucceeded();
             verify(store, never()).save(any());
+            verify(store).breakLease(transferProcess);
             verifyNoInteractions(listener);
         }
 
@@ -1159,6 +1151,7 @@ class TransferProcessProtocolServiceImplTest {
             when(protocolTokenValidator.verify(any(), any(), any(), any(), eq(message))).thenReturn(ServiceResult.success(participantAgent()));
             when(store.findById(any())).thenReturn(transferProcess);
             when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(transferProcess));
+            when(store.breakLease(any())).thenReturn(StoreResult.success());
             when(negotiationStore.findContractAgreement(any())).thenReturn(contractAgreement());
             when(validationService.validateAgreement(any(ParticipantAgent.class), any())).thenAnswer(i -> Result.success(i.getArgument(1)));
             when(validationService.validateRequest(any(ParticipantAgent.class), isA(ContractAgreement.class))).thenReturn(Result.success());
@@ -1168,6 +1161,7 @@ class TransferProcessProtocolServiceImplTest {
             assertThat(result).isFailed().satisfies(failure -> {
                 assertThat(failure.getReason()).isEqualTo(CONFLICT);
             });
+            verify(store).breakLease(transferProcess);
             verifyNoInteractions(listener);
         }
 


### PR DESCRIPTION
## What this PR changes/adds

Ensures that "breakLease" is always triggered after an entity is leased in the Transfer Process protocol service.

Contract Negotiation PR will came after #5727 is merged

## Why it does that

_Briefly state why the change was necessary._

## Further notes
- I removed a backward compatibility check that was introduced in 0.5.1, when there was protocol 0.8, there's no reason to keep it anymore.
- Moved the "counterPartyValidation" before the entity leasing, so, if the counter party id is not as expected, it will return an error right away just using the "read only" entity


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #5728 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
