### PR TITLE
chore: provide TokenValidationService as default

### DIFF
--- a/core/common/token-core/src/main/java/org/eclipse/edc/token/TokenServicesExtension.java
+++ b/core/common/token-core/src/main/java/org/eclipse/edc/token/TokenServicesExtension.java
@@ -44,7 +44,7 @@ public class TokenServicesExtension implements ServiceExtension {
         return new TokenValidationRulesRegistryImpl();
     }
 
-    @Provider
+    @Provider(isDefault = true)
     public TokenValidationService validationService() {
         return new TokenValidationServiceImpl();
     }


### PR DESCRIPTION
## What this PR changes/adds

This PR changes the `@Provider` for the `TokenValidationService` to be a default provider

## Why it does that

to make it easier in downstream projects to replace the token validation service, e.g. with one based on Hashicorp Vault Transit.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Relates to https://github.com/eclipse-edc/IdentityHub/issues/982 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
