### PR TITLE
feat: add validation of profile/protocol field in v5 management api

### DIFF
--- a/core/common/participant-context-connector-core/src/main/java/org/eclipse/edc/participantcontext/connector/profile/ParticipantProfileResolverImpl.java
+++ b/core/common/participant-context-connector-core/src/main/java/org/eclipse/edc/participantcontext/connector/profile/ParticipantProfileResolverImpl.java
@@ -22,7 +22,6 @@ import org.eclipse.edc.protocol.spi.ParticipantProfileResolver;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -58,17 +57,16 @@ public class ParticipantProfileResolverImpl implements ParticipantProfileResolve
     }
 
     @Override
-    public Optional<DataspaceProfileContext> resolve(String participantContextId, String profileId) {
+    public DataspaceProfileContext resolve(String participantContextId, String profileId) {
 
         if (dspEnableAllProfiles) {
-            var profile = profileRegistry.getProfile(profileId);
-            return Optional.ofNullable(profile);
+            return profileRegistry.getProfile(profileId);
         }
         var configured = parse(readRaw(participantContextId));
         if (!configured.contains(profileId)) {
-            return Optional.empty();
+            return null;
         }
-        return Optional.ofNullable(profileRegistry.getProfile(profileId));
+        return profileRegistry.getProfile(profileId);
     }
 
     private String readRaw(String participantContextId) {

--- a/core/common/participant-context-connector-core/src/test/java/org/eclipse/edc/participantcontext/connector/profile/ParticipantProfileResolverImplTest.java
+++ b/core/common/participant-context-connector-core/src/test/java/org/eclipse/edc/participantcontext/connector/profile/ParticipantProfileResolverImplTest.java
@@ -85,14 +85,14 @@ class ParticipantProfileResolverImplTest {
         var pb = profile("b");
         when(registry.getProfile("b")).thenReturn(pb);
 
-        assertThat(resolver.resolve("p1", "b")).contains(pb);
+        assertThat(resolver.resolve("p1", "b")).isEqualTo(pb);
     }
 
     @Test
     void resolve_notAssociated_returnsEmpty() {
         when(config.getString(eq("p1"), eq(PROFILES_CONFIG_KEY), any())).thenReturn("a");
 
-        assertThat(resolver.resolve("p1", "b")).isEmpty();
+        assertThat(resolver.resolve("p1", "b")).isNull();
     }
 
     @Test
@@ -100,7 +100,7 @@ class ParticipantProfileResolverImplTest {
         when(config.getString(eq("p1"), eq(PROFILES_CONFIG_KEY), any())).thenReturn("a,b");
         when(registry.getProfile("b")).thenReturn(null);
 
-        assertThat(resolver.resolve("p1", "b")).isEmpty();
+        assertThat(resolver.resolve("p1", "b")).isNull();
     }
 
     private DataspaceProfileContext profile(String id) {

--- a/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-catalog-http-api-2025-virtual/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/virtual/controller/DspVirtualCatalogApiController20251.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-catalog-http-api-2025-virtual/src/main/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/virtual/controller/DspVirtualCatalogApiController20251.java
@@ -136,8 +136,10 @@ public class DspVirtualCatalogApiController20251 {
     }
 
     private DataspaceProfileContext resolveProfile(String participantContextId, String profileId) {
-        var profile = profileResolver.resolve(participantContextId, profileId)
-                .orElseThrow(() -> new NotFoundException("No profile '%s' for participant '%s'".formatted(profileId, participantContextId)));
+        var profile = profileResolver.resolve(participantContextId, profileId);
+        if (profile == null) {
+            throw new NotFoundException("No profile '%s' for participant '%s'".formatted(profileId, participantContextId));
+        }
         if (!V_2025_1_VERSION.equals(profile.protocolVersion().version())) {
             throw new NotFoundException("Profile '%s' is not for DSP version %s".formatted(profileId, V_2025_1_VERSION));
         }

--- a/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-catalog-http-api-2025-virtual/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-catalog-http-api-2025-virtual/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiControllerV20251Test.java
@@ -26,7 +26,6 @@ import org.eclipse.edc.spi.result.ServiceResult;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.eclipse.edc.protocol.dsp.catalog.http.api.CatalogApiPaths.BASE_PATH;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
@@ -55,7 +54,7 @@ public class DspCatalogApiControllerV20251Test extends DspCatalogApiControllerTe
         when(participantContextService.getParticipantContext(participantContext.getParticipantContextId()))
                 .thenReturn(ServiceResult.success(participantContext));
         when(profileResolver.resolve(participantContext.getParticipantContextId(), PROFILE_ID))
-                .thenReturn(Optional.of(PROFILE));
+                .thenReturn(PROFILE);
     }
 
     @Override

--- a/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-negotiation-http-api-2025-virtual/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/virtual/controller/DspVirtualNegotiationApiController20251.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-negotiation-http-api-2025-virtual/src/main/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/virtual/controller/DspVirtualNegotiationApiController20251.java
@@ -286,8 +286,10 @@ public class DspVirtualNegotiationApiController20251 {
     }
 
     private DataspaceProfileContext resolveProfile(String participantContextId, String profileId) {
-        var profile = profileResolver.resolve(participantContextId, profileId)
-                .orElseThrow(() -> new NotFoundException("No profile '%s' for participant '%s'".formatted(profileId, participantContextId)));
+        var profile = profileResolver.resolve(participantContextId, profileId);
+        if (profile == null) {
+            throw new NotFoundException("No profile '%s' for participant '%s'".formatted(profileId, participantContextId));
+        }
         if (!V_2025_1_VERSION.equals(profile.protocolVersion().version())) {
             throw new NotFoundException("Profile '%s' is not for DSP version %s".formatted(profileId, V_2025_1_VERSION));
         }

--- a/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-negotiation-http-api-2025-virtual/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-negotiation-http-api-2025-virtual/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiControllerV20251Test.java
@@ -26,7 +26,6 @@ import org.eclipse.edc.spi.result.ServiceResult;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.BASE_PATH;
 import static org.eclipse.edc.protocol.dsp.negotiation.http.api.NegotiationApiPaths.CONTRACT_OFFERS;
@@ -57,7 +56,7 @@ class DspNegotiationApiControllerV20251Test extends DspNegotiationApiControllerT
         when(participantContextService.getParticipantContext(participantContext.getParticipantContextId()))
                 .thenReturn(ServiceResult.success(participantContext));
         when(profileResolver.resolve(participantContext.getParticipantContextId(), PROFILE_ID))
-                .thenReturn(Optional.of(PROFILE));
+                .thenReturn(PROFILE);
     }
 
     @Override

--- a/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-transfer-process-http-api-2025-virtual/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/v2025/virtual/controller/DspVirtualTransferProcessApiController20251.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-transfer-process-http-api-2025-virtual/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/v2025/virtual/controller/DspVirtualTransferProcessApiController20251.java
@@ -210,8 +210,10 @@ public class DspVirtualTransferProcessApiController20251 {
     }
 
     private DataspaceProfileContext resolveProfile(String participantContextId, String profileId) {
-        var profile = profileResolver.resolve(participantContextId, profileId)
-                .orElseThrow(() -> new NotFoundException("No profile '%s' for participant '%s'".formatted(profileId, participantContextId)));
+        var profile = profileResolver.resolve(participantContextId, profileId);
+        if (profile == null) {
+            throw new NotFoundException("No profile '%s' for participant '%s'".formatted(profileId, participantContextId));
+        }
         if (!V_2025_1_VERSION.equals(profile.protocolVersion().version())) {
             throw new NotFoundException("Profile '%s' is not for DSP version %s".formatted(profileId, V_2025_1_VERSION));
         }

--- a/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-transfer-process-http-api-2025-virtual/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspTransferProcessApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-transfer-process-http-api-2025-virtual/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspTransferProcessApiControllerV20251Test.java
@@ -26,7 +26,6 @@ import org.eclipse.edc.spi.result.ServiceResult;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.V_2025_1;
@@ -55,7 +54,7 @@ class DspTransferProcessApiControllerV20251Test extends DspTransferProcessApiCon
         when(participantContextService.getParticipantContext(participantContext.getParticipantContextId()))
                 .thenReturn(ServiceResult.success(participantContext));
         when(profileResolver.resolve(participantContext.getParticipantContextId(), PROFILE_ID))
-                .thenReturn(Optional.of(PROFILE));
+                .thenReturn(PROFILE);
     }
 
     @Override

--- a/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/main/java/org/eclipse/edc/protocol/dsp/http/DspVirtualProfileDispatcher.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/main/java/org/eclipse/edc/protocol/dsp/http/DspVirtualProfileDispatcher.java
@@ -21,7 +21,7 @@ import org.eclipse.edc.protocol.dsp.spi.http.DspVirtualSubResourceLocator;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContext;
 import org.eclipse.edc.protocol.spi.ParticipantProfileResolver;
 
-import java.util.Optional;
+import static java.util.Optional.ofNullable;
 
 /**
  * JAX-RS resource that dispatches requests to sub-resources of a DSP virtual profile resource.
@@ -52,7 +52,7 @@ public class DspVirtualProfileDispatcher {
     }
 
     private DataspaceProfileContext resolveProfile(String participantContextId, String profileId) {
-        return Optional.ofNullable(profileResolver.resolve(participantContextId, profileId))
+        return ofNullable(profileResolver.resolve(participantContextId, profileId))
                 .orElseThrow(() -> new NotFoundException("No profile '%s' for participant '%s'".formatted(profileId, participantContextId)));
     }
 }

--- a/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/main/java/org/eclipse/edc/protocol/dsp/http/DspVirtualProfileDispatcher.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/main/java/org/eclipse/edc/protocol/dsp/http/DspVirtualProfileDispatcher.java
@@ -21,6 +21,8 @@ import org.eclipse.edc.protocol.dsp.spi.http.DspVirtualSubResourceLocator;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContext;
 import org.eclipse.edc.protocol.spi.ParticipantProfileResolver;
 
+import java.util.Optional;
+
 /**
  * JAX-RS resource that dispatches requests to sub-resources of a DSP virtual profile resource.
  * <p>
@@ -50,7 +52,7 @@ public class DspVirtualProfileDispatcher {
     }
 
     private DataspaceProfileContext resolveProfile(String participantContextId, String profileId) {
-        return profileResolver.resolve(participantContextId, profileId)
+        return Optional.ofNullable(profileResolver.resolve(participantContextId, profileId))
                 .orElseThrow(() -> new NotFoundException("No profile '%s' for participant '%s'".formatted(profileId, participantContextId)));
     }
 }

--- a/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/test/java/org/eclipse/edc/protocol/dsp/http/DspVirtualProfileDispatcherTest.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/test/java/org/eclipse/edc/protocol/dsp/http/DspVirtualProfileDispatcherTest.java
@@ -27,7 +27,6 @@ import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Optional;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
@@ -85,7 +84,7 @@ class DspVirtualProfileDispatcherTest extends RestControllerTestBase {
 
     @Test
     void shouldReturnNotFound_whenProfileNotResolvedForParticipant() {
-        when(profileResolver.resolve(PARTICIPANT_ID, PROFILE_ID)).thenReturn(Optional.empty());
+        when(profileResolver.resolve(PARTICIPANT_ID, PROFILE_ID)).thenReturn(null);
 
         baseRequest()
                 .get("/%s/%s/catalog/request".formatted(PARTICIPANT_ID, PROFILE_ID))
@@ -112,7 +111,7 @@ class DspVirtualProfileDispatcherTest extends RestControllerTestBase {
                 mock(), mock(),
                 new JsonLdNamespace("https://example.org/dspace/"),
                 List.of("https://example.org/context.jsonld"));
-        when(profileResolver.resolve(PARTICIPANT_ID, PROFILE_ID)).thenReturn(Optional.of(profile));
+        when(profileResolver.resolve(PARTICIPANT_ID, PROFILE_ID)).thenReturn(profile);
     }
 
     private RequestSpecification baseRequest() {

--- a/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/CatalogApiV5Extension.java
+++ b/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/CatalogApiV5Extension.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.connector.controlplane.transform.edc.catalog.to.JsonObjec
 import org.eclipse.edc.connector.controlplane.transform.edc.catalog.to.JsonObjectToDatasetRequestTransformer;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.protocol.spi.ParticipantProfileResolver;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -62,6 +63,8 @@ public class CatalogApiV5Extension implements ServiceExtension {
     private AuthorizationService authorizationService;
     @Inject
     private ParticipantContextService participantContextService;
+    @Inject
+    private ParticipantProfileResolver profileResolver;
 
     @Override
     public String name() {
@@ -77,7 +80,7 @@ public class CatalogApiV5Extension implements ServiceExtension {
 
         // authorization service does need an additional lookup function - catalogs are not a persisted entity
 
-        webService.registerResource(ApiContext.MANAGEMENT, new CatalogApiV5Controller(service, managementApiTransformerRegistry, authorizationService, participantContextService));
+        webService.registerResource(ApiContext.MANAGEMENT, new CatalogApiV5Controller(service, managementApiTransformerRegistry, authorizationService, participantContextService, profileResolver));
         webService.registerDynamicResource(ApiContext.MANAGEMENT, CatalogApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
     }
 }

--- a/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v5/CatalogApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v5/CatalogApiV5Controller.java
@@ -33,12 +33,17 @@ import org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogService;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.protocol.spi.ParticipantProfileResolver;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.Violation;
 import org.eclipse.edc.web.spi.exception.BadGatewayException;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
+import org.eclipse.edc.web.spi.exception.ValidationFailureException;
 import org.eclipse.edc.web.spi.validation.SchemaType;
+
+import java.util.List;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_TYPE_TERM;
@@ -53,13 +58,16 @@ public class CatalogApiV5Controller implements CatalogApiV5 {
     private final CatalogService service;
     private final TypeTransformerRegistry transformerRegistry;
     private final ParticipantContextService participantContextService;
+    private final ParticipantProfileResolver profileResolver;
+
 
     public CatalogApiV5Controller(CatalogService service, TypeTransformerRegistry transformerRegistry,
-                                  AuthorizationService authorizationService, ParticipantContextService participantContextService) {
+                                  AuthorizationService authorizationService, ParticipantContextService participantContextService, ParticipantProfileResolver profileResolver) {
         this.service = service;
         this.transformerRegistry = transformerRegistry;
         this.authorizationService = authorizationService;
         this.participantContextService = participantContextService;
+        this.profileResolver = profileResolver;
     }
 
 
@@ -79,6 +87,9 @@ public class CatalogApiV5Controller implements CatalogApiV5 {
                 .orElseThrow(InvalidRequestException::new);
 
         var scopes = request.getAdditionalScopes().toArray(new String[0]);
+
+        checkProfile(participantContextId, request.getProfile());
+
         service.requestCatalog(participantContext, request.getCounterPartyId(), request.getCounterPartyAddress(), request.getProtocol(), request.getQuerySpec(), scopes)
                 .whenComplete((result, throwable) -> {
                     try {
@@ -104,6 +115,8 @@ public class CatalogApiV5Controller implements CatalogApiV5 {
         var request = transformerRegistry.transform(requestBody, DatasetRequest.class)
                 .orElseThrow(InvalidRequestException::new);
 
+        checkProfile(participantContextId, request.getProfile());
+
         service.requestDataset(participantContext, request.getId(), request.getCounterPartyId(), request.getCounterPartyAddress(), request.getProtocol())
                 .whenComplete((result, throwable) -> {
                     try {
@@ -112,6 +125,14 @@ public class CatalogApiV5Controller implements CatalogApiV5 {
                         response.resume(mapped);
                     }
                 });
+    }
+
+
+    private void checkProfile(String participantContextId, String profileId) {
+        var profile = profileResolver.resolve(participantContextId, profileId);
+        if (profile == null) {
+            throw new ValidationFailureException(List.of(Violation.violation("No profile '%s' for participant '%s'".formatted(profileId, participantContextId), null)));
+        }
     }
 
     /**

--- a/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v5/CatalogApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v5/CatalogApiV5Controller.java
@@ -37,7 +37,6 @@ import org.eclipse.edc.protocol.spi.ParticipantProfileResolver;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
-import org.eclipse.edc.validator.spi.Violation;
 import org.eclipse.edc.web.spi.exception.BadGatewayException;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.ValidationFailureException;
@@ -48,6 +47,7 @@ import java.util.List;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_TYPE_TERM;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_TYPE_TERM;
+import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
 @Consumes(APPLICATION_JSON)
@@ -131,7 +131,7 @@ public class CatalogApiV5Controller implements CatalogApiV5 {
     private void checkProfile(String participantContextId, String profileId) {
         var profile = profileResolver.resolve(participantContextId, profileId);
         if (profile == null) {
-            throw new ValidationFailureException(List.of(Violation.violation("No profile '%s' for participant '%s'".formatted(profileId, participantContextId), null)));
+            throw new ValidationFailureException(List.of(violation("No profile '%s' for participant '%s'".formatted(profileId, participantContextId), null)));
         }
     }
 

--- a/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/BaseCatalogApiControllerTest.java
+++ b/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/BaseCatalogApiControllerTest.java
@@ -23,6 +23,8 @@ import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogServic
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContext;
+import org.eclipse.edc.protocol.spi.ParticipantProfileResolver;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
@@ -60,6 +62,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
     protected final TypeTransformerRegistry transformerRegistry = mock();
     protected final AuthorizationService authorizationService = mock();
     protected final ParticipantContextService participantContextService = mock();
+    protected final ParticipantProfileResolver profileResolver = mock();
     protected final String participantContextId = "test-participant-context-id";
 
     @BeforeEach
@@ -69,6 +72,8 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
                         .identity(participantContextId).build()));
 
         when(authorizationService.authorize(any(), any(), any(), any())).thenReturn(ServiceResult.success());
+
+        when(profileResolver.resolve(any(), any())).thenReturn(mock(DataspaceProfileContext.class));
     }
 
     @Test

--- a/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v5/CatalogApiV5ControllerTest.java
+++ b/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v5/CatalogApiV5ControllerTest.java
@@ -28,6 +28,6 @@ class CatalogApiV5ControllerTest extends BaseCatalogApiControllerTest {
 
     @Override
     protected Object controller() {
-        return new CatalogApiV5Controller(service, transformerRegistry, authorizationService, participantContextService);
+        return new CatalogApiV5Controller(service, transformerRegistry, authorizationService, participantContextService, profileResolver);
     }
 }

--- a/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiV5Extension.java
+++ b/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiV5Extension.java
@@ -30,6 +30,7 @@ import org.eclipse.edc.connector.controlplane.transform.edc.contractnegotiation.
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantResource;
+import org.eclipse.edc.protocol.spi.ParticipantProfileResolver;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.query.Criterion;
@@ -78,6 +79,9 @@ public class ContractNegotiationApiV5Extension implements ServiceExtension {
     @Inject
     private ParticipantContextService participantContextService;
 
+    @Inject
+    private ParticipantProfileResolver profileResolver;
+
     @Override
     public String name() {
         return NAME;
@@ -100,7 +104,7 @@ public class ContractNegotiationApiV5Extension implements ServiceExtension {
 
         authorizationService.addLookupFunction(ContractNegotiation.class, this::findContractNegotiation);
 
-        webService.registerResource(ApiContext.MANAGEMENT, new ContractNegotiationApiV5Controller(service, participantContextService, authorizationService, managementApiTransformerRegistry, monitor));
+        webService.registerResource(ApiContext.MANAGEMENT, new ContractNegotiationApiV5Controller(service, participantContextService, authorizationService, managementApiTransformerRegistry, profileResolver, monitor));
         webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractNegotiationApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
     }
 

--- a/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v5/ContractNegotiationApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v5/ContractNegotiationApiV5Controller.java
@@ -38,16 +38,20 @@ import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.Ter
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.protocol.spi.ParticipantProfileResolver;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.Violation;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.ObjectNotFoundException;
+import org.eclipse.edc.web.spi.exception.ValidationFailureException;
 import org.eclipse.edc.web.spi.validation.SchemaType;
 
+import java.util.List;
 import java.util.Optional;
 
 import static jakarta.json.stream.JsonCollectors.toJsonArray;
@@ -66,13 +70,16 @@ public class ContractNegotiationApiV5Controller implements ContractNegotiationAp
     private final ParticipantContextService participantContextService;
     private final AuthorizationService authorizationService;
     private final TypeTransformerRegistry transformerRegistry;
+    private final ParticipantProfileResolver profileResolver;
     private final Monitor monitor;
 
-    public ContractNegotiationApiV5Controller(ContractNegotiationService service, ParticipantContextService participantContextService, AuthorizationService authorizationService, TypeTransformerRegistry transformerRegistry, Monitor monitor) {
+    public ContractNegotiationApiV5Controller(ContractNegotiationService service, ParticipantContextService participantContextService,
+                                              AuthorizationService authorizationService, TypeTransformerRegistry transformerRegistry, ParticipantProfileResolver profileResolver, Monitor monitor) {
         this.service = service;
         this.participantContextService = participantContextService;
         this.authorizationService = authorizationService;
         this.transformerRegistry = transformerRegistry;
+        this.profileResolver = profileResolver;
         this.monitor = monitor;
     }
 
@@ -183,6 +190,8 @@ public class ContractNegotiationApiV5Controller implements ContractNegotiationAp
         var participantContext = participantContextService.getParticipantContext(participantContextId)
                 .orElseThrow(exceptionMapper(ParticipantContext.class, participantContextId));
 
+        checkProfile(participantContextId, contractRequest.getProfile());
+
         return service.initiateNegotiation(participantContext, contractRequest)
                 .map(cn -> IdResponse.Builder.newInstance().id(cn.getId()).createdAt(cn.getCreatedAt()).build())
                 .compose(idResponse -> ServiceResult.from(transformerRegistry.transform(idResponse, JsonObject.class)))
@@ -222,6 +231,13 @@ public class ContractNegotiationApiV5Controller implements ContractNegotiationAp
                 .orElseThrow(exceptionMapper(ContractNegotiation.class, id));
 
         service.delete(id).orElseThrow(exceptionMapper(ContractNegotiation.class, id));
+    }
+
+    private void checkProfile(String participantContextId, String profileId) {
+        var profile = profileResolver.resolve(participantContextId, profileId);
+        if (profile == null) {
+            throw new ValidationFailureException(List.of(Violation.violation("No profile '%s' for participant '%s'".formatted(profileId, participantContextId), null)));
+        }
     }
 
     private void logIfError(Result<?> result) {

--- a/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v5/ContractNegotiationApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v5/ContractNegotiationApiV5Controller.java
@@ -45,7 +45,6 @@ import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
-import org.eclipse.edc.validator.spi.Violation;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.ObjectNotFoundException;
 import org.eclipse.edc.web.spi.exception.ValidationFailureException;
@@ -60,6 +59,7 @@ import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiat
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.TerminateNegotiation.TERMINATE_NEGOTIATION_TYPE_TERM;
 import static org.eclipse.edc.participantcontext.spi.types.ParticipantResource.filterByParticipantContextId;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
+import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
 @Consumes(APPLICATION_JSON)
@@ -236,7 +236,7 @@ public class ContractNegotiationApiV5Controller implements ContractNegotiationAp
     private void checkProfile(String participantContextId, String profileId) {
         var profile = profileResolver.resolve(participantContextId, profileId);
         if (profile == null) {
-            throw new ValidationFailureException(List.of(Violation.violation("No profile '%s' for participant '%s'".formatted(profileId, participantContextId), null)));
+            throw new ValidationFailureException(List.of(violation("No profile '%s' for participant '%s'".formatted(profileId, participantContextId), null)));
         }
     }
 

--- a/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiControllerTestBase.java
+++ b/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiControllerTestBase.java
@@ -31,6 +31,8 @@ import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.C
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContext;
+import org.eclipse.edc.protocol.spi.ParticipantProfileResolver;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
@@ -73,11 +75,13 @@ public abstract class ContractNegotiationApiControllerTestBase extends RestContr
     protected final TypeTransformerRegistry transformerRegistry = mock();
     protected final AuthorizationService authorizationService = mock();
     protected final ParticipantContextService participantContextService = mock();
+    protected final ParticipantProfileResolver profileResolver = mock();
     private final String participantContextId = "test-participant-context-id";
 
     @BeforeEach
     void setup() {
         when(authorizationService.authorize(any(), any(), any(), any())).thenReturn(ServiceResult.success());
+        when(profileResolver.resolve(any(), any())).thenReturn(mock(DataspaceProfileContext.class));
     }
 
     private RequestSpecification baseRequest(String participantContextId) {

--- a/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v5/ContractNegotiationApiV5ControllerTest.java
+++ b/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v5/ContractNegotiationApiV5ControllerTest.java
@@ -22,7 +22,7 @@ class ContractNegotiationApiV5ControllerTest extends ContractNegotiationApiContr
 
     @Override
     protected Object controller() {
-        return new ContractNegotiationApiV5Controller(service, participantContextService, authorizationService, transformerRegistry, monitor);
+        return new ContractNegotiationApiV5Controller(service, participantContextService, authorizationService, transformerRegistry, profileResolver, monitor);
     }
 
     @Override

--- a/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/TransferProcessApiV5Extension.java
+++ b/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/TransferProcessApiV5Extension.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.connector.controlplane.transform.edc.transferprocess.to.J
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantResource;
+import org.eclipse.edc.protocol.spi.ParticipantProfileResolver;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.query.Criterion;
@@ -75,6 +76,9 @@ public class TransferProcessApiV5Extension implements ServiceExtension {
     @Inject
     private ParticipantContextService participantContextService;
 
+    @Inject
+    private ParticipantProfileResolver profileResolver;
+
     @Override
     public String name() {
         return NAME;
@@ -94,7 +98,7 @@ public class TransferProcessApiV5Extension implements ServiceExtension {
 
         authorizationService.addLookupFunction(TransferProcess.class, this::findTransferProcess);
 
-        webService.registerResource(ApiContext.MANAGEMENT, new TransferProcessApiV5Controller(context.getMonitor(), authorizationService, participantContextService, service, managementApiTransformerRegistry));
+        webService.registerResource(ApiContext.MANAGEMENT, new TransferProcessApiV5Controller(context.getMonitor(), authorizationService, participantContextService, service, profileResolver, managementApiTransformerRegistry));
         webService.registerDynamicResource(ApiContext.MANAGEMENT, TransferProcessApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
     }
 

--- a/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v5/TransferProcessApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v5/TransferProcessApiV5Controller.java
@@ -40,15 +40,19 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.Suspend
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.TerminateTransferCommand;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.protocol.spi.ParticipantProfileResolver;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.Violation;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.ObjectNotFoundException;
+import org.eclipse.edc.web.spi.exception.ValidationFailureException;
 import org.eclipse.edc.web.spi.validation.SchemaType;
 
+import java.util.List;
 import java.util.Optional;
 
 import static jakarta.json.stream.JsonCollectors.toJsonArray;
@@ -71,13 +75,16 @@ public class TransferProcessApiV5Controller implements TransferProcessApiV5 {
     private final AuthorizationService authorizationService;
     private final ParticipantContextService participantContextService;
     private final TransferProcessService service;
+    private final ParticipantProfileResolver profileResolver;
     private final TypeTransformerRegistry transformerRegistry;
 
-    public TransferProcessApiV5Controller(Monitor monitor, AuthorizationService authorizationService, ParticipantContextService participantContextService, TransferProcessService service, TypeTransformerRegistry transformerRegistry) {
+    public TransferProcessApiV5Controller(Monitor monitor, AuthorizationService authorizationService, ParticipantContextService participantContextService,
+                                          TransferProcessService service, ParticipantProfileResolver profileResolver, TypeTransformerRegistry transformerRegistry) {
         this.monitor = monitor;
         this.authorizationService = authorizationService;
         this.participantContextService = participantContextService;
         this.service = service;
+        this.profileResolver = profileResolver;
         this.transformerRegistry = transformerRegistry;
     }
 
@@ -173,6 +180,8 @@ public class TransferProcessApiV5Controller implements TransferProcessApiV5 {
         var participantContext = participantContextService.getParticipantContext(participantContextId)
                 .orElseThrow(exceptionMapper(ParticipantContext.class, participantContextId));
 
+        checkProfile(participantContextId, transferRequest.getProfile());
+
         var createdTransfer = service.initiateTransfer(participantContext, transferRequest)
                 .onSuccess(d -> monitor.debug(format("Transfer Process created %s", d.getId())))
                 .orElseThrow(it -> mapToException(it, TransferProcess.class));
@@ -244,5 +253,12 @@ public class TransferProcessApiV5Controller implements TransferProcessApiV5 {
         service.resume(new ResumeTransferCommand(id))
                 .onSuccess(tp -> monitor.debug(format("Resumption requested for TransferProcess with ID %s", id)))
                 .orElseThrow(exceptionMapper(TransferProcess.class, id));
+    }
+
+    private void checkProfile(String participantContextId, String profileId) {
+        var profile = profileResolver.resolve(participantContextId, profileId);
+        if (profile == null) {
+            throw new ValidationFailureException(List.of(Violation.violation("No profile '%s' for participant '%s'".formatted(profileId, participantContextId), null)));
+        }
     }
 }

--- a/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v5/TransferProcessApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v5/TransferProcessApiV5Controller.java
@@ -46,7 +46,6 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
-import org.eclipse.edc.validator.spi.Violation;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.ObjectNotFoundException;
 import org.eclipse.edc.web.spi.exception.ValidationFailureException;
@@ -63,6 +62,7 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Terminat
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_TYPE_TERM;
 import static org.eclipse.edc.participantcontext.spi.types.ParticipantResource.filterByParticipantContextId;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
+import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.mapToException;
 
@@ -258,7 +258,7 @@ public class TransferProcessApiV5Controller implements TransferProcessApiV5 {
     private void checkProfile(String participantContextId, String profileId) {
         var profile = profileResolver.resolve(participantContextId, profileId);
         if (profile == null) {
-            throw new ValidationFailureException(List.of(Violation.violation("No profile '%s' for participant '%s'".formatted(profileId, participantContextId), null)));
+            throw new ValidationFailureException(List.of(violation("No profile '%s' for participant '%s'".formatted(profileId, participantContextId), null)));
         }
     }
 }

--- a/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/BaseTransferProcessApiControllerTest.java
+++ b/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/BaseTransferProcessApiControllerTest.java
@@ -30,6 +30,8 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.command.Termina
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContext;
+import org.eclipse.edc.protocol.spi.ParticipantProfileResolver;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
@@ -64,6 +66,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
     protected final AuthorizationService authorizationService = mock();
     protected final TransferProcessService service = mock();
     protected final ParticipantContextService participantContextService = mock();
+    protected final ParticipantProfileResolver profileResolver = mock();
     private final String participantContextId = "test-participant-context-id";
 
     protected abstract String versionPath();
@@ -77,6 +80,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
     @BeforeEach
     void setup() {
         when(authorizationService.authorize(any(), any(), any(), any())).thenReturn(ServiceResult.success());
+        when(profileResolver.resolve(any(), any())).thenReturn(mock(DataspaceProfileContext.class));
     }
 
     @NotNull

--- a/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v5/TransferProcessApiV5ControllerTest.java
+++ b/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v5/TransferProcessApiV5ControllerTest.java
@@ -19,7 +19,7 @@ import org.eclipse.edc.connector.controlplane.api.management.transferprocess.Bas
 public class TransferProcessApiV5ControllerTest extends BaseTransferProcessApiControllerTest {
     @Override
     protected Object controller() {
-        return new TransferProcessApiV5Controller(monitor, authorizationService, participantContextService, service, transformerRegistry);
+        return new TransferProcessApiV5Controller(monitor, authorizationService, participantContextService, service, profileResolver, transformerRegistry);
     }
 
     @Override

--- a/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/ParticipantProfileResolver.java
+++ b/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/ParticipantProfileResolver.java
@@ -15,9 +15,9 @@
 package org.eclipse.edc.protocol.spi;
 
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Resolves the {@link DataspaceProfileContext}s a given participant context is associated with.
@@ -52,7 +52,8 @@ public interface ParticipantProfileResolver {
      *
      * @param participantContextId the participant context identifier
      * @param profileId            the profile id
-     * @return the resolved profile, or empty if the participant is not associated with it
+     * @return the resolved profile, or null if the participant is not associated with it
      */
-    Optional<DataspaceProfileContext> resolve(String participantContextId, String profileId);
+    @Nullable
+    DataspaceProfileContext resolve(String participantContextId, String profileId);
 }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CatalogApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CatalogApiV5EndToEndTest.java
@@ -281,6 +281,28 @@ public class CatalogApiV5EndToEndTest {
         }
 
         @Test
+        void requestCatalog_shouldReturnBadRequest_withWrongProfile(ManagementEndToEndV5TestContext context) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(TYPE, "CatalogRequest")
+                    .add("counterPartyAddress", context.providerProtocolUrl(COUNTER_PARTY_ID, context.profile()))
+                    .add("counterPartyId", COUNTER_PARTY_ID)
+                    .add("profile", "wrong-profile")
+                    .build()
+                    .toString();
+
+            context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .body(requestBody)
+                    .post("/v5beta/participants/%s/catalog/request".formatted(PARTICIPANT_CONTEXT_ID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(400)
+                    .contentType(JSON)
+                    .body("[0].message", containsString("No profile 'wrong-profile' for participant 'test-participant'"));
+        }
+
+        @Test
         void requestCatalog_whenAssetIsCatalogAsset_shouldReturnCatalogOfCatalogs(ManagementEndToEndV5TestContext context, AssetIndex assetIndex,
                                                                                   PolicyDefinitionStore policyDefinitionStore,
                                                                                   ContractDefinitionStore contractDefinitionStore) {
@@ -363,6 +385,30 @@ public class CatalogApiV5EndToEndTest {
                     .body(ID, is("asset-id"))
                     .body(TYPE, is("Dataset"))
                     .body("distribution[0].accessService.'@id'", notNullValue());
+        }
+
+        @Test
+        void getDataset_shouldReturnBadRequest_whenWrongProfile(ManagementEndToEndV5TestContext context) {
+
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(TYPE, "DatasetRequest")
+                    .add(ID, "asset-id")
+                    .add("counterPartyAddress", context.providerProtocolUrl(COUNTER_PARTY_ID, context.profile()))
+                    .add("counterPartyId", COUNTER_PARTY_ID)
+                    .add("profile", "wrong-profile")
+                    .build()
+                    .toString();
+
+            context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .body(requestBody)
+                    .post("/v5beta/participants/%s/catalog/dataset/request".formatted(PARTICIPANT_CONTEXT_ID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(400)
+                    .contentType(JSON)
+                    .body("[0].message", containsString("No profile 'wrong-profile' for participant 'test-participant'"));
         }
 
         @Test

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/ContractNegotiationApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/ContractNegotiationApiV5EndToEndTest.java
@@ -35,6 +35,7 @@ import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
 import org.eclipse.edc.test.e2e.managementapi.Runtimes;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -98,7 +99,7 @@ public class ContractNegotiationApiV5EndToEndTest {
         @Test
         void initiate(ManagementEndToEndV5TestContext context, ContractNegotiationStore store) {
 
-            var requestJson = contractRequestJson();
+            var requestJson = contractRequestJson(context.profile());
 
             var id = context.baseRequest(participantTokenJwt)
                     .contentType(JSON)
@@ -132,8 +133,24 @@ public class ContractNegotiationApiV5EndToEndTest {
         }
 
         @Test
+        void initiate_ShouldFails_whenWrongProfile(ManagementEndToEndV5TestContext context) {
+
+            var requestJson = contractRequestJson("wrong-profile");
+
+            context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .body(requestJson.toString())
+                    .post("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/contractnegotiations")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(400)
+                    .contentType(JSON)
+                    .body("[0].message", CoreMatchers.containsString("No profile 'wrong-profile' for participant 'test-participant'"));
+        }
+
+        @Test
         void initiate_tokenBearerWrong(ManagementEndToEndV5TestContext context, OauthServer authServer, ParticipantContextService service) {
-            var requestJson = contractRequestJson();
+            var requestJson = contractRequestJson(context.profile());
 
             var otherParticipantId = UUID.randomUUID().toString();
 
@@ -154,7 +171,7 @@ public class ContractNegotiationApiV5EndToEndTest {
 
         @Test
         void initiate_tokenLacksWriteScope(ManagementEndToEndV5TestContext context, OauthServer authServer, ParticipantContextService service) {
-            var requestJson = contractRequestJson();
+            var requestJson = contractRequestJson(context.profile());
 
             var otherParticipantId = UUID.randomUUID().toString();
 
@@ -176,7 +193,7 @@ public class ContractNegotiationApiV5EndToEndTest {
         @Test
         void initiate_tokenBearerIsAdmin(ManagementEndToEndV5TestContext context, OauthServer authServer, ContractNegotiationStore store) {
 
-            var requestJson = contractRequestJson();
+            var requestJson = contractRequestJson(context.profile());
 
             var token = authServer.createAdminToken();
 
@@ -639,12 +656,12 @@ public class ContractNegotiationApiV5EndToEndTest {
                     .statusCode(403);
         }
 
-        private JsonObject contractRequestJson() {
+        private JsonObject contractRequestJson(String profile) {
             return createObjectBuilder()
                     .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
                     .add(TYPE, "ContractRequest")
                     .add("counterPartyAddress", "test-address")
-                    .add("profile", "test-test-profile")
+                    .add("profile", profile)
                     .add("providerId", "test-provider-id")
                     .add("callbackAddresses", createCallbackAddress())
                     .add("policy", createPolicy())

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/TransferProcessApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/TransferProcessApiV5EndToEndTest.java
@@ -37,6 +37,7 @@ import org.eclipse.edc.spi.types.domain.DataAddress;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
 import org.eclipse.edc.test.e2e.managementapi.Runtimes;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -117,7 +118,7 @@ public class TransferProcessApiV5EndToEndTest {
                     .build();
             contractNegotiationStore.save(contractNegotiation);
 
-            var requestBody = createTransferRequestJson(contractId, assetId);
+            var requestBody = createTransferRequestJson(contractId, assetId, context.profile());
 
             var id = context.baseRequest(participantTokenJwt)
                     .contentType(JSON)
@@ -134,7 +135,7 @@ public class TransferProcessApiV5EndToEndTest {
                     });
         }
 
-        private JsonObject createTransferRequestJson(String contractId, String assetId) {
+        private JsonObject createTransferRequestJson(String contractId, String assetId, String profile) {
             return createObjectBuilder()
                     .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
                     .add(TYPE, "TransferRequest")
@@ -147,7 +148,7 @@ public class TransferProcessApiV5EndToEndTest {
                     )
                     .add("transferType", "HttpData-PUSH")
                     .add("callbackAddresses", createCallbackAddress())
-                    .add("profile", "test-profile")
+                    .add("profile", profile)
                     .add("counterPartyAddress", "http://connector-address")
                     .add("contractId", contractId)
                     .add("assetId", assetId)
@@ -172,10 +173,28 @@ public class TransferProcessApiV5EndToEndTest {
         }
 
         @Test
+        void initiate_shouldFails_whenWrongProfile(ManagementEndToEndV5TestContext context) {
+            var assetId = UUID.randomUUID().toString();
+            var contractId = UUID.randomUUID().toString();
+            var requestBody = createTransferRequestJson(contractId, assetId, "wrong-profile");
+
+
+            context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .body(requestBody.toString())
+                    .post("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/transferprocesses")
+                    .then()
+                    .log().ifError()
+                    .statusCode(400)
+                    .contentType(JSON)
+                    .body("[0].message", CoreMatchers.containsString("No profile 'wrong-profile' for participant 'test-participant'"));
+        }
+
+        @Test
         void initiate_tokenBearerWrong(ManagementEndToEndV5TestContext context, OauthServer authServer, ParticipantContextService service) {
             var assetId = UUID.randomUUID().toString();
             var contractId = UUID.randomUUID().toString();
-            var requestBody = createTransferRequestJson(contractId, assetId);
+            var requestBody = createTransferRequestJson(contractId, assetId, context.profile());
 
             var otherParticipantId = UUID.randomUUID().toString();
 
@@ -197,7 +216,7 @@ public class TransferProcessApiV5EndToEndTest {
         void initiate_tokenLacksWriteScope(ManagementEndToEndV5TestContext context, OauthServer authServer) {
             var assetId = UUID.randomUUID().toString();
             var contractId = UUID.randomUUID().toString();
-            var requestBody = createTransferRequestJson(contractId, assetId);
+            var requestBody = createTransferRequestJson(contractId, assetId, context.profile());
 
             var token = authServer.createToken(PARTICIPANT_CONTEXT_ID, Map.of("scope", "management-api:read"));
 


### PR DESCRIPTION
## What this PR changes/adds

add validation of profile/protocol field in v5 management api:

- Adds ParticipantProfileResolver into catalog / negotiation / transfer controller for checking that the participant can handle the dsp request with the specified profile.
- Refactor the ParticipantProfileResolver to remove Optional in the resolve, returning `null` instead if the profile is not found. 

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5737 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
