### PR TITLE
feat: publish EDC events to NATS

### DIFF
--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -14,7 +14,7 @@
   {
     "version": "5.0.0-beta",
     "urlPath": "/v5beta",
-    "lastUpdated": "2026-04-25T09:00:00Z",
+    "lastUpdated": "2026-05-15T09:00:00Z",
     "maturity": "beta"
   }
 ]

--- a/extensions/common/events/events-nats/README.md
+++ b/extensions/common/events/events-nats/README.md
@@ -1,0 +1,9 @@
+# Publishing Events to NATS
+
+This module provides a way to register an event publisher that publishes EDC events to NATS.
+
+## Configuration 
+
+| Parameter name           | Description                               | Default value |
+|--------------------------|-------------------------------------------|---------------|
+| `edc.events.nats.stream` | NATS stream on which events are published |               |

--- a/extensions/common/events/events-nats/build.gradle.kts
+++ b/extensions/common/events/events-nats/build.gradle.kts
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+dependencies {
+    api(project(":spi:common:core-spi"))
+    implementation(libs.nats)
+    implementation(libs.failsafe.core)
+
+    testImplementation(testFixtures(project(":core:common:junit")))
+    testImplementation(project(":core:common:connector-core"))
+    testImplementation(project(":core:common:runtime-core"))
+    testImplementation(libs.testcontainers.junit)
+    testImplementation(libs.wiremock)
+    testImplementation(libs.awaitility)
+}
+
+

--- a/extensions/common/events/events-nats/build.gradle.kts
+++ b/extensions/common/events/events-nats/build.gradle.kts
@@ -20,6 +20,8 @@ plugins {
 dependencies {
     api(project(":spi:common:core-spi"))
     implementation(libs.nats)
+    implementation(libs.cloudEvents)
+    implementation(libs.cloudEvents.json)
     implementation(libs.failsafe.core)
 
     testImplementation(testFixtures(project(":core:common:junit")))

--- a/extensions/common/events/events-nats/build.gradle.kts
+++ b/extensions/common/events/events-nats/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2026 Metaform Systems, Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       2026 Metaform Systems, Inc. - initial API and implementation
  *
  */
 

--- a/extensions/common/events/events-nats/build.gradle.kts
+++ b/extensions/common/events/events-nats/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
     testImplementation(project(":core:common:connector-core"))
     testImplementation(project(":core:common:runtime-core"))
     testImplementation(libs.testcontainers.junit)
-    testImplementation(libs.wiremock)
     testImplementation(libs.awaitility)
 }
 

--- a/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/Constants.java
+++ b/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/Constants.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.event.nats;
+
+public interface Constants {
+    String EVENTS_SUBJECT = "events";
+    String EVENTS_PREFIX = EVENTS_SUBJECT + ".>";
+}

--- a/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsEventPublisher.java
+++ b/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsEventPublisher.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.event.nats;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.nats.client.JetStream;
+import io.nats.client.JetStreamApiException;
+import io.nats.client.PublishOptions;
+import io.nats.client.impl.Headers;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.event.EventSubscriber;
+import org.eclipse.edc.spi.monitor.Monitor;
+
+import java.io.IOException;
+
+import static org.eclipse.edc.event.nats.Constants.EVENTS_SUBJECT;
+
+public class NatsEventPublisher implements EventSubscriber {
+    private final Monitor monitor;
+    private final JetStream jetStream;
+    private final ObjectMapper objectMapper;
+
+    public NatsEventPublisher(Monitor monitor, JetStream jetStream, ObjectMapper objectMapper) {
+        this.monitor = monitor;
+        this.jetStream = jetStream;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public <E extends Event> void on(EventEnvelope<E> event) {
+        var eventName = event.getPayload().name();
+        var subject = "%s.%s".formatted(EVENTS_SUBJECT, eventName);
+
+        var opts = PublishOptions.builder().build();
+        try {
+            jetStream.publish(subject, getHeaders(), serialize(event.getPayload()), opts);
+        } catch (IOException | JetStreamApiException e) {
+            monitor.severe("Error publishing event", e);
+        }
+    }
+
+    private byte[] serialize(Object payload) throws JsonProcessingException {
+        // todo: serialize as CloudEvents
+        return objectMapper.writeValueAsBytes(payload);
+    }
+
+    private Headers getHeaders() {
+        return null;
+    }
+}

--- a/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsEventPublisher.java
+++ b/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsEventPublisher.java
@@ -16,6 +16,9 @@ package org.eclipse.edc.event.nats;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.cloudevents.core.format.ContentType;
+import io.cloudevents.core.v1.CloudEventBuilder;
+import io.cloudevents.jackson.JsonFormat;
 import io.nats.client.JetStream;
 import io.nats.client.JetStreamApiException;
 import io.nats.client.PublishOptions;
@@ -26,6 +29,10 @@ import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.monitor.Monitor;
 
 import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 import static org.eclipse.edc.event.nats.Constants.EVENTS_SUBJECT;
 
@@ -33,11 +40,14 @@ public class NatsEventPublisher implements EventSubscriber {
     private final Monitor monitor;
     private final JetStream jetStream;
     private final ObjectMapper objectMapper;
+    private final String hostname;
+    private final JsonFormat jsonFormat = new JsonFormat();
 
-    public NatsEventPublisher(Monitor monitor, JetStream jetStream, ObjectMapper objectMapper) {
+    public NatsEventPublisher(Monitor monitor, JetStream jetStream, ObjectMapper objectMapper, String hostname) {
         this.monitor = monitor;
         this.jetStream = jetStream;
         this.objectMapper = objectMapper;
+        this.hostname = hostname;
     }
 
     @Override
@@ -47,18 +57,31 @@ public class NatsEventPublisher implements EventSubscriber {
 
         var opts = PublishOptions.builder().build();
         try {
-            jetStream.publish(subject, getHeaders(), serialize(event.getPayload()), opts);
+            jetStream.publish(subject, getHeaders(), serialize(event), opts);
         } catch (IOException | JetStreamApiException e) {
             monitor.severe("Error publishing event", e);
         }
     }
 
-    private byte[] serialize(Object payload) throws JsonProcessingException {
-        // todo: serialize as CloudEvents
-        return objectMapper.writeValueAsBytes(payload);
+    private <E extends Event> byte[] serialize(EventEnvelope<E> envelope) throws JsonProcessingException {
+        var payload = envelope.getPayload();
+        var json = objectMapper.writeValueAsBytes(payload);
+
+        var cloudEvent = new CloudEventBuilder()
+                .withId(envelope.getId())
+                .withSource(URI.create(hostname))
+                .withTime(OffsetDateTime.ofInstant(Instant.ofEpochMilli(envelope.getAt()), ZoneOffset.UTC))
+                .withType(payload.getClass().getName())
+                .withDataContentType(ContentType.JSON.toString())
+                .withData(json)
+                .build();
+
+        return jsonFormat.serialize(cloudEvent);
     }
 
     private Headers getHeaders() {
-        return null;
+        var h = new Headers();
+        h.add("Content-Type", "application/cloudevents+json");
+        return h;
     }
 }

--- a/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
+++ b/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
@@ -34,6 +34,7 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.Hostname;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -59,7 +60,7 @@ public class NatsPublishingExtension implements ServiceExtension {
     private Options authenticationOptions;
 
     @Inject
-    private ObjectMapper objectMapper;
+    private TypeManager typeManager;
 
     @Inject
     private Hostname hostname;
@@ -73,31 +74,12 @@ public class NatsPublishingExtension implements ServiceExtension {
 
     @Override
     public void prepare() {
-
-        var builder = authenticationOptions != null ? new Options.Builder(authenticationOptions) : new Options.Builder();
-
-        var optionsBuilder = builder
-                .server(natsConfig.natsUrl)
-                .maxReconnects(-1)
-                .reconnectWait(Duration.ofSeconds(1))
-                .maxPingsOut(5)
-                .pingInterval(Duration.ofSeconds(20));
-
         try {
-            natsConnection = Nats.connect(optionsBuilder.build());
+            var natsEventPublisher = new NatsEventPublisher(monitor.withPrefix("NATS events"),
+                    natsConnection.jetStream(), typeManager.getMapper(), hostname.get());
+            eventRouter.register(Event.class, natsEventPublisher);
         } catch (IOException e) {
-            monitor.severe("Error connecting to NATS", e);
             throw new EdcException("Error connecting to NATS", e);
-        } catch (InterruptedException e) {
-            throw new EdcException(e);
-        }
-        if (natsConfig.createStream) {
-            try {
-                createStream(natsConfig, natsConnection);
-            } catch (Exception e) {
-                monitor.severe("Error creating NATS stream", e);
-                throw new EdcException("Error creating NATS stream", e);
-            }
         }
 
     }
@@ -131,13 +113,32 @@ public class NatsPublishingExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
+        var builder = authenticationOptions != null ? new Options.Builder(authenticationOptions) : new Options.Builder();
+
+        var optionsBuilder = builder
+                .server(natsConfig.natsUrl)
+                .maxReconnects(-1)
+                .reconnectWait(Duration.ofSeconds(1))
+                .maxPingsOut(5)
+                .pingInterval(Duration.ofSeconds(20));
+
         try {
-            var natsEventPublisher = new NatsEventPublisher(context.getMonitor().withPrefix("NATS events"),
-                    natsConnection.jetStream(), objectMapper, hostname.get());
-            eventRouter.register(Event.class, natsEventPublisher);
+            natsConnection = Nats.connect(optionsBuilder.build());
         } catch (IOException e) {
+            monitor.severe("Error connecting to NATS", e);
             throw new EdcException("Error connecting to NATS", e);
+        } catch (InterruptedException e) {
+            throw new EdcException(e);
         }
+        if (natsConfig.createStream) {
+            try {
+                createStream(natsConfig, natsConnection);
+            } catch (Exception e) {
+                monitor.severe("Error creating NATS stream", e);
+                throw new EdcException("Error creating NATS stream", e);
+            }
+        }
+
     }
 
     @Override
@@ -152,10 +153,10 @@ public class NatsPublishingExtension implements ServiceExtension {
     }
 
     @Settings
-    public record NatsConfig(@Setting(key = "nats.url", description = "The URL of the NATS server'") String natsUrl,
-                             @Setting(key = "nats.event.stream", description = "The name of the NATS stream to use for event publishing'") String natsStreamName,
-                             @Setting(key = "nats.event.stream.create", required = false, description = "If the stream should be attempted to be created. May fail if the stream exists.'", defaultValue = "true") boolean createStream,
-                             @Setting(key = "nats.event.stream.create.force", required = false, description = "If the stream should be created if it does not exist'", defaultValue = "true") boolean createStreamForce,
-                             @Setting(key = "nats.event.async", required = false, description = "Whether events should be published synchronously or asynchronously'", defaultValue = "true") boolean publishNatsEventAsync) {
+    public record NatsConfig(
+            @Setting(key = "edc.events.nats.url", description = "The URL of the NATS server'") String natsUrl,
+            @Setting(key = "edc.events.nats.stream", description = "The name of the NATS stream to use for event publishing'") String natsStreamName,
+            @Setting(key = "edc.events.nats.stream.create", required = false, description = "If the stream should be attempted to be created. May fail if the stream exists.'", defaultValue = "true") boolean createStream,
+            @Setting(key = "edc.events.nats.stream.create.force", required = false, description = "If the stream should be created if it does not exist'", defaultValue = "true") boolean createStreamForce) {
     }
 }

--- a/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
+++ b/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
@@ -43,6 +43,7 @@ import static org.eclipse.edc.event.nats.NatsPublishingExtension.NAME;
 @Extension(value = NAME)
 public class NatsPublishingExtension implements ServiceExtension {
     public static final String NAME = "NATS Event Publishing Extension";
+    // NATS error code for stream name in use
     private static final int ERR_STREAM_NAME_IN_USE = 10058;
 
     @Configuration
@@ -100,6 +101,7 @@ public class NatsPublishingExtension implements ServiceExtension {
             monitor.severe("Error connecting to NATS", e);
             throw new EdcException("Error connecting to NATS", e);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new EdcException(e);
         }
         if (natsConfig.createStream) {
@@ -119,6 +121,7 @@ public class NatsPublishingExtension implements ServiceExtension {
             try {
                 natsConnection.close();
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 monitor.warning("Error closing NATS connection during shutdown", e);
             }
         }
@@ -130,7 +133,7 @@ public class NatsPublishingExtension implements ServiceExtension {
                 .name(natsConfig.natsStreamName)
                 .subjects(Constants.EVENTS_PREFIX)
                 .storageType(StorageType.Memory)
-                .retentionPolicy(RetentionPolicy.Interest) // messages are removed only when _all_ subscribers have ack'd
+                .retentionPolicy(RetentionPolicy.Interest) // messages are removed only when _all current_ subscribers have received them
                 .build();
         try {
             jsm.addStream(streamConfig);
@@ -156,6 +159,6 @@ public class NatsPublishingExtension implements ServiceExtension {
             @Setting(key = "edc.events.nats.url", description = "The URL of the NATS server'") String natsUrl,
             @Setting(key = "edc.events.nats.stream", description = "The name of the NATS stream to use for event publishing'") String natsStreamName,
             @Setting(key = "edc.events.nats.stream.create", required = false, description = "If the stream should be attempted to be created. May fail if the stream exists.'", defaultValue = "true") boolean createStream,
-            @Setting(key = "edc.events.nats.stream.create.force", required = false, description = "If the stream should be created, and overwritten if it exists'", defaultValue = "true") boolean createStreamForce) {
+            @Setting(key = "edc.events.nats.stream.create.force", required = false, description = "If the stream should be created, and overwritten if it exists'", defaultValue = "false") boolean createStreamForce) {
     }
 }

--- a/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
+++ b/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
@@ -31,13 +31,13 @@ import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.Hostname;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 
 import java.io.IOException;
 import java.time.Duration;
 
-import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.event.nats.NatsPublishingExtension.NAME;
 
 @Extension(value = NAME)
@@ -60,6 +60,9 @@ public class NatsPublishingExtension implements ServiceExtension {
 
     @Inject
     private ObjectMapper objectMapper;
+
+    @Inject
+    private Hostname hostname;
 
     private Connection natsConnection;
 
@@ -129,7 +132,8 @@ public class NatsPublishingExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         try {
-            var natsEventPublisher = new NatsEventPublisher(context.getMonitor().withPrefix("NATS events"), natsConnection.jetStream(), objectMapper);
+            var natsEventPublisher = new NatsEventPublisher(context.getMonitor().withPrefix("NATS events"),
+                    natsConnection.jetStream(), objectMapper, hostname.get());
             eventRouter.register(Event.class, natsEventPublisher);
         } catch (IOException e) {
             throw new EdcException("Error connecting to NATS", e);

--- a/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
+++ b/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
@@ -157,6 +157,6 @@ public class NatsPublishingExtension implements ServiceExtension {
             @Setting(key = "edc.events.nats.url", description = "The URL of the NATS server'") String natsUrl,
             @Setting(key = "edc.events.nats.stream", description = "The name of the NATS stream to use for event publishing'") String natsStreamName,
             @Setting(key = "edc.events.nats.stream.create", required = false, description = "If the stream should be attempted to be created. May fail if the stream exists.'", defaultValue = "true") boolean createStream,
-            @Setting(key = "edc.events.nats.stream.create.force", required = false, description = "If the stream should be created if it does not exist'", defaultValue = "true") boolean createStreamForce) {
+            @Setting(key = "edc.events.nats.stream.create.force", required = false, description = "If the stream should be created, and overwritten if it exists'", defaultValue = "true") boolean createStreamForce) {
     }
 }

--- a/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
+++ b/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
@@ -142,7 +142,7 @@ public class NatsPublishingExtension implements ServiceExtension {
                     jsm.deleteStream(natsConfig.natsStreamName);
                     jsm.addStream(streamConfig);
                 } else {
-                    var msg = "NATS stream already exists and force create ('nats.event.stream.create.force') is disabled";
+                    var msg = "NATS stream already exists and force create ('edc.events.nats.stream.create.force') is disabled";
                     monitor.severe(msg);
                     throw new EdcException(msg, e);
                 }

--- a/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
+++ b/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
@@ -1,0 +1,157 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.event.nats;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.nats.client.Connection;
+import io.nats.client.JetStreamApiException;
+import io.nats.client.Nats;
+import io.nats.client.Options;
+import io.nats.client.api.RetentionPolicy;
+import io.nats.client.api.StorageType;
+import io.nats.client.api.StreamConfiguration;
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventRouter;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import static java.util.Optional.ofNullable;
+import static org.eclipse.edc.event.nats.NatsPublishingExtension.NAME;
+
+@Extension(value = NAME)
+public class NatsPublishingExtension implements ServiceExtension {
+    public static final String NAME = "NATS Event Publishing Extension";
+    private static final int ERR_STREAM_NAME_IN_USE = 10058;
+
+    @Configuration
+    private NatsConfig natsConfig;
+
+    @Inject
+    private EventRouter eventRouter;
+
+    @Inject
+    private Monitor monitor;
+
+    // authentication options can be contributed from the outside. Note that the 'server' will be overwritten!
+    @Inject(required = false)
+    private Options authenticationOptions;
+
+    @Inject
+    private ObjectMapper objectMapper;
+
+    private Connection natsConnection;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void prepare() {
+
+        var builder = authenticationOptions != null ? new Options.Builder(authenticationOptions) : new Options.Builder();
+
+        var optionsBuilder = builder
+                .server(natsConfig.natsUrl)
+                .maxReconnects(-1)
+                .reconnectWait(Duration.ofSeconds(1))
+                .maxPingsOut(5)
+                .pingInterval(Duration.ofSeconds(20));
+
+        try {
+            natsConnection = Nats.connect(optionsBuilder.build());
+        } catch (IOException e) {
+            monitor.severe("Error connecting to NATS", e);
+            throw new EdcException("Error connecting to NATS", e);
+        } catch (InterruptedException e) {
+            throw new EdcException(e);
+        }
+        if (natsConfig.createStream) {
+            try {
+                createStream(natsConfig, natsConnection);
+            } catch (Exception e) {
+                monitor.severe("Error creating NATS stream", e);
+                throw new EdcException("Error creating NATS stream", e);
+            }
+        }
+
+    }
+
+    private void createStream(NatsConfig natsConfig, Connection natsConnection) throws Exception {
+        var jsm = natsConnection.jetStreamManagement();
+        var streamConfig = StreamConfiguration.builder()
+                .name(natsConfig.natsStreamName)
+                .subjects(Constants.EVENTS_PREFIX)
+                .storageType(StorageType.Memory)
+                .retentionPolicy(RetentionPolicy.Interest) // messages are removed only when _all_ subscribers have ack'd
+                .build();
+        try {
+            jsm.addStream(streamConfig);
+        } catch (JetStreamApiException e) {
+            if (e.getApiErrorCode() == ERR_STREAM_NAME_IN_USE) {
+                if (natsConfig.createStreamForce) {
+                    monitor.debug("NATS stream '%s' already exists, deleting and recreating".formatted(natsConfig.natsStreamName));
+                    jsm.deleteStream(natsConfig.natsStreamName);
+                    jsm.addStream(streamConfig);
+                } else {
+                    var msg = "NATS stream already exists and force create ('nats.event.stream.create.force') is disabled";
+                    monitor.severe(msg);
+                    throw new EdcException(msg, e);
+                }
+            } else {
+                throw new EdcException("Error creating NATS stream", e);
+            }
+        }
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        try {
+            var natsEventPublisher = new NatsEventPublisher(context.getMonitor().withPrefix("NATS events"), natsConnection.jetStream(), objectMapper);
+            eventRouter.register(Event.class, natsEventPublisher);
+        } catch (IOException e) {
+            throw new EdcException("Error connecting to NATS", e);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        if (natsConnection != null) {
+            try {
+                natsConnection.close();
+            } catch (InterruptedException e) {
+                monitor.warning("Error closing NATS connection during shutdown", e);
+            }
+        }
+    }
+
+    @Settings
+    public record NatsConfig(@Setting(key = "nats.url", description = "The URL of the NATS server'") String natsUrl,
+                             @Setting(key = "nats.event.stream", description = "The name of the NATS stream to use for event publishing'") String natsStreamName,
+                             @Setting(key = "nats.event.stream.create", required = false, description = "If the stream should be attempted to be created. May fail if the stream exists.'", defaultValue = "true") boolean createStream,
+                             @Setting(key = "nats.event.stream.create.force", required = false, description = "If the stream should be created if it does not exist'", defaultValue = "true") boolean createStreamForce,
+                             @Setting(key = "nats.event.async", required = false, description = "Whether events should be published synchronously or asynchronously'", defaultValue = "true") boolean publishNatsEventAsync) {
+    }
+}

--- a/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
+++ b/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.event.nats;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.nats.client.Connection;
 import io.nats.client.JetStreamApiException;
 import io.nats.client.Nats;

--- a/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
+++ b/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
@@ -84,33 +84,6 @@ public class NatsPublishingExtension implements ServiceExtension {
 
     }
 
-    private void createStream(NatsConfig natsConfig, Connection natsConnection) throws Exception {
-        var jsm = natsConnection.jetStreamManagement();
-        var streamConfig = StreamConfiguration.builder()
-                .name(natsConfig.natsStreamName)
-                .subjects(Constants.EVENTS_PREFIX)
-                .storageType(StorageType.Memory)
-                .retentionPolicy(RetentionPolicy.Interest) // messages are removed only when _all_ subscribers have ack'd
-                .build();
-        try {
-            jsm.addStream(streamConfig);
-        } catch (JetStreamApiException e) {
-            if (e.getApiErrorCode() == ERR_STREAM_NAME_IN_USE) {
-                if (natsConfig.createStreamForce) {
-                    monitor.debug("NATS stream '%s' already exists, deleting and recreating".formatted(natsConfig.natsStreamName));
-                    jsm.deleteStream(natsConfig.natsStreamName);
-                    jsm.addStream(streamConfig);
-                } else {
-                    var msg = "NATS stream already exists and force create ('nats.event.stream.create.force') is disabled";
-                    monitor.severe(msg);
-                    throw new EdcException(msg, e);
-                }
-            } else {
-                throw new EdcException("Error creating NATS stream", e);
-            }
-        }
-    }
-
     @Override
     public void initialize(ServiceExtensionContext context) {
         var builder = authenticationOptions != null ? new Options.Builder(authenticationOptions) : new Options.Builder();
@@ -148,6 +121,33 @@ public class NatsPublishingExtension implements ServiceExtension {
                 natsConnection.close();
             } catch (InterruptedException e) {
                 monitor.warning("Error closing NATS connection during shutdown", e);
+            }
+        }
+    }
+
+    private void createStream(NatsConfig natsConfig, Connection natsConnection) throws Exception {
+        var jsm = natsConnection.jetStreamManagement();
+        var streamConfig = StreamConfiguration.builder()
+                .name(natsConfig.natsStreamName)
+                .subjects(Constants.EVENTS_PREFIX)
+                .storageType(StorageType.Memory)
+                .retentionPolicy(RetentionPolicy.Interest) // messages are removed only when _all_ subscribers have ack'd
+                .build();
+        try {
+            jsm.addStream(streamConfig);
+        } catch (JetStreamApiException e) {
+            if (e.getApiErrorCode() == ERR_STREAM_NAME_IN_USE) {
+                if (natsConfig.createStreamForce) {
+                    monitor.debug("NATS stream '%s' already exists, deleting and recreating".formatted(natsConfig.natsStreamName));
+                    jsm.deleteStream(natsConfig.natsStreamName);
+                    jsm.addStream(streamConfig);
+                } else {
+                    var msg = "NATS stream already exists and force create ('nats.event.stream.create.force') is disabled";
+                    monitor.severe(msg);
+                    throw new EdcException(msg, e);
+                }
+            } else {
+                throw new EdcException("Error creating NATS stream", e);
             }
         }
     }

--- a/extensions/common/events/events-nats/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/common/events/events-nats/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Microsoft Corporation - Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#
+
+org.eclipse.edc.event.nats.NatsPublishingExtension

--- a/extensions/common/events/events-nats/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/common/events/events-nats/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2026 Metaform Systems, Inc.
 #
 #  This program and the accompanying materials are made available under the
 #  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 #  Contributors:
-#       Microsoft Corporation - Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#       2026 Metaform Systems, Inc. - initial API and implementation
 #
 #
 

--- a/extensions/common/events/events-nats/src/test/java/org/eclipse/edc/event/nats/NatsEventPublisherTest.java
+++ b/extensions/common/events/events-nats/src/test/java/org/eclipse/edc/event/nats/NatsEventPublisherTest.java
@@ -41,7 +41,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@EndToEndTest
 class NatsEventPublisherTest {
     private final JetStream jetstream = mock();
     private final Monitor monitor = mock();

--- a/extensions/common/events/events-nats/src/test/java/org/eclipse/edc/event/nats/NatsEventPublisherTest.java
+++ b/extensions/common/events/events-nats/src/test/java/org/eclipse/edc/event/nats/NatsEventPublisherTest.java
@@ -21,7 +21,6 @@ import io.nats.client.JetStreamApiException;
 import io.nats.client.PublishOptions;
 import io.nats.client.api.Error;
 import io.nats.client.impl.Headers;
-import io.nats.client.support.Status;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventEnvelope;
@@ -47,7 +46,6 @@ class NatsEventPublisherTest {
     private final JetStream jetstream = mock();
     private final Monitor monitor = mock();
     private final NatsEventPublisher natsEventPublisher = new NatsEventPublisher(monitor, jetstream, new ObjectMapper(), "localhost/test");
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     void onEvent_shouldPublish() throws JetStreamApiException, IOException {

--- a/extensions/common/events/events-nats/src/test/java/org/eclipse/edc/event/nats/NatsEventPublisherTest.java
+++ b/extensions/common/events/events-nats/src/test/java/org/eclipse/edc/event/nats/NatsEventPublisherTest.java
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.event.nats;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.nats.client.JetStream;
+import io.nats.client.JetStreamApiException;
+import io.nats.client.PublishOptions;
+import io.nats.client.api.Error;
+import io.nats.client.impl.Headers;
+import io.nats.client.support.Status;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@EndToEndTest
+class NatsEventPublisherTest {
+    private final JetStream jetstream = mock();
+    private final Monitor monitor = mock();
+    private final NatsEventPublisher natsEventPublisher = new NatsEventPublisher(monitor, jetstream, new ObjectMapper(), "localhost/test");
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void onEvent_shouldPublish() throws JetStreamApiException, IOException {
+        natsEventPublisher.on(payload(new DummyEvent("foobar")));
+
+        verify(monitor, never()).severe(anyString(), isA(Throwable[].class));
+        verify(jetstream).publish(eq("events.dummy.foobar"), any(Headers.class), notNull(), any(PublishOptions.class));
+    }
+
+
+    @Test
+    void onEvent_publishFails() throws JetStreamApiException, IOException {
+        when(jetstream.publish(anyString(), any(Headers.class), any(byte[].class), any(PublishOptions.class)))
+                .thenThrow(new JetStreamApiException(Error.JsBadRequestErr));
+
+        natsEventPublisher.on(payload(new DummyEvent("foobar")));
+
+        verify(monitor).severe(anyString(), isA(JetStreamApiException.class));
+        verify(jetstream).publish(eq("events.dummy.foobar"), any(Headers.class), notNull(), any(PublishOptions.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    private EventEnvelope<Event> payload(DummyEvent foobar) {
+        return EventEnvelope.Builder.newInstance()
+                .at(Instant.now().toEpochMilli())
+                .id(UUID.randomUUID().toString())
+                .payload(foobar)
+                .build();
+    }
+
+    public static class DummyEvent extends Event {
+
+        private String data;
+
+        DummyEvent(String data) {
+            this.data = data;
+        }
+
+        @Override
+        public String name() {
+            return "dummy.foobar";
+        }
+
+        public String getData() {
+            return data;
+        }
+    }
+}

--- a/extensions/common/events/events-nats/src/test/java/org/eclipse/edc/event/nats/NatsEventPublisherTest.java
+++ b/extensions/common/events/events-nats/src/test/java/org/eclipse/edc/event/nats/NatsEventPublisherTest.java
@@ -21,7 +21,6 @@ import io.nats.client.JetStreamApiException;
 import io.nats.client.PublishOptions;
 import io.nats.client.api.Error;
 import io.nats.client.impl.Headers;
-import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.monitor.Monitor;

--- a/extensions/common/events/events-nats/src/test/java/org/eclipse/edc/event/nats/NatsPublishingExtensionTest.java
+++ b/extensions/common/events/events-nats/src/test/java/org/eclipse/edc/event/nats/NatsPublishingExtensionTest.java
@@ -1,0 +1,192 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.event.nats;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.nats.client.JetStreamApiException;
+import io.nats.client.Nats;
+import io.nats.client.Options;
+import io.nats.client.api.StreamConfiguration;
+import org.eclipse.edc.boot.system.injection.ObjectFactory;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventRouter;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@Testcontainers
+@EndToEndTest
+@ExtendWith(DependencyInjectionExtension.class)
+class NatsPublishingExtensionTest {
+    private final EventRouter eventRouter = mock();
+
+    @Container
+    static GenericContainer<?> nats = new GenericContainer<>("nats:latest")
+            .withCommand("-js")
+            .withExposedPorts(4222);
+
+    @BeforeAll
+    static void setup() {
+        nats.start();
+        nats.waitingFor(Wait.forListeningPort());
+    }
+
+    @AfterAll
+    static void teardown() {
+        nats.stop();
+    }
+
+    @BeforeEach
+    void setUp(ServiceExtensionContext context) {
+        context.registerService(EventRouter.class, eventRouter);
+        context.registerService(ObjectMapper.class, new ObjectMapper());
+        context.registerService(Options.class, null);
+    }
+
+    @AfterEach
+    void cleanup() throws IOException, InterruptedException, JetStreamApiException {
+        try (var nc = Nats.connect("nats://localhost:" + nats.getMappedPort(4222))) {
+            var jsm = nc.jetStreamManagement();
+            for (String stream : jsm.getStreamNames()) {
+                jsm.deleteStream(stream);
+            }
+        }
+    }
+
+    @Test
+    void prepare(ServiceExtensionContext context, ObjectFactory factory) {
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
+                "nats.url", "nats://localhost:" + nats.getMappedPort(4222),
+                "nats.event.stream", "test-stream",
+                "nats.event.stream.create", "true"
+        )));
+        var ext = factory.constructInstance(NatsPublishingExtension.class);
+        assertThatNoException().isThrownBy(ext::prepare);
+    }
+
+    @Test
+    void prepare_natsConnectionFails(ServiceExtensionContext context, ObjectFactory factory) {
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
+                "nats.url", "nats://localhost:4222",
+                "nats.event.stream", "test-stream",
+                "nats.event.stream.forcecreate", "true"
+        )));
+        var ext = factory.constructInstance(NatsPublishingExtension.class);
+        assertThatExceptionOfType(EdcException.class).isThrownBy(ext::prepare);
+    }
+
+    @Test
+    void prepare_noCreateStream(ServiceExtensionContext context, ObjectFactory factory) {
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
+                "nats.url", "nats://localhost:" + nats.getMappedPort(4222),
+                "nats.event.stream", "test-stream",
+                "nats.event.stream.create", "false"
+        )));
+        var ext = factory.constructInstance(NatsPublishingExtension.class);
+        assertThatNoException().isThrownBy(ext::prepare);
+    }
+
+    @Test
+    void prepare_streamExists_noForce(ServiceExtensionContext context, ObjectFactory factory) throws Exception {
+        var streamName = UUID.randomUUID().toString();
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
+                "nats.url", "nats://localhost:" + nats.getMappedPort(4222),
+                "nats.event.stream", streamName,
+                "nats.event.stream.create", "true",
+                "nats.event.stream.create.force", "false"
+        )));
+
+        // create stream - will cause collision
+        try (var conn = Nats.connect("localhost:" + nats.getMappedPort(4222))) {
+            var jsm = conn.jetStreamManagement();
+            jsm.addStream(StreamConfiguration.builder().name(streamName).build());
+
+            var ext = factory.constructInstance(NatsPublishingExtension.class);
+            assertThatExceptionOfType(EdcException.class).isThrownBy(ext::prepare);
+        }
+    }
+
+    @Test
+    void prepare_streamExists_withForce(ServiceExtensionContext context, ObjectFactory factory) throws Exception {
+        var streamName = UUID.randomUUID().toString();
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
+                "nats.url", "nats://localhost:" + nats.getMappedPort(4222),
+                "nats.event.stream", streamName,
+                "nats.event.stream.create", "true",
+                "nats.event.stream.create.force", "true"
+        )));
+
+        // create stream - will cause collision
+        try (var conn = Nats.connect("localhost:" + nats.getMappedPort(4222))) {
+            var jsm = conn.jetStreamManagement();
+            jsm.addStream(StreamConfiguration.builder().name(streamName).build());
+        }
+
+        var ext = factory.constructInstance(NatsPublishingExtension.class);
+        assertThatNoException().isThrownBy(ext::prepare);
+    }
+
+
+    @Test
+    void initialize(ServiceExtensionContext context, ObjectFactory factory) throws Exception {
+        var streamName = UUID.randomUUID().toString();
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
+                "nats.url", "nats://localhost:" + nats.getMappedPort(4222),
+                "nats.event.stream", streamName,
+                "nats.event.stream.create", "true",
+                "nats.event.stream.create.force", "true"
+        )));
+
+        // create stream - will cause collision
+        try (var conn = Nats.connect("localhost:" + nats.getMappedPort(4222))) {
+            var jsm = conn.jetStreamManagement();
+            jsm.addStream(StreamConfiguration.builder().name(streamName).build());
+        }
+
+        var ext = factory.constructInstance(NatsPublishingExtension.class);
+        assertThatNoException().isThrownBy(ext::prepare);
+        assertThatNoException().isThrownBy(() -> ext.initialize(context));
+
+        verify(eventRouter).register(eq(Event.class), isA(NatsEventPublisher.class));
+    }
+}

--- a/extensions/common/events/events-nats/src/test/java/org/eclipse/edc/event/nats/NatsPublishingExtensionTest.java
+++ b/extensions/common/events/events-nats/src/test/java/org/eclipse/edc/event/nats/NatsPublishingExtensionTest.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edcnats;
+package org.eclipse.edc.event.nats;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.nats.client.JetStreamApiException;
@@ -20,8 +20,6 @@ import io.nats.client.Nats;
 import io.nats.client.Options;
 import io.nats.client.api.StreamConfiguration;
 import org.eclipse.edc.boot.system.injection.ObjectFactory;
-import org.eclipse.edc.event.nats.NatsEventPublisher;
-import org.eclipse.edc.event.nats.NatsPublishingExtension;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.EdcException;
@@ -66,8 +64,8 @@ class NatsPublishingExtensionTest {
 
     @BeforeAll
     static void setup() {
-        nats.start();
         nats.waitingFor(Wait.forListeningPort());
+        nats.start();
     }
 
     @AfterAll

--- a/extensions/common/events/events-nats/src/test/java/org/eclipse/edc/event/nats/NatsPublishingExtensionTest.java
+++ b/extensions/common/events/events-nats/src/test/java/org/eclipse/edc/event/nats/NatsPublishingExtensionTest.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.event.nats;
+package org.eclipse.edcnats;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.nats.client.JetStreamApiException;
@@ -20,6 +20,8 @@ import io.nats.client.Nats;
 import io.nats.client.Options;
 import io.nats.client.api.StreamConfiguration;
 import org.eclipse.edc.boot.system.injection.ObjectFactory;
+import org.eclipse.edc.event.nats.NatsEventPublisher;
+import org.eclipse.edc.event.nats.NatsPublishingExtension;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.EdcException;
@@ -33,7 +35,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatchers;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
@@ -45,9 +46,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -94,46 +93,46 @@ class NatsPublishingExtensionTest {
     }
 
     @Test
-    void prepare(ServiceExtensionContext context, ObjectFactory factory) {
+    void initialize(ServiceExtensionContext context, ObjectFactory factory) {
         when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
-                "nats.url", "nats://localhost:" + nats.getMappedPort(4222),
-                "nats.event.stream", "test-stream",
-                "nats.event.stream.create", "true"
+                "edc.events.nats.url", "nats://localhost:" + nats.getMappedPort(4222),
+                "edc.events.nats.stream", "test-stream",
+                "edc.events.nats.stream.create", "true"
         )));
         var ext = factory.constructInstance(NatsPublishingExtension.class);
-        assertThatNoException().isThrownBy(ext::prepare);
+        assertThatNoException().isThrownBy(() -> ext.initialize(context));
     }
 
     @Test
-    void prepare_natsConnectionFails(ServiceExtensionContext context, ObjectFactory factory) {
+    void initialize_natsConnectionFails(ServiceExtensionContext context, ObjectFactory factory) {
         when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
-                "nats.url", "nats://localhost:4222",
-                "nats.event.stream", "test-stream",
-                "nats.event.stream.forcecreate", "true"
+                "edc.events.nats.url", "nats://localhost:4222",
+                "edc.events.nats.stream", "test-stream",
+                "edc.events.nats.stream.create.force", "true"
         )));
         var ext = factory.constructInstance(NatsPublishingExtension.class);
-        assertThatExceptionOfType(EdcException.class).isThrownBy(ext::prepare);
+        assertThatExceptionOfType(EdcException.class).isThrownBy(() -> ext.initialize(context));
     }
 
     @Test
-    void prepare_noCreateStream(ServiceExtensionContext context, ObjectFactory factory) {
+    void initialize_noCreateStream(ServiceExtensionContext context, ObjectFactory factory) {
         when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
-                "nats.url", "nats://localhost:" + nats.getMappedPort(4222),
-                "nats.event.stream", "test-stream",
-                "nats.event.stream.create", "false"
+                "edc.events.nats.url", "nats://localhost:" + nats.getMappedPort(4222),
+                "edc.events.nats.stream", "test-stream",
+                "edc.events.nats.stream.create", "false"
         )));
         var ext = factory.constructInstance(NatsPublishingExtension.class);
-        assertThatNoException().isThrownBy(ext::prepare);
+        assertThatNoException().isThrownBy(() -> ext.initialize(context));
     }
 
     @Test
-    void prepare_streamExists_noForce(ServiceExtensionContext context, ObjectFactory factory) throws Exception {
+    void initialize_streamExists_noForce(ServiceExtensionContext context, ObjectFactory factory) throws Exception {
         var streamName = UUID.randomUUID().toString();
         when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
-                "nats.url", "nats://localhost:" + nats.getMappedPort(4222),
-                "nats.event.stream", streamName,
-                "nats.event.stream.create", "true",
-                "nats.event.stream.create.force", "false"
+                "edc.events.nats.url", "nats://localhost:" + nats.getMappedPort(4222),
+                "edc.events.nats.stream", streamName,
+                "edc.events.nats.stream.create", "true",
+                "edc.events.nats.stream.create.force", "false"
         )));
 
         // create stream - will cause collision
@@ -142,18 +141,18 @@ class NatsPublishingExtensionTest {
             jsm.addStream(StreamConfiguration.builder().name(streamName).build());
 
             var ext = factory.constructInstance(NatsPublishingExtension.class);
-            assertThatExceptionOfType(EdcException.class).isThrownBy(ext::prepare);
+            assertThatExceptionOfType(EdcException.class).isThrownBy(() -> ext.initialize(context));
         }
     }
 
     @Test
-    void prepare_streamExists_withForce(ServiceExtensionContext context, ObjectFactory factory) throws Exception {
+    void initialize_streamExists_withForce(ServiceExtensionContext context, ObjectFactory factory) throws Exception {
         var streamName = UUID.randomUUID().toString();
         when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
-                "nats.url", "nats://localhost:" + nats.getMappedPort(4222),
-                "nats.event.stream", streamName,
-                "nats.event.stream.create", "true",
-                "nats.event.stream.create.force", "true"
+                "edc.events.nats.url", "nats://localhost:" + nats.getMappedPort(4222),
+                "edc.events.nats.stream", streamName,
+                "edc.events.nats.stream.create", "true",
+                "edc.events.nats.stream.create.force", "true"
         )));
 
         // create stream - will cause collision
@@ -163,29 +162,29 @@ class NatsPublishingExtensionTest {
         }
 
         var ext = factory.constructInstance(NatsPublishingExtension.class);
-        assertThatNoException().isThrownBy(ext::prepare);
-    }
-
-
-    @Test
-    void initialize(ServiceExtensionContext context, ObjectFactory factory) throws Exception {
-        var streamName = UUID.randomUUID().toString();
-        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
-                "nats.url", "nats://localhost:" + nats.getMappedPort(4222),
-                "nats.event.stream", streamName,
-                "nats.event.stream.create", "true",
-                "nats.event.stream.create.force", "true"
-        )));
-
-        // create stream - will cause collision
-        try (var conn = Nats.connect("localhost:" + nats.getMappedPort(4222))) {
-            var jsm = conn.jetStreamManagement();
-            jsm.addStream(StreamConfiguration.builder().name(streamName).build());
-        }
-
-        var ext = factory.constructInstance(NatsPublishingExtension.class);
-        assertThatNoException().isThrownBy(ext::prepare);
         assertThatNoException().isThrownBy(() -> ext.initialize(context));
+    }
+
+
+    @Test
+    void prepare(ServiceExtensionContext context, ObjectFactory factory) throws Exception {
+        var streamName = UUID.randomUUID().toString();
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(Map.of(
+                "edc.events.nats.url", "nats://localhost:" + nats.getMappedPort(4222),
+                "edc.events.nats.stream", streamName,
+                "edc.events.nats.stream.create", "true",
+                "edc.events.nats.stream.create.force", "true"
+        )));
+
+        // create stream - will cause collision
+        try (var conn = Nats.connect("localhost:" + nats.getMappedPort(4222))) {
+            var jsm = conn.jetStreamManagement();
+            jsm.addStream(StreamConfiguration.builder().name(streamName).build());
+        }
+
+        var ext = factory.constructInstance(NatsPublishingExtension.class);
+        assertThatNoException().isThrownBy(() -> ext.initialize(context));
+        assertThatNoException().isThrownBy(ext::prepare);
 
         verify(eventRouter).register(eq(Event.class), isA(NatsEventPublisher.class));
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,6 +110,7 @@ cloudEvents = { module = "io.cloudevents:cloudevents-http-basic", version.ref = 
 postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
 kafkaClients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafkaClients" }
 jsonschema = { module = "com.networknt:json-schema-validator", version = "2.0.0" }
+nats = { module = "io.nats:jnats", version = "2.25.3" }
 
 # DSP-TCK libraries
 dsp-tck-runtime = { module = "org.eclipse.dataspacetck.dsp:tck-runtime", version.ref = "dsp-tck" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -107,6 +107,7 @@ apache-commons-pool = { module = "org.apache.commons:commons-pool2", version.ref
 atomikos-jta = { module = "com.atomikos:transactions-jta", version.ref = "atomikos" }
 atomikos-jdbc = { module = "com.atomikos:transactions-jdbc", version.ref = "atomikos" }
 cloudEvents = { module = "io.cloudevents:cloudevents-http-basic", version.ref = "cloudEvents" }
+cloudEvents-json = { module = "io.cloudevents:cloudevents-json-jackson", version.ref = "cloudEvents" }
 postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
 kafkaClients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafkaClients" }
 jsonschema = { module = "com.networknt:json-schema-validator", version = "2.0.0" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -340,6 +340,7 @@ include(":spi:federated-catalog-spi")
 
 // modules for system tests ------------------------------------------------------------------------
 include(":system-tests:bom-tests")
+include(":system-tests:nats-events-tests")
 include(":system-tests:e2e-dataplane-tests:runtimes:data-plane")
 include(":system-tests:e2e-dataplane-tests:tests")
 include(":system-tests:e2e-transfer-test:control-plane")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -165,6 +165,7 @@ include(":extensions:common:http:lib:jersey-providers-lib")
 
 include(":extensions:common:configuration:configuration-filesystem")
 include(":extensions:common:events:events-cloud-http")
+include(":extensions:common:events:events-nats")
 include(":extensions:common:http")
 include(":extensions:common:console-monitor")
 include(":extensions:common:otel-monitor")

--- a/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/EventRouter.java
+++ b/spi/common/core-spi/src/main/java/org/eclipse/edc/spi/event/EventRouter.java
@@ -25,7 +25,7 @@ public interface EventRouter {
 
     /**
      * Register a new synchronous subscriber.
-     * The synchronous subscribers are supposed to being notified before the standard subscribers in a synchronous way.
+     * The synchronous subscribers are being notified before the standard subscribers synchronously.
      * If a synchronous subscriber thrown an exception, this will stop the publish operation.
      *
      * @param subscriber that will receive every published event

--- a/system-tests/nats-events-tests/build.gradle.kts
+++ b/system-tests/nats-events-tests/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2026 Metaform Systems, Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       2026 Metaform Systems, Inc. - initial API and implementation
  *
  */
 

--- a/system-tests/nats-events-tests/build.gradle.kts
+++ b/system-tests/nats-events-tests/build.gradle.kts
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+plugins {
+    java
+}
+
+dependencies {
+    testImplementation(project(":core:common:junit"))
+    testImplementation(libs.restAssured)
+    testImplementation(libs.awaitility)
+    testImplementation(libs.testcontainers.junit)
+    testImplementation(libs.nats)
+    testImplementation(libs.cloudEvents.json)
+}
+
+edcBuild {
+    publish.set(false)
+}

--- a/system-tests/nats-events-tests/src/test/java/org/eclipse/edc/test/nats/NatsEventTest.java
+++ b/system-tests/nats-events-tests/src/test/java/org/eclipse/edc/test/nats/NatsEventTest.java
@@ -1,0 +1,171 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.nats;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.jackson.JsonFormat;
+import io.nats.client.JetStream;
+import io.nats.client.JetStreamApiException;
+import io.nats.client.Nats;
+import io.nats.client.PushSubscribeOptions;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HashMap;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.util.io.Ports.getFreePort;
+import static org.hamcrest.Matchers.equalTo;
+
+public class NatsEventTest {
+    public static final String DEFAULT_PORT = "8080";
+    public static final String DEFAULT_PATH = "/api";
+    public static final String MANAGEMENT_PORT = "8081";
+    public static final String MANAGEMENT_PATH = "/api/management";
+    public static final String STREAM_NAME = "test-stream";
+
+    @Container
+    static GenericContainer<?> nats = new GenericContainer<>("nats:latest")
+            .withCommand("-js")
+            .withExposedPorts(4222);
+
+
+    @RegisterExtension
+    protected RuntimeExtension runtime = new RuntimePerMethodExtension(
+            new EmbeddedRuntime("control-plane-with-nats-events", ":dist:bom:controlplane-dcp-bom", ":extensions:common:events:events-nats")
+                    .configurationProvider(() -> ConfigFactory.fromMap(new HashMap<>() {{
+                                put("edc.iam.sts.oauth.token.url", "https://sts.com/token");
+                                put("edc.iam.sts.oauth.client.id", "test-client");
+                                put("edc.iam.sts.oauth.client.secret.alias", "test-alias");
+                                put("web.http.port", DEFAULT_PORT);
+                                put("web.http.path", DEFAULT_PATH);
+                                put("web.http.control.port", String.valueOf(getFreePort()));
+                                put("web.http.control.path", "/api/control");
+                                put("web.http.management.port", MANAGEMENT_PORT);
+                                put("web.http.management.path", MANAGEMENT_PATH);
+                                put("edc.iam.sts.privatekey.alias", "privatekey");
+                                put("edc.iam.sts.publickey.id", "publickey");
+                                put("edc.participant.did", "did:web:someone");
+
+                                // nats-specific config
+                                put("edc.events.nats.url", "nats://localhost:" + nats.getMappedPort(4222));
+                                put("edc.events.nats.stream", STREAM_NAME);
+                                put("edc.events.nats.stream.create", "true");
+                                put("edc.events.nats.stream.create.force", "true");
+                            }})
+                    )
+    );
+
+    @BeforeAll
+    static void setup() {
+        nats.start();
+        nats.waitingFor(Wait.forListeningPort());
+    }
+
+    @AfterAll
+    static void teardown() {
+        nats.stop();
+    }
+
+    @AfterEach
+    void cleanup() throws IOException, InterruptedException, JetStreamApiException {
+        try (var nc = Nats.connect("nats://localhost:" + nats.getMappedPort(4222))) {
+            var jsm = nc.jetStreamManagement();
+            for (String stream : jsm.getStreamNames()) {
+                jsm.deleteStream(stream);
+            }
+        }
+    }
+
+    @Test
+    void publishEvent_expectPublished() throws IOException, JetStreamApiException, InterruptedException {
+        await().untilAsserted(() -> given()
+                .baseUri("http://localhost:" + DEFAULT_PORT + DEFAULT_PATH + "/check/startup")
+                .get()
+                .then()
+                .statusCode(200)
+                .log().ifValidationFails()
+                .body("isSystemHealthy", equalTo(true)));
+
+        //subscribe to the "events.>" subject
+        JetStream js;
+        try (var nc = Nats.connect("nats://localhost:" + nats.getMappedPort(4222))) {
+            js = nc.jetStream();
+            var pushOptions = PushSubscribeOptions.builder()
+                    .stream(STREAM_NAME)
+                    .build();
+            var subscription = js.subscribe("events.>", pushOptions);
+
+
+            // create an asset, expect an event
+            var asset = """
+                    {
+                       "@context": [
+                         "https://w3id.org/edc/connector/management/v2"
+                       ],
+                       "@id": "asset-1",
+                       "@type": "Asset",
+                       "properties": {
+                         "description": "This asset requires Membership to view and Manufacturer (part_types=non_critical) to negotiate."
+                       },
+                       "dataplaneMetadata": {
+                          "@type": "DataplaneMetadata",
+                          "properties": {}
+                       }
+                    }
+                    """;
+            given()
+                    .baseUri("http://localhost:%s%s".formatted(MANAGEMENT_PORT, MANAGEMENT_PATH))
+                    .body(asset)
+                    .contentType("application/json")
+                    .post("/v4/assets")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200);
+
+            // verify that an event was received
+            var message = subscription.nextMessage(Duration.ofMillis(5000));
+            assertThat(message).isNotNull();
+            assertThat(message.getSubject()).isEqualTo("events.asset.created");
+            message.ack();
+
+            // verify the properties of the event
+            var cloudEvent = new JsonFormat().deserialize(message.getData());
+            assertThat(cloudEvent).isNotNull();
+            assertThat(cloudEvent.getType()).isEqualTo("org.eclipse.edc.connector.controlplane.asset.spi.event.AssetCreated");
+            assertThat(cloudEvent.getSource().toString()).isEqualTo("localhost");
+            var json = new String(cloudEvent.getData().toBytes(), StandardCharsets.UTF_8);
+            assertThat(json).matches(".*\"assetId\".*:.*\"asset-1\".*");
+            assertThat(json).matches(".*\"participantContextId\".*:.*\"anonymous\".*");
+        }
+
+    }
+
+}

--- a/system-tests/nats-events-tests/src/test/java/org/eclipse/edc/test/nats/NatsEventTest.java
+++ b/system-tests/nats-events-tests/src/test/java/org/eclipse/edc/test/nats/NatsEventTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.test.nats;
 
-import io.cloudevents.CloudEvent;
 import io.cloudevents.jackson.JsonFormat;
 import io.nats.client.JetStream;
 import io.nats.client.JetStreamApiException;

--- a/system-tests/nats-events-tests/src/test/java/org/eclipse/edc/test/nats/NatsEventTest.java
+++ b/system-tests/nats-events-tests/src/test/java/org/eclipse/edc/test/nats/NatsEventTest.java
@@ -86,8 +86,8 @@ public class NatsEventTest {
 
     @BeforeAll
     static void setup() {
-        nats.start();
         nats.waitingFor(Wait.forListeningPort());
+        nats.start();
     }
 
     @AfterAll

--- a/system-tests/nats-events-tests/src/test/java/org/eclipse/edc/test/nats/NatsEventTest.java
+++ b/system-tests/nats-events-tests/src/test/java/org/eclipse/edc/test/nats/NatsEventTest.java
@@ -19,6 +19,7 @@ import io.nats.client.JetStream;
 import io.nats.client.JetStreamApiException;
 import io.nats.client.Nats;
 import io.nats.client.PushSubscribeOptions;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
@@ -43,6 +44,7 @@ import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 import static org.hamcrest.Matchers.equalTo;
 
+@EndToEndTest
 public class NatsEventTest {
     public static final String DEFAULT_PORT = "8080";
     public static final String DEFAULT_PATH = "/api";


### PR DESCRIPTION
## What this PR changes/adds

this PR publishes all EDC events (subclasses from `Event`) to a NATS stream.

The stream is configurable, but the subject is `"events.<event-name>"`, e.g. `"events.asset.create"`. This allows for an easy subscription mechanism

## Why it does that

to allow operators of EDC to consume events via message passing

## Further notes

NATS was chosen because it is fast, small and easy to set up. In addition, a sister project https://github.com/eclipse-cfm/cfm already uses it with great success, so the integration is easy.

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5739
Closes https://github.com/eclipse-cfm/planning/issues/52

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
