### PR TITLE
feat: add profile field

### DIFF
--- a/core/common/lib/json-ld-lib/src/main/resources/document/management-context-v2.jsonld
+++ b/core/common/lib/json-ld-lib/src/main/resources/document/management-context-v2.jsonld
@@ -244,6 +244,7 @@
         "dataDestination": "edc:dataDestination",
         "contractId": "edc:contractId",
         "protocol": "edc:protocol",
+        "profile": "edc:profile",
         "dataplaneMetadata": {
           "@id": "edc:dataplaneMetadata"
         }

--- a/core/common/lib/json-ld-lib/src/main/resources/document/management-context-v2.jsonld
+++ b/core/common/lib/json-ld-lib/src/main/resources/document/management-context-v2.jsonld
@@ -150,7 +150,8 @@
           "@id": "edc:callbackAddresses",
           "@container": "@set"
         },
-        "protocol": "edc:protocol"
+        "protocol": "edc:protocol",
+        "profile": "edc:profile"
       }
     },
     "QuerySpec": {
@@ -172,6 +173,7 @@
         "type": "edc:type",
         "counterPartyAddress": "edc:counterPartyAddress",
         "protocol": "edc:protocol",
+        "profile": "edc:profile",
         "callbackAddresses": {
           "@id": "edc:callbackAddresses",
           "@container": "@set"

--- a/core/common/lib/json-ld-lib/src/main/resources/document/management-context-v2.jsonld
+++ b/core/common/lib/json-ld-lib/src/main/resources/document/management-context-v2.jsonld
@@ -119,7 +119,8 @@
       "@context": {
         "counterPartyAddress": "edc:counterPartyAddress",
         "counterPartyId": "edc:counterPartyId",
-        "protocol": "edc:protocol"
+        "protocol": "edc:protocol",
+        "profile": "edc:profile"
       }
     },
     "CatalogRequest": {
@@ -128,6 +129,7 @@
         "counterPartyAddress": "edc:counterPartyAddress",
         "counterPartyId": "edc:counterPartyId",
         "protocol": "edc:protocol",
+        "profile": "edc:profile",
         "additionalScopes": {
           "@id": "edc:additionalScopes",
           "@container": "@set"

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/catalog/to/JsonObjectToCatalogRequestTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/catalog/to/JsonObjectToCatalogRequestTransformer.java
@@ -26,6 +26,7 @@ import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_ADDITIONAL_SCOPES;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_COUNTER_PARTY_ADDRESS;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_COUNTER_PARTY_ID;
+import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_PROFILE;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_PROTOCOL;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_QUERY_SPEC;
 
@@ -49,11 +50,13 @@ public class JsonObjectToCatalogRequestTransformer extends AbstractJsonLdTransfo
                 .orElse(null);
 
         var builder = CatalogRequest.Builder.newInstance()
-                .protocol(transformString(object.get(CATALOG_REQUEST_PROTOCOL), context))
+
                 .counterPartyAddress(counterPartyAddress)
                 .counterPartyId(counterPartyId)
                 .querySpec(querySpec);
 
+        ofNullable(transformString(object.get(CATALOG_REQUEST_PROTOCOL), context)).ifPresent(builder::protocol);
+        ofNullable(transformString(object.get(CATALOG_REQUEST_PROFILE), context)).ifPresent(builder::profile);
 
         ofNullable(object.getJsonArray(CATALOG_REQUEST_ADDITIONAL_SCOPES))
                 .ifPresent(ja -> builder.additionalScopes(ja.stream().map(this::nodeValue).toList()));

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/catalog/to/JsonObjectToDatasetRequestTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/catalog/to/JsonObjectToDatasetRequestTransformer.java
@@ -23,8 +23,10 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
+import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_COUNTER_PARTY_ADDRESS;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_COUNTER_PARTY_ID;
+import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_PROFILE;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_PROTOCOL;
 
 public class JsonObjectToDatasetRequestTransformer extends AbstractJsonLdTransformer<JsonObject, DatasetRequest> {
@@ -36,8 +38,10 @@ public class JsonObjectToDatasetRequestTransformer extends AbstractJsonLdTransfo
     @Override
     public @Nullable DatasetRequest transform(@NotNull JsonObject object, @NotNull TransformerContext context) {
         var builder = DatasetRequest.Builder.newInstance()
-                .id(nodeId(object))
-                .protocol(transformString(object.get(DATASET_REQUEST_PROTOCOL), context));
+                .id(nodeId(object));
+
+        ofNullable(transformString(object.get(DATASET_REQUEST_PROTOCOL), context)).ifPresent(builder::protocol);
+        ofNullable(transformString(object.get(DATASET_REQUEST_PROFILE), context)).ifPresent(builder::profile);
 
         var counterPartyAddress = transformString(object.get(DATASET_REQUEST_COUNTER_PARTY_ADDRESS), context);
 

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/contractnegotiation/from/JsonObjectFromContractNegotiationTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/contractnegotiation/from/JsonObjectFromContractNegotiationTransformer.java
@@ -35,6 +35,7 @@ import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiat
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_CREATED_AT;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_ERRORDETAIL;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_NEG_TYPE;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_PROFILE;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_PROTOCOL;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_STATE;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_TYPE;
@@ -62,6 +63,7 @@ public class JsonObjectFromContractNegotiationTransformer extends AbstractJsonLd
                 .add(ID, contractNegotiation.getId())
                 .add(CONTRACT_NEGOTIATION_NEG_TYPE, contractNegotiation.getType().toString())
                 .add(CONTRACT_NEGOTIATION_PROTOCOL, contractNegotiation.getProtocol())
+                .add(CONTRACT_NEGOTIATION_PROFILE, contractNegotiation.getProfile())
                 .add(CONTRACT_NEGOTIATION_STATE, ContractNegotiationStates.from(contractNegotiation.getState()).name())
                 .add(CONTRACT_NEGOTIATION_COUNTERPARTY_ID, contractNegotiation.getCounterPartyId())
                 .add(CONTRACT_NEGOTIATION_COUNTERPARTY_ADDR, contractNegotiation.getCounterPartyAddress())

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/contractnegotiation/to/JsonObjectToContractRequestTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/contractnegotiation/to/JsonObjectToContractRequestTransformer.java
@@ -23,8 +23,10 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest.CALLBACK_ADDRESSES;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest.CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest.CONTRACT_REQUEST_PROFILE;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest.POLICY;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest.PROTOCOL;
 
@@ -37,8 +39,10 @@ public class JsonObjectToContractRequestTransformer extends AbstractJsonLdTransf
     @Override
     public @Nullable ContractRequest transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext context) {
         var contractRequestBuilder = ContractRequest.Builder.newInstance()
-                .counterPartyAddress(transformString(jsonObject.get(CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS), context))
-                .protocol(transformString(jsonObject.get(PROTOCOL), context));
+                .counterPartyAddress(transformString(jsonObject.get(CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS), context));
+        
+        ofNullable(transformString(jsonObject.get(PROTOCOL), context)).ifPresent(contractRequestBuilder::protocol);
+        ofNullable(transformString(jsonObject.get(CONTRACT_REQUEST_PROFILE), context)).ifPresent(contractRequestBuilder::profile);
 
         contractRequestBuilder.contractOffer(contractOffer(jsonObject, context));
 

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/transferprocess/to/JsonObjectToTransferRequestTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/transferprocess/to/JsonObjectToTransferRequestTransformer.java
@@ -39,6 +39,7 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_DATAPLANE_METADATA;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_DATA_DESTINATION;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_PRIVATE_PROPERTIES;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_PROFILE;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_PROTOCOL;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_TRANSFER_TYPE;
 
@@ -66,6 +67,7 @@ public class JsonObjectToTransferRequestTransformer extends AbstractJsonLdTransf
             case TRANSFER_REQUEST_PRIVATE_PROPERTIES -> value ->
                     transformProperties(value, builder::privateProperties, context);
             case TRANSFER_REQUEST_PROTOCOL -> value -> builder.protocol(transformString(value, context));
+            case TRANSFER_REQUEST_PROFILE -> value -> builder.profile(transformString(value, context));
             case TRANSFER_REQUEST_TRANSFER_TYPE -> value ->
                     builder.transferType(transformString(value, context));
             case TRANSFER_REQUEST_DATAPLANE_METADATA -> value ->

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/catalog/to/JsonObjectToCatalogRequestTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/catalog/to/JsonObjectToCatalogRequestTransformerTest.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_ADDITIONAL_SCOPES;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_COUNTER_PARTY_ADDRESS;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_COUNTER_PARTY_ID;
+import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_PROFILE;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_PROTOCOL;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_QUERY_SPEC;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_TYPE;
@@ -67,6 +68,28 @@ class JsonObjectToCatalogRequestTransformerTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getProtocol()).isEqualTo("protocol");
+        assertThat(result.getCounterPartyAddress()).isEqualTo("http://provider/url");
+        assertThat(result.getCounterPartyId()).isEqualTo("http://provider/url");
+        assertThat(result.getQuerySpec()).isEqualTo(querySpec);
+        verify(context).transform(querySpecJson, QuerySpec.class);
+    }
+
+    @Test
+    void transform_withProfile() {
+        var querySpec = QuerySpec.Builder.newInstance().build();
+        var querySpecJson = Json.createObjectBuilder().build();
+        when(context.transform(any(), eq(QuerySpec.class))).thenReturn(querySpec);
+        var json = Json.createObjectBuilder()
+                .add(TYPE, CATALOG_REQUEST_TYPE)
+                .add(CATALOG_REQUEST_PROFILE, "profile")
+                .add(CATALOG_REQUEST_COUNTER_PARTY_ADDRESS, "http://provider/url")
+                .add(CATALOG_REQUEST_QUERY_SPEC, querySpecJson)
+                .build();
+
+        var result = transformer.transform(json, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getProfile()).isEqualTo("profile");
         assertThat(result.getCounterPartyAddress()).isEqualTo("http://provider/url");
         assertThat(result.getCounterPartyId()).isEqualTo("http://provider/url");
         assertThat(result.getQuerySpec()).isEqualTo(querySpec);

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/catalog/to/JsonObjectToDatasetRequestTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/catalog/to/JsonObjectToDatasetRequestTransformerTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_COUNTER_PARTY_ADDRESS;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_COUNTER_PARTY_ID;
+import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_PROFILE;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_PROTOCOL;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
@@ -60,6 +61,26 @@ class JsonObjectToDatasetRequestTransformerTest {
         assertThat(result).isNotNull();
         assertThat(result.getId()).isEqualTo("id");
         assertThat(result.getProtocol()).isEqualTo("protocol");
+        assertThat(result.getCounterPartyAddress()).isEqualTo("http://provider/url");
+        assertThat(result.getCounterPartyId()).isEqualTo("http://provider/url");
+    }
+
+    @Test
+    void transform_withProfile() {
+        var querySpec = QuerySpec.Builder.newInstance().build();
+        when(context.transform(any(), eq(QuerySpec.class))).thenReturn(querySpec);
+        var json = Json.createObjectBuilder()
+                .add(TYPE, DATASET_REQUEST_TYPE)
+                .add(ID, "id")
+                .add(DATASET_REQUEST_PROFILE, "profile")
+                .add(DATASET_REQUEST_COUNTER_PARTY_ADDRESS, "http://provider/url")
+                .build();
+
+        var result = transformer.transform(json, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo("id");
+        assertThat(result.getProfile()).isEqualTo("profile");
         assertThat(result.getCounterPartyAddress()).isEqualTo("http://provider/url");
         assertThat(result.getCounterPartyId()).isEqualTo("http://provider/url");
     }

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/contractnegotiation/from/JsonObjectFromContractNegotiationTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/contractnegotiation/from/JsonObjectFromContractNegotiationTransformerTest.java
@@ -36,6 +36,7 @@ import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiat
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_COUNTERPARTY_ID;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_CREATED_AT;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_NEG_TYPE;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_PROFILE;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_PROTOCOL;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.CONTRACT_NEGOTIATION_STATE;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
@@ -81,6 +82,7 @@ class JsonObjectFromContractNegotiationTransformerTest {
         assertThat(jsonObject.getString(CONTRACT_NEGOTIATION_AGREEMENT_ID)).isEqualTo("test-agreement");
         assertThat(jsonObject.getString(CONTRACT_NEGOTIATION_NEG_TYPE)).isEqualTo("PROVIDER");
         assertThat(jsonObject.getString(CONTRACT_NEGOTIATION_PROTOCOL)).isEqualTo("protocol");
+        assertThat(jsonObject.getString(CONTRACT_NEGOTIATION_PROFILE)).isEqualTo("protocol");
         assertThat(jsonObject.getString(CONTRACT_NEGOTIATION_CORRELATION_ID)).isEqualTo(cn.getCorrelationId());
         assertThat(jsonObject.getString(CONTRACT_NEGOTIATION_ASSET_ID)).isEqualTo(co.getAssetId());
         assertThat(jsonObject.getJsonNumber(CONTRACT_NEGOTIATION_CREATED_AT).longValue()).isEqualTo(1234);

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/contractnegotiation/to/JsonObjectToContractRequestTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/contractnegotiation/to/JsonObjectToContractRequestTransformerTest.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest.CALLBACK_ADDRESSES;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest.CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest.CONTRACT_REQUEST_PROFILE;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest.POLICY;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest.PROTOCOL;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
@@ -89,6 +90,34 @@ class JsonObjectToContractRequestTransformerTest {
         assertThat(request.getCounterPartyAddress()).isEqualTo("test-address");
         assertThat(request.getContractOffer()).isSameAs(offer);
     }
+
+    @Test
+    void transform_withProfile() {
+        var jsonObject = Json.createObjectBuilder()
+                .add(TYPE, ContractRequest.CONTRACT_REQUEST_TYPE)
+                .add(CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS, "test-address")
+                .add(CONTRACT_REQUEST_PROFILE, "test-profile")
+                .add(CALLBACK_ADDRESSES, createCallbackAddress())
+                .add(POLICY, createPolicy())
+                .build();
+        when(context.transform(any(JsonObject.class), eq(CallbackAddress.class))).thenReturn(CallbackAddress.Builder.newInstance()
+                .uri("http://test.local")
+                .events(Set.of("foo", "bar"))
+                .transactional(true)
+                .build());
+        var offer = createContractOffer("test-provider-id");
+        when(context.transform(any(JsonValue.class), eq(ContractOffer.class))).thenReturn(offer);
+
+        var request = transformer.transform(jsonLd.expand(jsonObject).getContent(), context);
+
+        assertThat(request).isNotNull();
+        assertThat(request.getProviderId()).isEqualTo("test-provider-id");
+        assertThat(request.getCallbackAddresses()).isNotEmpty();
+        assertThat(request.getProfile()).isEqualTo("test-profile");
+        assertThat(request.getCounterPartyAddress()).isEqualTo("test-address");
+        assertThat(request.getContractOffer()).isSameAs(offer);
+    }
+
 
     @Test
     void transform_shouldSetProviderIdAsCounterPartyAddress_whenProviderIdNotDefined() {

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/transferprocess/to/JsonObjectToTransferRequestTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/transferprocess/to/JsonObjectToTransferRequestTransformerTest.java
@@ -32,6 +32,7 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_DATAPLANE_METADATA;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_DATA_DESTINATION;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_PRIVATE_PROPERTIES;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_PROFILE;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_PROTOCOL;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_TRANSFER_TYPE;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_TYPE;
@@ -85,6 +86,40 @@ class JsonObjectToTransferRequestTransformerTest {
         assertThat(result.getDataDestination()).isSameAs(dataDestination);
         assertThat(result.getPrivateProperties()).containsAllEntriesOf(privateProperties);
         assertThat(result.getProtocol()).isEqualTo("protocol");
+        assertThat(result.getTransferType()).isEqualTo("Http-Pull");
+        assertThat(result.getDataplaneMetadata()).isSameAs(dataplaneMetadata);
+    }
+
+    @Test
+    void transform_withProfile() {
+        var dataDestinationJson = createObjectBuilder().build();
+        var privatePropertiesJson = createObjectBuilder().add("fooPrivate", "bar").build();
+        var dataDestination = DataAddress.Builder.newInstance().type("type").build();
+        var privateProperties = Map.of("fooPrivate", "bar");
+        when(context.transform(any(), eq(DataAddress.class))).thenReturn(dataDestination);
+        var dataplaneMetadata = DataplaneMetadata.Builder.newInstance().label("label").build();
+        when(context.transform(any(), eq(DataplaneMetadata.class))).thenReturn(dataplaneMetadata);
+
+        var json = createObjectBuilder()
+                .add(TYPE, TRANSFER_REQUEST_TYPE)
+                .add(TRANSFER_REQUEST_COUNTER_PARTY_ADDRESS, "address")
+                .add(TRANSFER_REQUEST_CONTRACT_ID, "contractId")
+                .add(TRANSFER_REQUEST_DATA_DESTINATION, dataDestinationJson)
+                .add(TRANSFER_REQUEST_PRIVATE_PROPERTIES, privatePropertiesJson)
+                .add(TRANSFER_REQUEST_TRANSFER_TYPE, "Http-Pull")
+                .add(TRANSFER_REQUEST_PROFILE, "profile")
+                .add(TRANSFER_REQUEST_DATAPLANE_METADATA, createObjectBuilder()
+                        .add("labels", Json.createArrayBuilder().add("label")))
+                .build();
+
+        var result = transformer.transform(json, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getCounterPartyAddress()).isEqualTo("address");
+        assertThat(result.getContractId()).isEqualTo("contractId");
+        assertThat(result.getDataDestination()).isSameAs(dataDestination);
+        assertThat(result.getPrivateProperties()).containsAllEntriesOf(privateProperties);
+        assertThat(result.getProfile()).isEqualTo("profile");
         assertThat(result.getTransferType()).isEqualTo("Http-Pull");
         assertThat(result.getDataplaneMetadata()).isSameAs(dataplaneMetadata);
     }

--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -14,7 +14,7 @@
   {
     "version": "5.0.0-beta",
     "urlPath": "/v5beta",
-    "lastUpdated": "2026-04-25T09:00:00Z",
+    "lastUpdated": "2026-05-15T09:00:00Z",
     "maturity": "beta"
   }
 ]

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/catalog-request-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/catalog-request-schema.json
@@ -25,6 +25,9 @@
         "protocol": {
           "type": "string"
         },
+        "profile": {
+          "type": "string"
+        },
         "counterPartyAddress": {
           "type": "string"
         },
@@ -41,10 +44,31 @@
           "$ref": "https://w3id.org/edc/connector/management/schema/v4/query-spec-schema.json#/definitions/QuerySpec"
         }
       },
+      "oneOf": [
+        {
+          "required": [
+            "protocol"
+          ],
+          "not": {
+            "required": [
+              "profile"
+            ]
+          }
+        },
+        {
+          "required": [
+            "profile"
+          ],
+          "not": {
+            "required": [
+              "protocol"
+            ]
+          }
+        }
+      ],
       "required": [
         "@context",
         "@type",
-        "protocol",
         "counterPartyAddress",
         "counterPartyId"
       ]

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/contract-negotiation-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/contract-negotiation-schema.json
@@ -38,6 +38,9 @@
         "protocol": {
           "type": "string"
         },
+        "profile": {
+          "type": "string"
+        },
         "createdAt": {
           "type": "integer"
         },
@@ -72,6 +75,7 @@
         "@id",
         "type",
         "state",
+        "profile",
         "protocol",
         "counterPartyAddress",
         "counterPartyId",

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/contract-request-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/contract-request-schema.json
@@ -28,6 +28,9 @@
         "protocol": {
           "type": "string"
         },
+        "profile": {
+          "type": "string"
+        },
         "policy": {
           "$ref": "https://w3id.org/edc/connector/management/schema/v4/contract-offer-schema.json"
         },
@@ -38,11 +41,32 @@
           }
         }
       },
+      "oneOf": [
+        {
+          "required": [
+            "protocol"
+          ],
+          "not": {
+            "required": [
+              "profile"
+            ]
+          }
+        },
+        {
+          "required": [
+            "profile"
+          ],
+          "not": {
+            "required": [
+              "protocol"
+            ]
+          }
+        }
+      ],
       "required": [
         "@context",
         "@type",
         "counterPartyAddress",
-        "protocol",
         "policy"
       ]
     }

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/dataset-request-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/dataset-request-schema.json
@@ -25,6 +25,9 @@
         "protocol": {
           "type": "string"
         },
+        "profile": {
+          "type": "string"
+        },
         "counterPartyAddress": {
           "type": "string"
         },

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/dataset-request-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/dataset-request-schema.json
@@ -32,11 +32,32 @@
           "type": "string"
         }
       },
+      "oneOf": [
+        {
+          "required": [
+            "protocol"
+          ],
+          "not": {
+            "required": [
+              "profile"
+            ]
+          }
+        },
+        {
+          "required": [
+            "profile"
+          ],
+          "not": {
+            "required": [
+              "protocol"
+            ]
+          }
+        }
+      ],
       "required": [
         "@context",
         "@type",
         "@id",
-        "protocol",
         "counterPartyAddress",
         "counterPartyId"
       ]

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/transfer-request-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/transfer-request-schema.json
@@ -28,6 +28,9 @@
         "protocol": {
           "type": "string"
         },
+        "profile": {
+          "type": "string"
+        },
         "contractId": {
           "type": "string"
         },
@@ -47,11 +50,32 @@
           "$ref": "https://w3id.org/edc/connector/management/schema/v4/dataplane-metadata-schema.json"
         }
       },
+      "oneOf": [
+        {
+          "required": [
+            "protocol"
+          ],
+          "not": {
+            "required": [
+              "profile"
+            ]
+          }
+        },
+        {
+          "required": [
+            "profile"
+          ],
+          "not": {
+            "required": [
+              "protocol"
+            ]
+          }
+        }
+      ],
       "required": [
         "@context",
         "@type",
         "counterPartyAddress",
-        "protocol",
         "contractId",
         "transferType"
       ]

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/model/ContractRequestDto.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/model/ContractRequestDto.java
@@ -25,34 +25,34 @@ public final class ContractRequestDto extends Typed {
     @JsonProperty("@id")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final String id;
-    private final String protocol;
+    private final String profile;
     private final String counterPartyAddress;
     private final String counterPartyId;
     private final OfferDto policy;
 
     public ContractRequestDto(String id,
-                              String protocol,
+                              String profile,
                               String counterPartyAddress,
                               String counterPartyId,
                               OfferDto policy) {
         super("ContractRequest");
         this.id = id;
-        this.protocol = protocol;
+        this.profile = profile;
         this.counterPartyAddress = counterPartyAddress;
         this.counterPartyId = counterPartyId;
         this.policy = policy;
     }
 
-    public ContractRequestDto(String protocol, String counterPartyAddress, String counterPartyId, OfferDto policy) {
-        this(null, protocol, counterPartyAddress, counterPartyId, policy);
+    public ContractRequestDto(String profile, String counterPartyAddress, String counterPartyId, OfferDto policy) {
+        this(null, profile, counterPartyAddress, counterPartyId, policy);
     }
 
     public String getId() {
         return id;
     }
 
-    public String getProtocol() {
-        return protocol;
+    public String getProfile() {
+        return profile;
     }
 
     public String getCounterPartyAddress() {

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/model/DatasetRequestDto.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/model/DatasetRequestDto.java
@@ -22,17 +22,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public final class DatasetRequestDto extends Typed {
     @JsonProperty("@id")
     private final String id;
-    private final String protocol;
+    private final String profile;
     private final String counterPartyAddress;
     private final String counterPartyId;
 
     public DatasetRequestDto(@JsonProperty("@id") String id,
-                             String protocol,
+                             String profile,
                              String counterPartyAddress,
                              String counterPartyId) {
         super("DatasetRequest");
         this.id = id;
-        this.protocol = protocol;
+        this.profile = profile;
         this.counterPartyAddress = counterPartyAddress;
         this.counterPartyId = counterPartyId;
     }
@@ -42,8 +42,8 @@ public final class DatasetRequestDto extends Typed {
         return id;
     }
 
-    public String getProtocol() {
-        return protocol;
+    public String getProfile() {
+        return profile;
     }
 
     public String getCounterPartyAddress() {

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/model/TransferRequestDto.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/model/TransferRequestDto.java
@@ -24,26 +24,26 @@ public final class TransferRequestDto extends Typed {
     @JsonProperty("@id")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final String id;
-    private final String protocol;
+    private final String profile;
     private final String counterPartyAddress;
     private final String transferType;
     private final String contractId;
 
     public TransferRequestDto(String id,
-                              String protocol,
+                              String profile,
                               String counterPartyAddress,
                               String transferType,
                               String contractId) {
         super("TransferRequest");
         this.id = id;
-        this.protocol = protocol;
+        this.profile = profile;
         this.counterPartyAddress = counterPartyAddress;
         this.transferType = transferType;
         this.contractId = contractId;
     }
 
-    public TransferRequestDto(String protocol, String counterPartyAddress, String transferType, String contractId) {
-        this(null, protocol, counterPartyAddress, transferType, contractId);
+    public TransferRequestDto(String profile, String counterPartyAddress, String transferType, String contractId) {
+        this(null, profile, counterPartyAddress, transferType, contractId);
     }
 
 
@@ -53,8 +53,8 @@ public final class TransferRequestDto extends Typed {
         return id;
     }
 
-    public String getProtocol() {
-        return protocol;
+    public String getProfile() {
+        return profile;
     }
 
     public String getCounterPartyAddress() {

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/CatalogRequest.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/CatalogRequest.java
@@ -96,6 +96,7 @@ public class CatalogRequest {
             return this;
         }
 
+        @Deprecated(since = "management-api:v5")
         public Builder protocol(String protocol) {
             instance.protocol = protocol;
             return this;

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/CatalogRequest.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/CatalogRequest.java
@@ -27,7 +27,7 @@ public class CatalogRequest {
 
     public static final String CATALOG_REQUEST_TYPE_TERM = "CatalogRequest";
     public static final String CATALOG_REQUEST_TYPE = EDC_NAMESPACE + CATALOG_REQUEST_TYPE_TERM;
-    @Deprecated(since = "management-api:v5")
+    @Deprecated(since = "management-api:v4")
     public static final String CATALOG_REQUEST_PROTOCOL = EDC_NAMESPACE + "protocol";
     public static final String CATALOG_REQUEST_PROFILE = EDC_NAMESPACE + "profile";
     public static final String CATALOG_REQUEST_COUNTER_PARTY_ADDRESS = EDC_NAMESPACE + "counterPartyAddress";
@@ -59,7 +59,7 @@ public class CatalogRequest {
         return querySpec;
     }
 
-    @Deprecated(since = "management-api:v5")
+    @Deprecated(since = "management-api:v4")
     public String getProtocol() {
         return protocol;
     }
@@ -96,7 +96,7 @@ public class CatalogRequest {
             return this;
         }
 
-        @Deprecated(since = "management-api:v5")
+        @Deprecated(since = "management-api:v4")
         public Builder protocol(String protocol) {
             instance.protocol = protocol;
             return this;

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/CatalogRequest.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/CatalogRequest.java
@@ -27,7 +27,9 @@ public class CatalogRequest {
 
     public static final String CATALOG_REQUEST_TYPE_TERM = "CatalogRequest";
     public static final String CATALOG_REQUEST_TYPE = EDC_NAMESPACE + CATALOG_REQUEST_TYPE_TERM;
+    @Deprecated(since = "management-api:v5")
     public static final String CATALOG_REQUEST_PROTOCOL = EDC_NAMESPACE + "protocol";
+    public static final String CATALOG_REQUEST_PROFILE = EDC_NAMESPACE + "profile";
     public static final String CATALOG_REQUEST_COUNTER_PARTY_ADDRESS = EDC_NAMESPACE + "counterPartyAddress";
     public static final String CATALOG_REQUEST_COUNTER_PARTY_ID = EDC_NAMESPACE + "counterPartyId";
     public static final String CATALOG_REQUEST_QUERY_SPEC = EDC_NAMESPACE + "querySpec";
@@ -57,7 +59,12 @@ public class CatalogRequest {
         return querySpec;
     }
 
+    @Deprecated(since = "management-api:v5")
     public String getProtocol() {
+        return protocol;
+    }
+
+    public String getProfile() {
         return protocol;
     }
 
@@ -91,6 +98,11 @@ public class CatalogRequest {
 
         public Builder protocol(String protocol) {
             instance.protocol = protocol;
+            return this;
+        }
+
+        public Builder profile(String profile) {
+            instance.protocol = profile;
             return this;
         }
 

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/DatasetRequest.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/DatasetRequest.java
@@ -23,7 +23,9 @@ public class DatasetRequest {
 
     public static final String DATASET_REQUEST_TYPE_TERM = "DatasetRequest";
     public static final String DATASET_REQUEST_TYPE = EDC_NAMESPACE + DATASET_REQUEST_TYPE_TERM;
+    @Deprecated(since = "management-api:v5")
     public static final String DATASET_REQUEST_PROTOCOL = EDC_NAMESPACE + "protocol";
+    public static final String DATASET_REQUEST_PROFILE = EDC_NAMESPACE + "profile";
     public static final String DATASET_REQUEST_COUNTER_PARTY_ADDRESS = EDC_NAMESPACE + "counterPartyAddress";
     public static final String DATASET_REQUEST_COUNTER_PARTY_ID = EDC_NAMESPACE + "counterPartyId";
 
@@ -47,7 +49,12 @@ public class DatasetRequest {
         return counterPartyId;
     }
 
+    @Deprecated(since = "management-api:v5")
     public String getProtocol() {
+        return protocol;
+    }
+
+    public String getProfile() {
         return protocol;
     }
 
@@ -81,6 +88,11 @@ public class DatasetRequest {
 
         public Builder protocol(String protocol) {
             instance.protocol = protocol;
+            return this;
+        }
+
+        public Builder profile(String profile) {
+            instance.protocol = profile;
             return this;
         }
 

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/DatasetRequest.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/DatasetRequest.java
@@ -23,7 +23,7 @@ public class DatasetRequest {
 
     public static final String DATASET_REQUEST_TYPE_TERM = "DatasetRequest";
     public static final String DATASET_REQUEST_TYPE = EDC_NAMESPACE + DATASET_REQUEST_TYPE_TERM;
-    @Deprecated(since = "management-api:v5")
+    @Deprecated(since = "management-api:v4")
     public static final String DATASET_REQUEST_PROTOCOL = EDC_NAMESPACE + "protocol";
     public static final String DATASET_REQUEST_PROFILE = EDC_NAMESPACE + "profile";
     public static final String DATASET_REQUEST_COUNTER_PARTY_ADDRESS = EDC_NAMESPACE + "counterPartyAddress";
@@ -49,7 +49,7 @@ public class DatasetRequest {
         return counterPartyId;
     }
 
-    @Deprecated(since = "management-api:v5")
+    @Deprecated(since = "management-api:v4")
     public String getProtocol() {
         return protocol;
     }
@@ -86,7 +86,7 @@ public class DatasetRequest {
             return this;
         }
 
-        @Deprecated(since = "management-api:v5")
+        @Deprecated(since = "management-api:v4")
         public Builder protocol(String protocol) {
             instance.protocol = protocol;
             return this;

--- a/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/DatasetRequest.java
+++ b/spi/control-plane/catalog-spi/src/main/java/org/eclipse/edc/connector/controlplane/catalog/spi/DatasetRequest.java
@@ -86,6 +86,7 @@ public class DatasetRequest {
             return this;
         }
 
+        @Deprecated(since = "management-api:v5")
         public Builder protocol(String protocol) {
             instance.protocol = protocol;
             return this;

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractNegotiation.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractNegotiation.java
@@ -112,6 +112,7 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> imp
      * Returns the data protocol used for this negotiation.
      *
      * @return The protocol.
+     * @deprecated The protocol field is being replaced by the profile field
      */
     @Deprecated(since = "management-api:v5")
     @NotNull

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractNegotiation.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractNegotiation.java
@@ -58,7 +58,9 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> imp
     public static final String CONTRACT_NEGOTIATION_COUNTERPARTY_ID = EDC_NAMESPACE + "counterPartyId";
     public static final String CONTRACT_NEGOTIATION_COUNTERPARTY_ADDR = EDC_NAMESPACE + "counterPartyAddress";
     public static final String CONTRACT_NEGOTIATION_ERRORDETAIL = EDC_NAMESPACE + "errorDetail";
+    @Deprecated(since = "management-api:v5")
     public static final String CONTRACT_NEGOTIATION_PROTOCOL = EDC_NAMESPACE + "protocol";
+    public static final String CONTRACT_NEGOTIATION_PROFILE = EDC_NAMESPACE + "profile";
     public static final String CONTRACT_NEGOTIATION_STATE = EDC_NAMESPACE + "state";
     public static final String CONTRACT_NEGOTIATION_NEG_TYPE = EDC_NAMESPACE + "type";
     public static final String CONTRACT_NEGOTIATION_CALLBACK_ADDR = EDC_NAMESPACE + "callbackAddresses";
@@ -111,8 +113,18 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> imp
      *
      * @return The protocol.
      */
+    @Deprecated(since = "management-api:v5")
     @NotNull
     public String getProtocol() {
+        return protocol;
+    }
+
+    /**
+     * Returns the profile used for this negotiation. It will replace the protocol field
+     *
+     * @return The profile.
+     */
+    public String getProfile() {
         return protocol;
     }
 

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractNegotiation.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractNegotiation.java
@@ -58,7 +58,7 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> imp
     public static final String CONTRACT_NEGOTIATION_COUNTERPARTY_ID = EDC_NAMESPACE + "counterPartyId";
     public static final String CONTRACT_NEGOTIATION_COUNTERPARTY_ADDR = EDC_NAMESPACE + "counterPartyAddress";
     public static final String CONTRACT_NEGOTIATION_ERRORDETAIL = EDC_NAMESPACE + "errorDetail";
-    @Deprecated(since = "management-api:v5")
+    @Deprecated(since = "management-api:v4")
     public static final String CONTRACT_NEGOTIATION_PROTOCOL = EDC_NAMESPACE + "protocol";
     public static final String CONTRACT_NEGOTIATION_PROFILE = EDC_NAMESPACE + "profile";
     public static final String CONTRACT_NEGOTIATION_STATE = EDC_NAMESPACE + "state";
@@ -114,7 +114,7 @@ public class ContractNegotiation extends StatefulEntity<ContractNegotiation> imp
      * @return The protocol.
      * @deprecated The protocol field is being replaced by the profile field
      */
-    @Deprecated(since = "management-api:v5")
+    @Deprecated(since = "management-api:v4")
     @NotNull
     public String getProtocol() {
         return protocol;

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractRequest.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractRequest.java
@@ -31,7 +31,9 @@ public class ContractRequest {
     public static final String CONTRACT_REQUEST_TYPE_TERM = "ContractRequest";
     public static final String CONTRACT_REQUEST_TYPE = EDC_NAMESPACE + CONTRACT_REQUEST_TYPE_TERM;
     public static final String CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS = EDC_NAMESPACE + "counterPartyAddress";
+    @Deprecated(since = "management-api:v5")
     public static final String PROTOCOL = EDC_NAMESPACE + "protocol";
+    public static final String CONTRACT_REQUEST_PROFILE = EDC_NAMESPACE + "profile";
     public static final String POLICY = EDC_NAMESPACE + "policy";
     public static final String CALLBACK_ADDRESSES = EDC_NAMESPACE + "callbackAddresses";
 
@@ -48,7 +50,12 @@ public class ContractRequest {
         return this.contractOffer.getPolicy().getAssigner();
     }
 
+    @Deprecated(since = "management-api:v5")
     public String getProtocol() {
+        return protocol;
+    }
+
+    public String getProfile() {
         return protocol;
     }
 
@@ -76,8 +83,14 @@ public class ContractRequest {
             return this;
         }
 
+        @Deprecated(since = "management-api:v5")
         public Builder protocol(String protocol) {
             contractRequest.protocol = protocol;
+            return this;
+        }
+
+        public Builder profile(String profile) {
+            contractRequest.protocol = profile;
             return this;
         }
 

--- a/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractRequest.java
+++ b/spi/control-plane/contract-spi/src/main/java/org/eclipse/edc/connector/controlplane/contract/spi/types/negotiation/ContractRequest.java
@@ -31,7 +31,7 @@ public class ContractRequest {
     public static final String CONTRACT_REQUEST_TYPE_TERM = "ContractRequest";
     public static final String CONTRACT_REQUEST_TYPE = EDC_NAMESPACE + CONTRACT_REQUEST_TYPE_TERM;
     public static final String CONTRACT_REQUEST_COUNTER_PARTY_ADDRESS = EDC_NAMESPACE + "counterPartyAddress";
-    @Deprecated(since = "management-api:v5")
+    @Deprecated(since = "management-api:v4")
     public static final String PROTOCOL = EDC_NAMESPACE + "protocol";
     public static final String CONTRACT_REQUEST_PROFILE = EDC_NAMESPACE + "profile";
     public static final String POLICY = EDC_NAMESPACE + "policy";
@@ -50,7 +50,7 @@ public class ContractRequest {
         return this.contractOffer.getPolicy().getAssigner();
     }
 
-    @Deprecated(since = "management-api:v5")
+    @Deprecated(since = "management-api:v4")
     public String getProtocol() {
         return protocol;
     }
@@ -83,7 +83,7 @@ public class ContractRequest {
             return this;
         }
 
-        @Deprecated(since = "management-api:v5")
+        @Deprecated(since = "management-api:v4")
         public Builder protocol(String protocol) {
             contractRequest.protocol = protocol;
             return this;

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferRequest.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferRequest.java
@@ -36,7 +36,7 @@ public class TransferRequest {
     public static final String TRANSFER_REQUEST_DATA_DESTINATION = EDC_NAMESPACE + "dataDestination";
     public static final String TRANSFER_REQUEST_TRANSFER_TYPE = EDC_NAMESPACE + "transferType";
     public static final String TRANSFER_REQUEST_PRIVATE_PROPERTIES = EDC_NAMESPACE + "privateProperties";
-    @Deprecated(since = "management-api:v5")
+    @Deprecated(since = "management-api:v4")
     public static final String TRANSFER_REQUEST_PROTOCOL = EDC_NAMESPACE + "protocol";
     public static final String TRANSFER_REQUEST_PROFILE = EDC_NAMESPACE + "profile";
     @Deprecated(since = "management-api:v3")
@@ -71,7 +71,7 @@ public class TransferRequest {
         return privateProperties;
     }
 
-    @Deprecated(since = "management-api:v5")
+    @Deprecated(since = "management-api:v4")
     public String getProtocol() {
         return protocol;
     }
@@ -134,7 +134,7 @@ public class TransferRequest {
             return this;
         }
 
-        @Deprecated(since = "management-api:v5")
+        @Deprecated(since = "management-api:v4")
         public Builder protocol(String protocol) {
             request.protocol = protocol;
             return this;

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferRequest.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/types/TransferRequest.java
@@ -36,7 +36,9 @@ public class TransferRequest {
     public static final String TRANSFER_REQUEST_DATA_DESTINATION = EDC_NAMESPACE + "dataDestination";
     public static final String TRANSFER_REQUEST_TRANSFER_TYPE = EDC_NAMESPACE + "transferType";
     public static final String TRANSFER_REQUEST_PRIVATE_PROPERTIES = EDC_NAMESPACE + "privateProperties";
+    @Deprecated(since = "management-api:v5")
     public static final String TRANSFER_REQUEST_PROTOCOL = EDC_NAMESPACE + "protocol";
+    public static final String TRANSFER_REQUEST_PROFILE = EDC_NAMESPACE + "profile";
     @Deprecated(since = "management-api:v3")
     public static final String TRANSFER_REQUEST_ASSET_ID = EDC_NAMESPACE + "assetId";
     public static final String TRANSFER_REQUEST_CALLBACK_ADDRESSES = EDC_NAMESPACE + "callbackAddresses";
@@ -69,7 +71,12 @@ public class TransferRequest {
         return privateProperties;
     }
 
+    @Deprecated(since = "management-api:v5")
     public String getProtocol() {
+        return protocol;
+    }
+
+    public String getProfile() {
         return protocol;
     }
 
@@ -127,8 +134,14 @@ public class TransferRequest {
             return this;
         }
 
+        @Deprecated(since = "management-api:v5")
         public Builder protocol(String protocol) {
             request.protocol = protocol;
+            return this;
+        }
+
+        public Builder profile(String profile) {
+            request.protocol = profile;
             return this;
         }
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/SerdeEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/SerdeEndToEndTest.java
@@ -137,6 +137,8 @@ import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.suspendTransf
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.terminateNegotiationObject;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.terminateTransferObject;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.transferRequestObject;
+import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.transferRequestObjectWithProfile;
+import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.transferRequestObjectWithProfileAndProtocol;
 
 @EndToEndTest
 public class SerdeEndToEndTest {
@@ -509,6 +511,22 @@ public class SerdeEndToEndTest {
         }
 
         @Test
+        void de_TransferRequest_withProfile(TypeTransformerRegistry typeTransformerRegistry, JsonObjectValidatorRegistry validatorRegistry, JsonLd jsonLd) {
+            var inputObject = transferRequestObjectWithProfile(jsonLdContext());
+            var transferRequest = deserialize(typeTransformerRegistry, validatorRegistry, jsonLd, inputObject, TransferRequest.class);
+
+            assertThat(transferRequest).isNotNull();
+            assertThat(transferRequest.getCounterPartyAddress()).isEqualTo(inputObject.getString("counterPartyAddress"));
+            assertThat(transferRequest.getContractId()).isEqualTo(inputObject.getString("contractId"));
+            assertThat(transferRequest.getDataDestination()).extracting(DataAddress::getType).isEqualTo(inputObject.getJsonObject("dataDestination").getString("type"));
+            assertThat(transferRequest.getPrivateProperties()).containsEntry(EDC_NAMESPACE + "fooPrivate", "bar");
+            assertThat(transferRequest.getProfile()).isEqualTo(inputObject.getString("profile"));
+            assertThat(transferRequest.getCallbackAddresses()).hasSize(inputObject.getJsonArray("callbackAddresses").size());
+            assertThat(transferRequest.getPrivateProperties()).hasSize(inputObject.getJsonObject("privateProperties").size());
+            assertThat(transferRequest.getTransferType()).isEqualTo(inputObject.getString("transferType"));
+        }
+
+        @Test
         void de_TransferRequest_withoutDataAddressType(TypeTransformerRegistry typeTransformerRegistry, JsonObjectValidatorRegistry validatorRegistry, JsonLd jsonLd) {
             var dataDestination = createObjectBuilder()
                     .add("type", "type").build();
@@ -525,6 +543,14 @@ public class SerdeEndToEndTest {
             assertThat(transferRequest.getCallbackAddresses()).hasSize(inputObject.getJsonArray("callbackAddresses").size());
             assertThat(transferRequest.getTransferType()).isEqualTo(inputObject.getString("transferType"));
 
+        }
+
+        @Test
+        void validate_TransferRequest_withProfileAndProtocol_shouldFail(JsonObjectValidatorRegistry validatorRegistry) {
+            var inputObject = transferRequestObjectWithProfileAndProtocol(jsonLdContext());
+            var request = validateWithResult(validatorRegistry, inputObject);
+
+            assertThat(request).isFailed();
         }
 
         @Test
@@ -823,6 +849,18 @@ public class SerdeEndToEndTest {
         @Disabled
         void validate_ContractRequest_withProfileAndProtocol_shouldFail(JsonObjectValidatorRegistry validatorRegistry) {
             super.validate_ContractRequest_withProfileAndProtocol_shouldFail(validatorRegistry);
+        }
+
+        @Override
+        @Disabled
+        void de_TransferRequest_withProfile(TypeTransformerRegistry typeTransformerRegistry, JsonObjectValidatorRegistry validatorRegistry, JsonLd jsonLd) {
+            super.de_TransferRequest_withProfile(typeTransformerRegistry, validatorRegistry, jsonLd);
+        }
+
+        @Override
+        @Disabled
+        void validate_TransferRequest_withProfileAndProtocol_shouldFail(JsonObjectValidatorRegistry validatorRegistry) {
+            super.validate_TransferRequest_withProfileAndProtocol_shouldFail(validatorRegistry);
         }
 
         @Override

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/SerdeEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/SerdeEndToEndTest.java
@@ -113,6 +113,8 @@ import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.celExpression
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.celExpressionTestRequest;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.contractDefinitionObject;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.contractRequestObject;
+import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.contractRequestObjectWithProfile;
+import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.contractRequestObjectWithProfileAndProtocol;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.createCelExpressionTestResponse;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.createContractAgreement;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.createContractNegotiation;
@@ -468,6 +470,29 @@ public class SerdeEndToEndTest {
         }
 
         @Test
+        void de_ContractRequest_withProfile(TypeTransformerRegistry typeTransformerRegistry, JsonObjectValidatorRegistry validatorRegistry, JsonLd jsonLd) {
+            var inputObject = contractRequestObjectWithProfile(jsonLdContext(), strictSchema());
+            var request = deserialize(typeTransformerRegistry, validatorRegistry, jsonLd, inputObject, ContractRequest.class);
+
+            assertThat(request).isNotNull();
+            assertThat(request.getProviderId()).isEqualTo(inputObject.getJsonObject("policy").getString("assigner"));
+            assertThat(request.getCallbackAddresses()).isNotEmpty();
+            assertThat(request.getProfile()).isEqualTo("test-profile");
+            assertThat(request.getCounterPartyAddress()).isEqualTo("test-address");
+            assertThat(request.getContractOffer().getPolicy()).isNotNull();
+
+        }
+
+        @Test
+        void validate_ContractRequest_withProfileAndProtocol_shouldFail(JsonObjectValidatorRegistry validatorRegistry) {
+            var inputObject = contractRequestObjectWithProfileAndProtocol(jsonLdContext(), strictSchema());
+            var request = validateWithResult(validatorRegistry, inputObject);
+
+            assertThat(request).isFailed();
+
+        }
+
+        @Test
         void de_TransferRequest(TypeTransformerRegistry typeTransformerRegistry, JsonObjectValidatorRegistry validatorRegistry, JsonLd jsonLd) {
             var inputObject = transferRequestObject(jsonLdContext());
             var transferRequest = deserialize(typeTransformerRegistry, validatorRegistry, jsonLd, inputObject, TransferRequest.class);
@@ -786,6 +811,18 @@ public class SerdeEndToEndTest {
         @Disabled
         void validate_CatalogRequest_WithBoth_ShouldFail(JsonObjectValidatorRegistry validatorRegistry) {
             super.validate_CatalogRequest_WithBoth_ShouldFail(validatorRegistry);
+        }
+
+        @Override
+        @Disabled
+        void de_ContractRequest_withProfile(TypeTransformerRegistry typeTransformerRegistry, JsonObjectValidatorRegistry validatorRegistry, JsonLd jsonLd) {
+            super.de_ContractRequest_withProfile(typeTransformerRegistry, validatorRegistry, jsonLd);
+        }
+
+        @Override
+        @Disabled
+        void validate_ContractRequest_withProfileAndProtocol_shouldFail(JsonObjectValidatorRegistry validatorRegistry) {
+            super.validate_ContractRequest_withProfileAndProtocol_shouldFail(validatorRegistry);
         }
 
         @Override

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/SerdeEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/SerdeEndToEndTest.java
@@ -64,6 +64,7 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.secret.Secret;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.validator.spi.ValidationResult;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
@@ -106,6 +107,8 @@ import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.assetObject;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.assetObjectWithMetadata;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.catalogAsset;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.catalogRequestObject;
+import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.catalogRequestObjectWithProfile;
+import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.catalogRequestObjectWithProfileAndProtocol;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.celExpression;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.celExpressionTestRequest;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.contractDefinitionObject;
@@ -119,6 +122,8 @@ import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.createTransfe
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.dataAddressObject;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.dataPaneInstanceObject;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.datasetRequestObject;
+import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.datasetRequestObjectWithProfile;
+import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.datasetRequestObjectWithProfileAndProtocol;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.inForceDatePermission;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.participantContextConfigObject;
 import static org.eclipse.edc.test.e2e.managementapi.TestFunctions.participantContextObject;
@@ -392,6 +397,28 @@ public class SerdeEndToEndTest {
         }
 
         @Test
+        void de_DatasetRequest_withProfile(TypeTransformerRegistry typeTransformerRegistry, JsonObjectValidatorRegistry validatorRegistry, JsonLd jsonLd) {
+            var inputObject = datasetRequestObjectWithProfile(jsonLdContext());
+            var request = deserialize(typeTransformerRegistry, validatorRegistry, jsonLd, inputObject, DatasetRequest.class);
+
+            assertThat(request).isNotNull();
+            assertThat(request.getId()).isEqualTo(inputObject.getString(ID));
+            assertThat(request.getProfile()).isEqualTo(inputObject.getString("profile"));
+            assertThat(request.getCounterPartyAddress()).isEqualTo(inputObject.getString("counterPartyAddress"));
+            assertThat(request.getCounterPartyId()).isEqualTo(inputObject.getString("counterPartyId"));
+
+        }
+
+        @Test
+        void validate_DatasetRequest_WithBoth_ShouldFail(JsonObjectValidatorRegistry validatorRegistry) {
+            var inputObject = datasetRequestObjectWithProfileAndProtocol(jsonLdContext());
+            var request = validateWithResult(validatorRegistry, inputObject);
+
+            assertThat(request).isFailed();
+
+        }
+
+        @Test
         void de_CatalogRequest(TypeTransformerRegistry typeTransformerRegistry, JsonObjectValidatorRegistry validatorRegistry, JsonLd jsonLd) {
             var inputObject = catalogRequestObject(jsonLdContext());
             var request = deserialize(typeTransformerRegistry, validatorRegistry, jsonLd, inputObject, CatalogRequest.class);
@@ -401,6 +428,28 @@ public class SerdeEndToEndTest {
             assertThat(request.getCounterPartyAddress()).isEqualTo(inputObject.getString("counterPartyAddress"));
             assertThat(request.getCounterPartyId()).isEqualTo(inputObject.getString("counterPartyId"));
             assertThat(request.getQuerySpec().getFilterExpression()).hasSize(1);
+
+        }
+
+        @Test
+        void de_CatalogRequest_WithProfile(TypeTransformerRegistry typeTransformerRegistry, JsonObjectValidatorRegistry validatorRegistry, JsonLd jsonLd) {
+            var inputObject = catalogRequestObjectWithProfile(jsonLdContext());
+            var request = deserialize(typeTransformerRegistry, validatorRegistry, jsonLd, inputObject, CatalogRequest.class);
+
+            assertThat(request).isNotNull();
+            assertThat(request.getProfile()).isEqualTo(inputObject.getString("profile"));
+            assertThat(request.getCounterPartyAddress()).isEqualTo(inputObject.getString("counterPartyAddress"));
+            assertThat(request.getCounterPartyId()).isEqualTo(inputObject.getString("counterPartyId"));
+            assertThat(request.getQuerySpec().getFilterExpression()).hasSize(1);
+
+        }
+
+        @Test
+        void validate_CatalogRequest_WithBoth_ShouldFail(JsonObjectValidatorRegistry validatorRegistry) {
+            var inputObject = catalogRequestObjectWithProfileAndProtocol(jsonLdContext());
+            var request = validateWithResult(validatorRegistry, inputObject);
+
+            assertThat(request).isFailed();
 
         }
 
@@ -583,6 +632,15 @@ public class SerdeEndToEndTest {
             }
         }
 
+        private ValidationResult validateWithResult(JsonObjectValidatorRegistry validator, JsonObject compacted) {
+            var type = compacted.getJsonString(TYPE) != null ? compacted.getString(TYPE) : null;
+            if (type != null) {
+                return validator.validate(schemaVersion() + ":" + type, compacted);
+            } else {
+                throw new RuntimeException("Validation failed: no type");
+            }
+        }
+
         private <T> T deserialize(TypeTransformerRegistry typeTransformerRegistry, JsonObjectValidatorRegistry validator, JsonLd jsonLd, JsonObject inputObject, Class<T> klass) {
             validate(validator, inputObject);
             var registry = forContext(typeTransformerRegistry, transformerScope());
@@ -702,8 +760,32 @@ public class SerdeEndToEndTest {
 
         @Override
         @Disabled
+        void de_DatasetRequest_withProfile(TypeTransformerRegistry typeTransformerRegistry, JsonObjectValidatorRegistry validatorRegistry, JsonLd jsonLd) {
+            super.de_DatasetRequest_withProfile(typeTransformerRegistry, validatorRegistry, jsonLd);
+        }
+
+        @Override
+        @Disabled
+        void validate_DatasetRequest_WithBoth_ShouldFail(JsonObjectValidatorRegistry validatorRegistry) {
+            super.validate_DatasetRequest_WithBoth_ShouldFail(validatorRegistry);
+        }
+
+        @Override
+        @Disabled
         void de_CatalogRequest(TypeTransformerRegistry typeTransformerRegistry, JsonObjectValidatorRegistry validatorRegistry, JsonLd jsonLd) {
             super.de_CatalogRequest(typeTransformerRegistry, validatorRegistry, jsonLd);
+        }
+
+        @Override
+        @Disabled
+        void de_CatalogRequest_WithProfile(TypeTransformerRegistry typeTransformerRegistry, JsonObjectValidatorRegistry validatorRegistry, JsonLd jsonLd) {
+            super.de_CatalogRequest_WithProfile(typeTransformerRegistry, validatorRegistry, jsonLd);
+        }
+
+        @Override
+        @Disabled
+        void validate_CatalogRequest_WithBoth_ShouldFail(JsonObjectValidatorRegistry validatorRegistry) {
+            super.validate_CatalogRequest_WithBoth_ShouldFail(validatorRegistry);
         }
 
         @Override

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
@@ -392,6 +392,27 @@ public class TestFunctions {
         return transferRequestObject(context, dataDestination);
     }
 
+    public static JsonObject transferRequestObjectWithProfile(String context) {
+        var dataDestination = createObjectBuilder()
+                .add(TYPE, "DataAddress")
+                .add("type", "type").build();
+
+        return transferRequestObjectWithProfile(context, dataDestination);
+    }
+
+    public static JsonObject transferRequestObjectWithProfileAndProtocol(String context) {
+        return createObjectBuilder()
+                .add(TYPE, "TransferRequest")
+                .add(CONTEXT, createContextBuilder(context).build())
+                .add("counterPartyAddress", "address")
+                .add("contractId", "contractId")
+                .add("profile", "profile")
+                .add("protocol", "protocol")
+                .add("callbackAddresses", createCallbackAddress())
+                .add("transferType", "myTransferType")
+                .build();
+    }
+
     public static JsonObject transferRequestObject(String context, JsonObject dataDestination) {
         var propertiesJson = Json.createObjectBuilder().add("foo", "bar").build();
         var privatePropertiesJson = Json.createObjectBuilder().add("fooPrivate", "bar").build();
@@ -405,6 +426,24 @@ public class TestFunctions {
                 .add("properties", propertiesJson)
                 .add("privateProperties", privatePropertiesJson)
                 .add("protocol", "protocol")
+                .add("callbackAddresses", createCallbackAddress())
+                .add("transferType", "myTransferType")
+                .build();
+    }
+
+    public static JsonObject transferRequestObjectWithProfile(String context, JsonObject dataDestination) {
+        var propertiesJson = Json.createObjectBuilder().add("foo", "bar").build();
+        var privatePropertiesJson = Json.createObjectBuilder().add("fooPrivate", "bar").build();
+
+        return createObjectBuilder()
+                .add(TYPE, "TransferRequest")
+                .add(CONTEXT, createContextBuilder(context).build())
+                .add("counterPartyAddress", "address")
+                .add("contractId", "contractId")
+                .add("dataDestination", dataDestination)
+                .add("properties", propertiesJson)
+                .add("privateProperties", privatePropertiesJson)
+                .add("profile", "profile")
                 .add("callbackAddresses", createCallbackAddress())
                 .add("transferType", "myTransferType")
                 .build();

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
@@ -283,6 +283,39 @@ public class TestFunctions {
                 .build();
     }
 
+    public static JsonObject contractRequestObjectWithProfile(String context, boolean alwaysArray) {
+        var permission = inForceDatePermission("gteq", "contractAgreement+0s", "lteq", "contractAgreement+10s", alwaysArray);
+        var policy = policy(permission, "Offer", alwaysArray)
+                .add(ID, "id")
+                .add("assigner", "provider")
+                .build();
+        return Json.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder(context).build())
+                .add(TYPE, "ContractRequest")
+                .add("counterPartyAddress", "test-address")
+                .add("profile", "test-profile")
+                .add("callbackAddresses", createCallbackAddress())
+                .add("policy", policy)
+                .build();
+    }
+
+    public static JsonObject contractRequestObjectWithProfileAndProtocol(String context, boolean alwaysArray) {
+        var permission = inForceDatePermission("gteq", "contractAgreement+0s", "lteq", "contractAgreement+10s", alwaysArray);
+        var policy = policy(permission, "Offer", alwaysArray)
+                .add(ID, "id")
+                .add("assigner", "provider")
+                .build();
+        return Json.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder(context).build())
+                .add(TYPE, "ContractRequest")
+                .add("counterPartyAddress", "test-address")
+                .add("profile", "test-profile")
+                .add("protocol", "test-protocol")
+                .add("callbackAddresses", createCallbackAddress())
+                .add("policy", policy)
+                .build();
+    }
+
     public static JsonObject datasetRequestObject(String context) {
         return Json.createObjectBuilder()
                 .add(CONTEXT, createContextBuilder(context).build())

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/TestFunctions.java
@@ -294,12 +294,58 @@ public class TestFunctions {
                 .build();
     }
 
+    public static JsonObject datasetRequestObjectWithProfile(String context) {
+        return Json.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder(context).build())
+                .add(TYPE, "DatasetRequest")
+                .add(ID, "dataset-request-id")
+                .add("counterPartyAddress", "test-address")
+                .add("counterPartyId", "test-counter-party-id")
+                .add("profile", "test-profile")
+                .build();
+    }
+
+    public static JsonObject datasetRequestObjectWithProfileAndProtocol(String context) {
+        return Json.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder(context).build())
+                .add(TYPE, "DatasetRequest")
+                .add(ID, "dataset-request-id")
+                .add("counterPartyAddress", "test-address")
+                .add("counterPartyId", "test-counter-party-id")
+                .add("profile", "test-profile")
+                .add("protocol", "test-protocol")
+                .build();
+    }
+
     public static JsonObject catalogRequestObject(String context) {
         return Json.createObjectBuilder()
                 .add(CONTEXT, createContextBuilder(context).build())
                 .add(TYPE, "CatalogRequest")
                 .add("counterPartyAddress", "test-address")
                 .add("counterPartyId", "test-counter-party-id")
+                .add("protocol", "test-protocol")
+                .add("querySpec", embeddedQuerySpec())
+                .build();
+    }
+
+    public static JsonObject catalogRequestObjectWithProfile(String context) {
+        return Json.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder(context).build())
+                .add(TYPE, "CatalogRequest")
+                .add("counterPartyAddress", "test-address")
+                .add("counterPartyId", "test-counter-party-id")
+                .add("profile", "test-profile")
+                .add("querySpec", embeddedQuerySpec())
+                .build();
+    }
+
+    public static JsonObject catalogRequestObjectWithProfileAndProtocol(String context) {
+        return Json.createObjectBuilder()
+                .add(CONTEXT, createContextBuilder(context).build())
+                .add(TYPE, "CatalogRequest")
+                .add("counterPartyAddress", "test-address")
+                .add("counterPartyId", "test-counter-party-id")
+                .add("profile", "test-profile")
                 .add("protocol", "test-protocol")
                 .add("querySpec", embeddedQuerySpec())
                 .build();

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CatalogApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/CatalogApiV4EndToEndTest.java
@@ -142,9 +142,9 @@ public class CatalogApiV4EndToEndTest {
                     .log().ifValidationFails()
                     .statusCode(400)
                     .contentType(JSON)
-                    .body("[0].message", containsString("required property 'protocol' not found"))
-                    .body("[1].message", containsString("required property 'counterPartyAddress' not found"))
-                    .body("[2].message", containsString("required property 'counterPartyId' not found"));
+                    .body("[1].message", containsString("required property 'protocol' not found"))
+                    .body("[3].message", containsString("required property 'counterPartyAddress' not found"))
+                    .body("[4].message", containsString("required property 'counterPartyId' not found"));
         }
 
         @Test

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CatalogApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CatalogApiV5EndToEndTest.java
@@ -105,7 +105,7 @@ public class CatalogApiV5EndToEndTest {
                     .add(TYPE, "CatalogRequest")
                     .add("counterPartyAddress", context.providerProtocolUrl(COUNTER_PARTY_ID))
                     .add("counterPartyId", COUNTER_PARTY_ID)
-                    .add("protocol", context.profile())
+                    .add("profile", context.profile())
                     .build()
                     .toString();
 
@@ -130,7 +130,7 @@ public class CatalogApiV5EndToEndTest {
                     .add(TYPE, "CatalogRequest")
                     .add("counterPartyAddress", context.providerProtocolUrl(COUNTER_PARTY_ID, context.profile()))
                     .add("counterPartyId", COUNTER_PARTY_ID)
-                    .add("protocol", context.profile())
+                    .add("profile", context.profile())
                     .build()
                     .toString();
 
@@ -152,7 +152,7 @@ public class CatalogApiV5EndToEndTest {
                     .add(TYPE, "CatalogRequest")
                     .add("counterPartyAddress", context.providerProtocolUrl(COUNTER_PARTY_ID, context.profile()))
                     .add("counterPartyId", COUNTER_PARTY_ID)
-                    .add("protocol", context.profile())
+                    .add("profile", context.profile())
                     .build()
                     .toString();
 
@@ -175,7 +175,7 @@ public class CatalogApiV5EndToEndTest {
                     .add(TYPE, "CatalogRequest")
                     .add("counterPartyAddress", context.providerProtocolUrl(COUNTER_PARTY_ID, context.profile()))
                     .add("counterPartyId", COUNTER_PARTY_ID)
-                    .add("protocol", context.profile())
+                    .add("profile", context.profile())
                     .build()
                     .toString();
 
@@ -198,7 +198,7 @@ public class CatalogApiV5EndToEndTest {
                     .add(TYPE, "CatalogRequest")
                     .add("counterPartyAddress", context.providerProtocolUrl(COUNTER_PARTY_ID, context.profile()))
                     .add("counterPartyId", COUNTER_PARTY_ID)
-                    .add("protocol", context.profile())
+                    .add("profile", context.profile())
                     .build()
                     .toString();
 
@@ -242,7 +242,7 @@ public class CatalogApiV5EndToEndTest {
                     .add(TYPE, "CatalogRequest")
                     .add("counterPartyAddress", context.providerProtocolUrl(COUNTER_PARTY_ID, context.profile()))
                     .add("counterPartyId", COUNTER_PARTY_ID)
-                    .add("protocol", context.profile())
+                    .add("profile", context.profile())
                     .add("querySpec", querySpec)
                     .build()
                     .toString();
@@ -274,9 +274,10 @@ public class CatalogApiV5EndToEndTest {
                     .log().ifValidationFails()
                     .statusCode(400)
                     .contentType(JSON)
-                    .body("[0].message", containsString("required property 'protocol' not found"))
-                    .body("[1].message", containsString("required property 'counterPartyAddress' not found"))
-                    .body("[2].message", containsString("required property 'counterPartyId' not found"));
+                    .body("[1].message", containsString("required property 'protocol' not found"))
+                    .body("[2].message", containsString("required property 'profile' not found"))
+                    .body("[3].message", containsString("required property 'counterPartyAddress' not found"))
+                    .body("[4].message", containsString("required property 'counterPartyId' not found"));
         }
 
         @Test
@@ -307,7 +308,7 @@ public class CatalogApiV5EndToEndTest {
                     .add(TYPE, "CatalogRequest")
                     .add("counterPartyAddress", context.providerProtocolUrl(COUNTER_PARTY_ID, context.profile()))
                     .add("counterPartyId", COUNTER_PARTY_ID)
-                    .add("protocol", context.profile())
+                    .add("profile", context.profile())
                     .build()
                     .toString();
 
@@ -347,7 +348,7 @@ public class CatalogApiV5EndToEndTest {
                     .add(ID, "asset-id")
                     .add("counterPartyAddress", context.providerProtocolUrl(COUNTER_PARTY_ID, context.profile()))
                     .add("counterPartyId", COUNTER_PARTY_ID)
-                    .add("protocol", context.profile())
+                    .add("profile", context.profile())
                     .build()
                     .toString();
 
@@ -392,7 +393,7 @@ public class CatalogApiV5EndToEndTest {
                     .add(ID, "asset-response")
                     .add("counterPartyAddress", context.providerProtocolUrl(COUNTER_PARTY_ID, context.profile()))
                     .add("counterPartyId", COUNTER_PARTY_ID)
-                    .add("protocol", context.profile())
+                    .add("profile", context.profile())
                     .build()
                     .toString();
 
@@ -419,7 +420,7 @@ public class CatalogApiV5EndToEndTest {
                     .add(ID, "asset-id")
                     .add("counterPartyAddress", context.providerProtocolUrl(COUNTER_PARTY_ID, context.profile()))
                     .add("counterPartyId", COUNTER_PARTY_ID)
-                    .add("protocol", context.profile())
+                    .add("profile", context.profile())
                     .build()
                     .toString();
 
@@ -454,7 +455,7 @@ public class CatalogApiV5EndToEndTest {
                     .add(ID, "asset-id")
                     .add("counterPartyAddress", context.providerProtocolUrl(COUNTER_PARTY_ID, context.profile()))
                     .add("counterPartyId", COUNTER_PARTY_ID)
-                    .add("protocol", context.profile())
+                    .add("profile", context.profile())
                     .build()
                     .toString();
 
@@ -503,7 +504,7 @@ public class CatalogApiV5EndToEndTest {
                     .add(ID, "asset-id")
                     .add("counterPartyAddress", context.providerProtocolUrl(COUNTER_PARTY_ID, context.profile()))
                     .add("counterPartyId", COUNTER_PARTY_ID)
-                    .add("protocol", context.profile())
+                    .add("profile", context.profile())
                     .build()
                     .toString();
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/ContractNegotiationApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/ContractNegotiationApiV5EndToEndTest.java
@@ -206,7 +206,8 @@ public class ContractNegotiationApiV5EndToEndTest {
                     .body(CONTEXT, contains(jsonLdContextArray()))
                     .body(TYPE, equalTo("ContractNegotiation"))
                     .body(ID, is("cn1"))
-                    .body("protocol", equalTo("dataspace-protocol-http"));
+                    .body("protocol", equalTo("dataspace-protocol-http"))
+                    .body("profile", equalTo("dataspace-protocol-http"));
         }
 
         @Test
@@ -643,7 +644,7 @@ public class ContractNegotiationApiV5EndToEndTest {
                     .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
                     .add(TYPE, "ContractRequest")
                     .add("counterPartyAddress", "test-address")
-                    .add("protocol", "test-protocol")
+                    .add("profile", "test-test-profile")
                     .add("providerId", "test-provider-id")
                     .add("callbackAddresses", createCallbackAddress())
                     .add("policy", createPolicy())

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/TransferProcessApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/TransferProcessApiV5EndToEndTest.java
@@ -128,7 +128,10 @@ public class TransferProcessApiV5EndToEndTest {
                     .statusCode(200)
                     .extract().jsonPath().getString(ID);
 
-            assertThat(transferProcessStore.findById(id)).isNotNull();
+            assertThat(transferProcessStore.findById(id)).isNotNull()
+                    .satisfies(tp -> {
+                        assertThat(tp.getProtocol()).isEqualTo(requestBody.getString("profile"));
+                    });
         }
 
         private JsonObject createTransferRequestJson(String contractId, String assetId) {
@@ -144,7 +147,7 @@ public class TransferProcessApiV5EndToEndTest {
                     )
                     .add("transferType", "HttpData-PUSH")
                     .add("callbackAddresses", createCallbackAddress())
-                    .add("protocol", "dataspace-protocol-http")
+                    .add("profile", "test-profile")
                     .add("counterPartyAddress", "http://connector-address")
                     .add("contractId", contractId)
                     .add("assetId", assetId)

--- a/system-tests/tck/tasks-tck-extension/src/main/java/org/eclipse/edc/tasks/tck/dsp/controller/TckWebhookController.java
+++ b/system-tests/tck/tasks-tck-extension/src/main/java/org/eclipse/edc/tasks/tck/dsp/controller/TckWebhookController.java
@@ -75,7 +75,7 @@ public class TckWebhookController {
                 .callbackAddresses(List.of(CallbackAddress.Builder.newInstance().uri(request.connectorAddress()).build()))
                 .counterPartyAddress(request.connectorAddress())
                 .contractOffer(contractOffer)
-                .protocol("http-dsp-profile-2025-1")
+                .profile("http-dsp-profile-2025-1")
                 .build();
 
         monitor.debug("Starting contract negotiation for [provider, address, offer]: [%s, %s, %s]".formatted(request.providerId(), request.connectorAddress(), request.offerId()));
@@ -101,7 +101,7 @@ public class TckWebhookController {
                 .id(request.agreementId() + "_" + UUID.randomUUID())
                 .transferType(request.format())
                 .counterPartyAddress(request.connectorAddress())
-                .protocol("http-dsp-profile-2025-1")
+                .profile("http-dsp-profile-2025-1")
                 .contractId(request.agreementId())
                 .build();
 


### PR DESCRIPTION
## What this PR changes/adds

 Since we are sharing the schema v4 with v4 api and v5, i've added profile field in schema v4. the `protocol` will continue to work on both versions. on the *Request object is `protocol` or `profile` are mutually exclusive required. On V5 we should advertise that `protocol` is being replaced by `profile`. The underlying storage and field in pojo is not changed.
 
 All the v5 tests are now switched to `profile` field.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5733 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
