### PR TITLE
feat: dataspace profile configuration

### DIFF
--- a/core/common/participant-context-connector-core/src/main/java/org/eclipse/edc/participantcontext/connector/ConnectorParticipantContextExtension.java
+++ b/core/common/participant-context-connector-core/src/main/java/org/eclipse/edc/participantcontext/connector/ConnectorParticipantContextExtension.java
@@ -36,7 +36,7 @@ public class ConnectorParticipantContextExtension implements ServiceExtension {
 
     public static final String NAME = "Connector Participant Context Extension";
 
-    @Setting(description = "When running in virtual mode, enable all the participants to use all the profiles enabled in the connector", key = "edc.dsp.profiles.enable.all", defaultValue = "false")
+    @Setting(description = "When running in virtual mode, enable all the participants to use all the profiles enabled in the connector", key = "edc.dataspace.enable.profiles.all", defaultValue = "false")
     private Boolean dspEnableAllProfiles;
 
     @Inject

--- a/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/build.gradle.kts
+++ b/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     api(project(":spi:common:core-spi"))
     api(project(":spi:common:web-spi"))
     api(project(":data-protocols:dsp:dsp-spi"))
+    api(project(":data-protocols:dsp:dsp-http-spi"))
     api(project(":data-protocols:dsp:dsp-virtual:dsp-http-virtual-spi"))
     implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
 

--- a/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/main/java/org/eclipse/edc/protocol/dsp/http/profile/DataspaceProfileConfigurationExtension.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/main/java/org/eclipse/edc/protocol/dsp/http/profile/DataspaceProfileConfigurationExtension.java
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.http.profile;
+
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.protocol.dsp.http.spi.api.DspBaseWebhookAddress;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContext;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.protocol.spi.DefaultParticipantIdExtractionFunction;
+import org.eclipse.edc.protocol.spi.ProtocolVersion;
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+import java.util.Arrays;
+import java.util.Map;
+
+@Extension(value = DataspaceProfileConfigurationExtension.NAME)
+public class DataspaceProfileConfigurationExtension implements ServiceExtension {
+
+    public static final String NAME = "Dataspace Profile Configuration Extension";
+
+    public static final String EDC_DATASPACE_PROFILES_PREFIX = "edc.dataspace.profiles";
+
+    public static final String PROFILE_NAME = "name";
+    public static final String PROTOCOL_VERSION = "protocolVersion";
+    public static final String PROTOCOL_BINDING = "protocolBinding";
+    public static final String PROTOCOL_NAMESPACE = "protocolNamespace";
+    public static final String PROFILE_JSON_LD_CONTEXT = "jsonLdContextsUrl";
+
+    @SettingContext(EDC_DATASPACE_PROFILES_PREFIX)
+    @Configuration
+    private Map<String, DataspaceProfileConfiguration> profileConfiguration;
+
+    @Inject
+    private DefaultParticipantIdExtractionFunction participantIdExtractionFunction;
+
+    @Inject
+    private DataspaceProfileContextRegistry profileRegistry;
+
+    @Inject
+    private DspBaseWebhookAddress dspWebhookAddress;
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        profileConfiguration.values().stream()
+                .map(this::toDataspaceProfileContext)
+                .forEach(profileRegistry::register);
+    }
+
+    private DataspaceProfileContext toDataspaceProfileContext(DataspaceProfileConfiguration config) {
+        var namespace = new JsonLdNamespace(config.protocolNamespace());
+        var protocolVersion = new ProtocolVersion(config.protocolVersion(), "/" + config.name(), config.protocolBinding());
+
+        var jsonLdContextsUrl = Arrays.stream(config.jsonLdContextsUrl().split(","))
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .toList();
+
+        return new DataspaceProfileContext(
+                config.name(),
+                protocolVersion,
+                () -> dspWebhookAddress.get() + "/" + config.name(),
+                participantIdExtractionFunction,
+                namespace,
+                jsonLdContextsUrl);
+    }
+
+    @Settings
+    private record DataspaceProfileConfiguration(
+            @Setting(
+                    key = PROFILE_NAME,
+                    description = "The name of the dataspace profile.")
+            String name,
+            @Setting(
+                    key = PROTOCOL_VERSION,
+                    description = "The version of the DSP protocol this profile binds to.")
+            String protocolVersion,
+            @Setting(
+                    key = PROTOCOL_BINDING,
+                    description = "The protocol binding (e.g. 'http') of the DSP protocol this profile binds to.")
+            String protocolBinding,
+            @Setting(
+                    key = PROTOCOL_NAMESPACE,
+                    description = "The JSON-LD namespace of the dataspace profile.")
+            String protocolNamespace,
+            @Setting(
+                    key = PROFILE_JSON_LD_CONTEXT,
+                    description = "The JSON-LD context URLs of the dataspace profile.")
+            String jsonLdContextsUrl
+    ) {
+
+    }
+}

--- a/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -13,3 +13,4 @@
 #
 
 org.eclipse.edc.protocol.dsp.http.DspVirtualHttpCoreExtension
+org.eclipse.edc.protocol.dsp.http.profile.DataspaceProfileConfigurationExtension

--- a/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/test/java/org/eclipse/edc/protocol/dsp/http/profile/DataspaceProfileConfigurationExtensionTest.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/test/java/org/eclipse/edc/protocol/dsp/http/profile/DataspaceProfileConfigurationExtensionTest.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.dsp.http.profile;
+
+import org.eclipse.edc.boot.system.injection.ObjectFactory;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.junit.extensions.TestExtensionContext;
+import org.eclipse.edc.protocol.dsp.http.spi.api.DspBaseWebhookAddress;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContext;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
+import org.eclipse.edc.protocol.spi.DefaultParticipantIdExtractionFunction;
+import org.eclipse.edc.protocol.spi.ProtocolVersion;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class DataspaceProfileConfigurationExtensionTest {
+
+    private static final String BASE_WEBHOOK = "http://localhost:8080/protocol";
+
+    private final DataspaceProfileContextRegistry registry = mock();
+    private final DspBaseWebhookAddress webhookAddress = mock();
+    private final DefaultParticipantIdExtractionFunction idExtractionFunction = mock();
+
+    @BeforeEach
+    void setup(TestExtensionContext context) {
+        when(webhookAddress.get()).thenReturn(BASE_WEBHOOK);
+        context.registerService(DataspaceProfileContextRegistry.class, registry);
+        context.registerService(DspBaseWebhookAddress.class, webhookAddress);
+        context.registerService(DefaultParticipantIdExtractionFunction.class, idExtractionFunction);
+    }
+
+    @Test
+    void prepare_registersProfileFromConfiguration(TestExtensionContext context, ObjectFactory factory) {
+        context.setConfig(ConfigFactory.fromMap(Map.of(
+                "edc.dataspace.profiles.dsp2025_1.name", "dsp2025_1",
+                "edc.dataspace.profiles.dsp2025_1.protocolVersion", "2025-1",
+                "edc.dataspace.profiles.dsp2025_1.protocolBinding", "HTTPS",
+                "edc.dataspace.profiles.dsp2025_1.protocolNamespace", "https://w3id.org/dspace/v1",
+                "edc.dataspace.profiles.dsp2025_1.jsonLdContextsUrl", "https://w3id.org/dspace/v1/context.jsonld , https://example.org/extra.jsonld"
+        )));
+
+        var extension = factory.constructInstance(DataspaceProfileConfigurationExtension.class);
+        extension.initialize(context);
+
+        var captor = ArgumentCaptor.forClass(DataspaceProfileContext.class);
+        verify(registry).register(captor.capture());
+
+        var registered = captor.getValue();
+        assertThat(registered.name()).isEqualTo("dsp2025_1");
+        assertThat(registered.protocolVersion()).isEqualTo(new ProtocolVersion("2025-1", "/dsp2025_1", "HTTPS"));
+        assertThat(registered.protocolNamespace()).isEqualTo(new JsonLdNamespace("https://w3id.org/dspace/v1"));
+        assertThat(registered.idExtractionFunction()).isSameAs(idExtractionFunction);
+        assertThat(registered.webhook().url()).isEqualTo(BASE_WEBHOOK + "/dsp2025_1");
+        assertThat(registered.jsonLdContextsUrl())
+                .containsExactly("https://w3id.org/dspace/v1/context.jsonld", "https://example.org/extra.jsonld");
+    }
+
+    @Test
+    void prepare_registersMultipleProfiles(TestExtensionContext context, ObjectFactory factory) {
+        context.setConfig(ConfigFactory.fromMap(Map.of(
+                "edc.dataspace.profiles.dsp2025_1.name", "dsp2025_1",
+                "edc.dataspace.profiles.dsp2025_1.protocolVersion", "2025-1",
+                "edc.dataspace.profiles.dsp2025_1.protocolBinding", "HTTPS",
+                "edc.dataspace.profiles.dsp2025_1.protocolNamespace", "https://w3id.org/dspace/v1",
+                "edc.dataspace.profiles.dsp2025_1.jsonLdContextsUrl", "https://w3id.org/dspace/v1/context.jsonld",
+                "edc.dataspace.profiles.dsp2024_1.name", "dsp2024_1",
+                "edc.dataspace.profiles.dsp2024_1.protocolVersion", "2024-1",
+                "edc.dataspace.profiles.dsp2024_1.protocolBinding", "HTTPS",
+                "edc.dataspace.profiles.dsp2024_1.protocolNamespace", "https://w3id.org/dspace/2024/1",
+                "edc.dataspace.profiles.dsp2024_1.jsonLdContextsUrl", "https://w3id.org/dspace/2024/1/context.jsonld"
+        )));
+
+        var extension = factory.constructInstance(DataspaceProfileConfigurationExtension.class);
+        extension.initialize(context);
+
+        verify(registry, times(2)).register(ArgumentCaptor.forClass(DataspaceProfileContext.class).capture());
+    }
+
+    @Test
+    void prepare_blankAndExtraCommasInJsonLdContextsAreFiltered(TestExtensionContext context, ObjectFactory factory) {
+        context.setConfig(ConfigFactory.fromMap(Map.of(
+                "edc.dataspace.profiles.dsp2025_1.name", "dsp2025_1",
+                "edc.dataspace.profiles.dsp2025_1.protocolVersion", "2025-1",
+                "edc.dataspace.profiles.dsp2025_1.protocolBinding", "HTTPS",
+                "edc.dataspace.profiles.dsp2025_1.protocolNamespace", "https://w3id.org/dspace/v1",
+                "edc.dataspace.profiles.dsp2025_1.jsonLdContextsUrl", " https://w3id.org/dspace/v1/context.jsonld ,, "
+        )));
+
+        var extension = factory.constructInstance(DataspaceProfileConfigurationExtension.class);
+        extension.initialize(context);
+
+        var captor = ArgumentCaptor.forClass(DataspaceProfileContext.class);
+        verify(registry).register(captor.capture());
+        assertThat(captor.getValue().jsonLdContextsUrl())
+                .containsExactly("https://w3id.org/dspace/v1/context.jsonld");
+    }
+}

--- a/docs/developer/decision-records/2026-05-11-multi-profile-virtual-connector/README.md
+++ b/docs/developer/decision-records/2026-05-11-multi-profile-virtual-connector/README.md
@@ -57,7 +57,7 @@ registry depending on those subsystems.
 ### `ParticipantProfileResolver` (new SPI)
 
 A new SPI `ParticipantProfileResolver` resolves which profiles a participant is associated with.
-It backs onto a per-participant configuration entry (`edc.dsp.profiles`, a comma-separated list of
+It backs onto a per-participant configuration entry (`edc.dataspace.profiles`, a comma-separated list of
 profile ids) read through `ParticipantContextConfig`. It exposes two operations:
 
 - `resolveAll(participantContextId)` — every profile the participant is associated with, in
@@ -108,7 +108,7 @@ is participant-scoped in virtual mode.
 The classic single-participant runtime continues to register exactly one default profile, the
 resolver returns it for the lone participant, and existing DSP URLs are unaffected. Adopters that
 already register one standard profile keep the existing behaviour and only need to opt in to the
-virtual controllers and the per-participant `edc.dsp.profiles` configuration to take advantage of
+virtual controllers and the per-participant `edc.dataspace.profiles` configuration to take advantage of
 multi-profile support.
 
 ### Additional Notes

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participants.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participants.java
@@ -25,7 +25,7 @@ public record Participants(Participant provider, Participant consumer) {
      * Default DSP profile id used in tests. Matches the bundled default profile registered by
      * {@code DspApiConfigurationV2025Extension}. Tests that need a different profile id should
      * use the 6-arg {@link Participant} constructor and ensure the participant config sets
-     * {@code edc.dsp.profiles} accordingly.
+     * {@code edc.dataspace.profiles} accordingly.
      */
     public static final String DEFAULT_PROFILE_ID = "http-dsp-profile-2025-1";
 

--- a/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/ParticipantProfileService.java
+++ b/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/ParticipantProfileService.java
@@ -35,7 +35,7 @@ public interface ParticipantProfileService {
      * Configuration key under {@code ParticipantContextConfig} that holds the comma-separated list
      * of profile ids associated with a participant.
      */
-    String PROFILES_CONFIG_KEY = "edc.dsp.profiles";
+    String PROFILES_CONFIG_KEY = "edc.dataspace.profiles";
 
     /**
      * Returns all profiles the participant is associated with. Profile ids configured but not

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualTransferEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualTransferEndToEndTest.java
@@ -60,7 +60,7 @@ class VirtualTransferEndToEndTest {
                 put("edc.iam.oauth2.issuer", "test-issuer");
                 put("edc.encryption.strict", "false");
                 put("web.http.protocol.virtual", "true");
-                put("edc.dsp.profiles.enable.all", "true");
+                put("edc.dataspace.enable.profiles.all", "true");
             }
         });
     }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/Runtimes.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/Runtimes.java
@@ -59,7 +59,7 @@ public interface Runtimes {
         static Config config() {
             return ConfigFactory.fromMap(Map.of(
                     "edc.participant.id", "anonymous",
-                    "edc.dsp.profiles.enable.all", "true")
+                    "edc.dataspace.enable.profiles.all", "true")
             );
         }
     }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CatalogApiV5MultiProfileEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CatalogApiV5MultiProfileEndToEndTest.java
@@ -1,0 +1,275 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi.v5;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.authentication.OauthServer;
+import org.eclipse.edc.api.authentication.OauthServerEndToEndExtension;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.asset.spi.index.AssetIndex;
+import org.eclipse.edc.connector.controlplane.catalog.spi.policy.CatalogPolicyContext;
+import org.eclipse.edc.connector.controlplane.contract.spi.offer.store.ContractDefinitionStore;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
+import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
+import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.participantcontext.spi.config.model.ParticipantContextConfiguration;
+import org.eclipse.edc.participantcontext.spi.config.store.ParticipantContextConfigStore;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContextState;
+import org.eclipse.edc.policy.engine.spi.AtomicConstraintRuleFunction;
+import org.eclipse.edc.policy.engine.spi.PolicyEngine;
+import org.eclipse.edc.policy.engine.spi.RuleBindingRegistry;
+import org.eclipse.edc.policy.model.Action;
+import org.eclipse.edc.policy.model.AtomicConstraint;
+import org.eclipse.edc.policy.model.LiteralExpression;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.policy.model.Permission;
+import org.eclipse.edc.policy.model.Policy;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.test.e2e.managementapi.Runtimes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CatalogApiV5MultiProfileEndToEndTest {
+
+    @SuppressWarnings("JUnitMalformedDeclaration")
+    abstract static class Tests {
+
+
+        private static final List<String> PROFILES = List.of("dsp2025_1", "dsp2025_2");
+        private static final AtomicConstraintRuleFunction<Permission, CatalogPolicyContext> POLICY_FUNCTION = mock();
+
+        @BeforeAll
+        static void setup(PolicyEngine policyEngine, RuleBindingRegistry ruleBindingRegistry) {
+
+            ruleBindingRegistry.bind("use", "catalog");
+            ruleBindingRegistry.bind("profile", "catalog");
+
+            policyEngine.registerFunction(CatalogPolicyContext.class, Permission.class, "profile", POLICY_FUNCTION);
+        }
+
+        @AfterEach
+        void teardown(ParticipantContextService participantContextService) {
+            var list = participantContextService.search(QuerySpec.max())
+                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+            for (var p : list) {
+                participantContextService.deleteParticipantContext(p.getParticipantContextId()).orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+            }
+        }
+
+        @Test
+        void requestCatalogMultipleProfile(ManagementEndToEndV5TestContext context, ParticipantContextService participantContextService,
+                                           ParticipantContextConfigStore configStore,
+                                           AssetIndex assetIndex, PolicyDefinitionStore policyDefinitionStore,
+                                           ContractDefinitionStore contractDefinitionStore, OauthServer authServer) {
+
+
+            when(POLICY_FUNCTION.evaluate(any(), eq("dsp2025_1"), any(), any()))
+                    .thenReturn(true)
+                    .thenReturn(false);
+
+            when(POLICY_FUNCTION.evaluate(any(), eq("dsp2025_2"), any(), any()))
+                    .thenReturn(false)
+                    .thenReturn(true);
+
+            var providerContextId = "provider-context-" + UUID.randomUUID();
+            var consumerContextId = "consumer-context-" + UUID.randomUUID();
+
+            var participantTokenJwt = authServer.createToken(consumerContextId);
+
+            createParticipant(participantContextService, configStore, consumerContextId, PROFILES);
+            createParticipant(participantContextService, configStore, providerContextId, PROFILES);
+
+
+            var firstAsset = "asset1";
+            var secondAsset = "asset2";
+
+            assetIndex.create(createAsset(providerContextId, firstAsset).build());
+            assetIndex.create(createAsset(providerContextId, secondAsset).build());
+
+            createContractOffer(providerContextId, policyDefinitionStore, contractDefinitionStore, firstAsset, "dsp2025_1");
+            createContractOffer(providerContextId, policyDefinitionStore, contractDefinitionStore, secondAsset, "dsp2025_2");
+
+            var firstCatalog = fetchCatalog(context, providerContextId, participantTokenJwt, consumerContextId, "dsp2025_1");
+
+            assertCatalogContainsAsset(firstCatalog, firstAsset);
+            var secondCatalog = fetchCatalog(context, providerContextId, participantTokenJwt, consumerContextId, "dsp2025_2");
+            assertCatalogContainsAsset(secondCatalog, secondAsset);
+
+        }
+
+        private void assertCatalogContainsAsset(JsonObject catalog, String assetId) {
+            var datasets = catalog.getJsonArray("dataset");
+            var containsAsset = datasets.stream()
+                    .filter(JsonObject.class::isInstance)
+                    .map(JsonObject.class::cast)
+                    .allMatch(dataset -> assetId.equals(dataset.getString(ID)));
+
+            if (!containsAsset) {
+                throw new AssertionError("Catalog does not contain  asset with id: %s, or contains asset with wrong id".formatted(assetId));
+            }
+        }
+
+        private void createContractOffer(String participantContextId, PolicyDefinitionStore policyStore,
+                                         ContractDefinitionStore contractDefStore, String assetId, String profile) {
+
+            var policyId = UUID.randomUUID().toString();
+            var permission = Permission.Builder.newInstance().action(Action.Builder.newInstance().type("use").build())
+
+                    .constraint(AtomicConstraint.Builder.newInstance()
+                            .leftExpression(new LiteralExpression("profile"))
+                            .operator(Operator.EQ)
+                            .rightExpression(new LiteralExpression(profile))
+                            .build())
+                    .build();
+            var policy = Policy.Builder.newInstance()
+                    .permission(permission)
+                    .build();
+
+            var contractDefinition = ContractDefinition.Builder.newInstance()
+                    .id(UUID.randomUUID().toString())
+                    .contractPolicyId(policyId)
+                    .accessPolicyId(policyId)
+                    .assetsSelectorCriterion(Criterion.criterion(EDC_NAMESPACE + "id", "=", assetId))
+                    .participantContextId(participantContextId)
+                    .build();
+
+
+            policyStore.create(PolicyDefinition.Builder.newInstance().id(policyId)
+                    .participantContextId(participantContextId)
+                    .policy(policy).build());
+            contractDefStore.save(contractDefinition);
+
+        }
+
+        private Asset.Builder createAsset(String participantContextId, String id) {
+            return Asset.Builder.newInstance()
+                    .participantContextId(participantContextId)
+                    .id(id);
+        }
+
+
+        private void createParticipant(ParticipantContextService participantContextService,
+                                       ParticipantContextConfigStore configStore, String participantContextId, List<String> profiles) {
+            var pc = ParticipantContext.Builder.newInstance()
+                    .participantContextId(participantContextId)
+                    .state(ParticipantContextState.ACTIVATED)
+                    .identity(participantContextId)
+                    .build();
+
+            var config = ParticipantContextConfiguration.Builder.newInstance()
+                    .participantContextId(participantContextId)
+                    .entries(Map.of("edc.mock.region", "eu",
+                            "edc.participant.id", "did:web:" + participantContextId,
+                            "edc.dataspace.profiles", String.join(",", profiles)
+                    ))
+                    .build();
+
+            configStore.save(config);
+
+            participantContextService.createParticipantContext(pc)
+                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+        }
+
+        private JsonObject fetchCatalog(ManagementEndToEndV5TestContext context, String providerContextId, String participantTokenJwt, String consumerContextId, String profile) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(TYPE, "CatalogRequest")
+                    .add("counterPartyAddress", context.providerProtocolUrl(providerContextId, profile))
+                    .add("counterPartyId", providerContextId)
+                    .add("profile", profile)
+                    .build()
+                    .toString();
+
+            return context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .body(requestBody)
+                    .post("/v5beta/participants/%s/catalog/request".formatted(consumerContextId))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .extract().body().as(JsonObject.class);
+        }
+
+    }
+
+    @Nested
+    @EndToEndTest
+    class InMemory extends Tests {
+
+        @Order(0)
+        @RegisterExtension
+        static final OauthServerEndToEndExtension AUTH_SERVER_EXTENSION = OauthServerEndToEndExtension.Builder.newInstance().build();
+
+        @Order(1)
+        @RegisterExtension
+        static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()
+                .name(Runtimes.ControlPlane.NAME)
+                .modules(Runtimes.ControlPlane.VIRTUAL_MODULES)
+                .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
+                .configurationProvider(InMemory::config)
+                .configurationProvider(AUTH_SERVER_EXTENSION::getConfig)
+                .paramProvider(ManagementEndToEndV5TestContext.class,
+                        ManagementEndToEndV5TestContext::forContext)
+                .build();
+
+        static Config config() {
+            return ConfigFactory.fromMap(Map.of(
+                            "edc.dataspace.profiles.dsp2025_1.name", "dsp2025_1",
+                            "edc.dataspace.profiles.dsp2025_1.protocolVersion", "2025-1",
+                            "edc.dataspace.profiles.dsp2025_1.protocolBinding", "HTTPS",
+                            "edc.dataspace.profiles.dsp2025_1.protocolNamespace", "https://w3id.org/dspace/2025/1/",
+                            "edc.dataspace.profiles.dsp2025_1.jsonLdContextsUrl", "https://w3id.org/dspace/2025/1/context.jsonld",
+                            "edc.dataspace.profiles.dsp2025_2.name", "dsp2025_2",
+                            "edc.dataspace.profiles.dsp2025_2.protocolVersion", "2025-1",
+                            "edc.dataspace.profiles.dsp2025_2.protocolBinding", "HTTPS",
+                            "edc.dataspace.profiles.dsp2025_2.protocolNamespace", "https://w3id.org/dspace/2025/1/",
+                            "edc.dataspace.profiles.dsp2025_2.jsonLdContextsUrl", "https://w3id.org/dspace/2025/1/context.jsonld"
+                    )
+            );
+        }
+    }
+
+}

--- a/system-tests/tck/dsp-tck-tests/src/test/java/org/eclipse/edc/tck/dsp/VirtualDspTckDockerTest.java
+++ b/system-tests/tck/dsp-tck-tests/src/test/java/org/eclipse/edc/tck/dsp/VirtualDspTckDockerTest.java
@@ -87,7 +87,7 @@ public class VirtualDspTckDockerTest extends DspTckDockerTest {
                 put("edc.transfer.proxy.token.verifier.publickey.alias", "public-key");
                 put("edc.iam.oauth2.jwks.url", "https://example.com/jwks");
                 put("edc.iam.oauth2.issuer", "test-issuer");
-                put("edc.dsp.profiles.enable.all", "true");
+                put("edc.dataspace.enable.profiles.all", "true");
             }
         });
     }


### PR DESCRIPTION
## What this PR changes/adds

Add dataspace profile configuration

The settings `edc.dsp.profiles` has been renamed to `edc.dataspace.profiles` and `edc.dsp.profiles.enable.all` has been renamed to `edc.dataspace.enable.profiles.all`

Also added an e2e tests with catalog interaction and multi profile scenario

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5758 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
