### PR TITLE
feat: discovery endpoint

### DIFF
--- a/core/common/lib/json-ld-lib/src/main/resources/document/management-context-v2.jsonld
+++ b/core/common/lib/json-ld-lib/src/main/resources/document/management-context-v2.jsonld
@@ -562,6 +562,34 @@
         }
       }
     },
+    "DiscoveryRequest": {
+      "@id": "edc:DiscoveryRequest",
+      "@context": {
+        "counterPartyId": {
+          "@id": "edc:counterPartyId"
+        },
+        "counterPartyAddress": {
+          "@id": "edc:counterPartyAddress"
+        }
+      }
+    },
+    "DiscoveryResponse": {
+      "@id": "edc:DiscoveryResponse",
+      "@context": {
+        "profile": {
+          "@id": "edc:profile"
+        },
+        "version": {
+          "@id": "edc:version"
+        },
+        "counterPartyPath": {
+          "@id": "edc:counterPartyPath"
+        },
+        "binding": {
+          "@id": "edc:binding"
+        }
+      }
+    },
     "inForceDate": "edc:inForceDate",
     "ruleFunctions": {
       "@id": "edc:ruleFunctions",

--- a/core/control-plane/control-plane-core/build.gradle.kts
+++ b/core/control-plane/control-plane-core/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
 dependencies {
     api(project(":spi:control-plane:asset-spi"))
     api(project(":spi:control-plane:control-plane-spi"))
+    api(project(":spi:common:http-spi"))
 
     implementation(project(":core:common:lib:store-lib"))
     implementation(project(":core:common:boot"))

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/discovery/DefaultUrlResolver.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/discovery/DefaultUrlResolver.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.discovery;
+
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryRequest;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryUrlResolver;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+import java.util.Objects;
+
+public class DefaultUrlResolver implements DiscoveryUrlResolver {
+
+    static final String WELL_KNOWN_PATH = "/.well-known/dspace-version";
+
+    @Override
+    public ServiceResult<String> resolve(DiscoveryRequest request) {
+        return ServiceResult.success(toWellKnownUrl(Objects.requireNonNull(request.counterPartyAddress())));
+    }
+
+    @Override
+    public boolean canResolve(DiscoveryRequest request) {
+        return request.counterPartyAddress() != null && !request.counterPartyAddress().isBlank() && request.counterPartyId() == null;
+    }
+
+    private String toWellKnownUrl(String baseUrl) {
+        var trimmed = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        return trimmed.endsWith(WELL_KNOWN_PATH) ? trimmed : trimmed + WELL_KNOWN_PATH;
+    }
+}

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/discovery/DiscoveryDefaultServicesExtension.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/discovery/DiscoveryDefaultServicesExtension.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.discovery;
+
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.protocol.spi.ParticipantProfileService;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryService;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.types.TypeManager;
+
+@Extension(value = DiscoveryDefaultServicesExtension.NAME)
+public class DiscoveryDefaultServicesExtension implements ServiceExtension {
+
+    public static final String NAME = "Discovery Default Services";
+
+    @Inject
+    private EdcHttpClient httpClient;
+    @Inject
+    private ParticipantProfileService participantProfileService;
+    @Inject
+    private TypeManager typeManager;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider(isDefault = true)
+    public DiscoveryService discoveryService() {
+        return new DiscoveryServiceImpl(httpClient, participantProfileService, typeManager.getMapper());
+    }
+}

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/discovery/DiscoveryServiceImpl.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/discovery/DiscoveryServiceImpl.java
@@ -1,0 +1,124 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.discovery;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContext;
+import org.eclipse.edc.protocol.spi.ParticipantProfileService;
+import org.eclipse.edc.protocol.spi.ProtocolVersion;
+import org.eclipse.edc.protocol.spi.ProtocolVersions;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryRequest;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryService;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryUrlResolver;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class DiscoveryServiceImpl implements DiscoveryService {
+
+    private final EdcHttpClient httpClient;
+    private final ParticipantProfileService participantProfileService;
+    private final ObjectMapper objectMapper;
+    private final List<DiscoveryUrlResolver> resolvers = new ArrayList<>();
+
+    public DiscoveryServiceImpl(
+            EdcHttpClient httpClient,
+            ParticipantProfileService participantProfileService,
+            ObjectMapper objectMapper) {
+        this.httpClient = httpClient;
+        this.participantProfileService = participantProfileService;
+        this.objectMapper = objectMapper;
+    }
+
+
+    @Override
+    public ServiceResult<List<DiscoveryResponse>> discover(String participantContextId, DiscoveryRequest request) {
+
+        var resolver = resolvers.stream()
+                .filter(r -> r.canResolve(request))
+                .findFirst()
+                .orElse(null);
+
+        if (resolver != null) {
+            return resolveMatches(participantContextId, request, resolver);
+
+        } else {
+            return ServiceResult.badRequest("No resolver found for request: %s".formatted(request));
+        }
+    }
+
+    private ServiceResult<List<DiscoveryResponse>> resolveMatches(String participantContextId, DiscoveryRequest request, DiscoveryUrlResolver resolver) {
+
+        var versionsResult = resolver.resolve(request).compose(this::fetchProtocolVersions);
+        if (versionsResult.failed()) {
+            return ServiceResult.badRequest(versionsResult.getFailureDetail());
+        }
+
+        var localProfiles = participantProfileService.resolveAll(participantContextId);
+        var matches = localProfiles.stream()
+                .flatMap(profileMatcher(versionsResult.getContent()))
+                .toList();
+
+        return ServiceResult.success(matches);
+    }
+
+    private Function<DataspaceProfileContext, Stream<? extends DiscoveryResponse>> profileMatcher(List<ProtocolVersion> versions) {
+        return profile -> versions.stream()
+                .filter(v -> v.version().equals(profile.protocolVersion().version()) &&
+                        v.binding().equals(profile.protocolVersion().binding()))
+                .map(v -> new DiscoveryResponse(
+                        profile.name(),
+                        v.version(),
+                        v.path(),
+                        v.binding()));
+    }
+
+
+    private ServiceResult<List<ProtocolVersion>> fetchProtocolVersions(String url) {
+        var request = new Request.Builder().url(url).get().build();
+        var result = httpClient.execute(request, response -> handleResponse(response, url));
+
+        if (result.failed()) {
+            return ServiceResult.badRequest(result.getFailureDetail());
+        }
+        return ServiceResult.success(result.getContent());
+    }
+
+    private Result<List<ProtocolVersion>> handleResponse(Response response, String url) {
+        if (!response.isSuccessful()) {
+            return Result.failure("Unexpected status %d fetching '%s'".formatted(response.code(), url));
+        }
+        try (var body = response.body()) {
+            var versions = objectMapper.readValue(body.byteStream(), ProtocolVersions.class);
+            return Result.success(versions.protocolVersions());
+        } catch (IOException e) {
+            return Result.failure("Failed to parse '%s': %s".formatted(url, e.getMessage()));
+        }
+    }
+
+    @Override
+    public void registerResolver(DiscoveryUrlResolver resolver) {
+        resolvers.add(resolver);
+    }
+}

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/discovery/DiscoveryServicesExtension.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/discovery/DiscoveryServicesExtension.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.discovery;
+
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryService;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+@Extension(value = DiscoveryServicesExtension.NAME)
+public class DiscoveryServicesExtension implements ServiceExtension {
+
+    public static final String NAME = "Discovery Services";
+
+    @Inject
+    private DiscoveryService discoveryService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        discoveryService.registerResolver(new DefaultUrlResolver());
+    }
+}

--- a/core/control-plane/control-plane-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/core/control-plane/control-plane-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -13,3 +13,5 @@
 #
 
 org.eclipse.edc.connector.controlplane.ControlPlaneDefaultServicesExtension
+org.eclipse.edc.connector.controlplane.discovery.DiscoveryDefaultServicesExtension
+org.eclipse.edc.connector.controlplane.discovery.DiscoveryServicesExtension

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/controlplane/discovery/DiscoveryServiceImplTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/controlplane/discovery/DiscoveryServiceImplTest.java
@@ -1,0 +1,238 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.discovery;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.protocol.spi.DataspaceProfileContext;
+import org.eclipse.edc.protocol.spi.ParticipantProfileService;
+import org.eclipse.edc.protocol.spi.ProtocolVersion;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryRequest;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryUrlResolver;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceFailure;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static okhttp3.MediaType.parse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DiscoveryServiceImplTest {
+
+    private static final String PARTICIPANT = "participant-id";
+    private static final String COUNTER_PARTY_BASE = "https://counter-party.example";
+
+    private final EdcHttpClient httpClient = mock();
+    private final ParticipantProfileService participantProfileService = mock();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final DiscoveryServiceImpl service = new DiscoveryServiceImpl(httpClient, participantProfileService, objectMapper);
+
+    private static Response httpResponse(Request request, int code, String body) {
+        return new Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .code(code)
+                .message(code >= 200 && code < 300 ? "OK" : "ERR")
+                .body(ResponseBody.create(body, parse("application/json")))
+                .build();
+    }
+
+    @Test
+    void shouldFailWhenNoResolverIsRegistered() {
+        var result = service.discover(PARTICIPANT, new DiscoveryRequest(null, COUNTER_PARTY_BASE));
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.reason()).isEqualTo(ServiceFailure.Reason.BAD_REQUEST);
+        verify(httpClient, never()).execute(any(Request.class), any(Function.class));
+    }
+
+    @Test
+    void shouldFailWhenNoResolverMatchesTheRequest() {
+        service.registerResolver(resolver(false, ServiceResult.success("ignored")));
+
+        var result = service.discover(PARTICIPANT, new DiscoveryRequest(null, COUNTER_PARTY_BASE));
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.reason()).isEqualTo(ServiceFailure.Reason.BAD_REQUEST);
+        verify(httpClient, never()).execute(any(Request.class), any(Function.class));
+    }
+
+    @Test
+    void shouldUseTheFirstResolverThatCanResolve() {
+        var matchingResolver = resolver(true, ServiceResult.success(COUNTER_PARTY_BASE));
+        var skippedResolver = resolver(true, ServiceResult.success("https://wrong.example"));
+        service.registerResolver(matchingResolver);
+        service.registerResolver(skippedResolver);
+        when(participantProfileService.resolveAll(PARTICIPANT)).thenReturn(List.of());
+        stubHttpVersions("{\"protocolVersions\":[]}");
+
+        var request = new DiscoveryRequest(null, COUNTER_PARTY_BASE);
+        var result = service.discover(PARTICIPANT, request);
+
+        assertThat(result.succeeded()).isTrue();
+        verify(matchingResolver).resolve(request);
+        verify(skippedResolver, never()).resolve(any());
+    }
+
+    @Test
+    void shouldReturnMatchesForOverlappingProfiles() {
+        service.registerResolver(resolver(true, ServiceResult.success(COUNTER_PARTY_BASE)));
+        when(participantProfileService.resolveAll(PARTICIPANT)).thenReturn(List.of(
+                profile("dsp-2025-1", new ProtocolVersion("2025-1", "/local-2025", "http")),
+                profile("dsp-2024-1", new ProtocolVersion("2024-1", "/local-2024", "http"))
+        ));
+        stubHttpVersions("""
+                {"protocolVersions":[
+                    {"version":"2025-1","path":"/remote-2025","binding":"http"},
+                    {"version":"2024-1","path":"/remote-2024","binding":"http"}
+                ]}""");
+
+        var result = service.discover(PARTICIPANT, new DiscoveryRequest(null, COUNTER_PARTY_BASE));
+
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).hasSize(2)
+                .anySatisfy(m -> {
+                    assertThat(m.profile()).isEqualTo("dsp-2025-1");
+                    assertThat(m.version()).isEqualTo("2025-1");
+                    assertThat(m.counterPartyPath()).isEqualTo("/remote-2025");
+                    assertThat(m.binding()).isEqualTo("http");
+                })
+                .anySatisfy(m -> {
+                    assertThat(m.profile()).isEqualTo("dsp-2024-1");
+                    assertThat(m.version()).isEqualTo("2024-1");
+                    assertThat(m.counterPartyPath()).isEqualTo("/remote-2024");
+                });
+    }
+
+    @Test
+    void shouldFilterByBothVersionAndBinding() {
+        service.registerResolver(resolver(true, ServiceResult.success(COUNTER_PARTY_BASE)));
+        when(participantProfileService.resolveAll(PARTICIPANT)).thenReturn(List.of(
+                profile("dsp-2025-1", new ProtocolVersion("2025-1", "/local", "http")),
+                profile("dsp-other", new ProtocolVersion("9999-1", "/x", "http"))
+        ));
+        stubHttpVersions("""
+                {"protocolVersions":[
+                    {"version":"2025-1","path":"/remote-http","binding":"http"},
+                    {"version":"2025-1","path":"/remote-grpc","binding":"grpc"}
+                ]}""");
+
+        var result = service.discover(PARTICIPANT, new DiscoveryRequest(null, COUNTER_PARTY_BASE));
+
+        assertThat(result.getContent()).singleElement().satisfies(m -> {
+            assertThat(m.profile()).isEqualTo("dsp-2025-1");
+            assertThat(m.binding()).isEqualTo("http");
+            assertThat(m.counterPartyPath()).isEqualTo("/remote-http");
+        });
+    }
+    
+    @Test
+    void shouldFailWhenResolverReturnsFailure() {
+        service.registerResolver(resolver(true, ServiceResult.notFound("no DataService endpoint")));
+
+        var result = service.discover(PARTICIPANT, new DiscoveryRequest("did:web:x", null));
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.reason()).isEqualTo(ServiceFailure.Reason.BAD_REQUEST);
+        verify(httpClient, never()).execute(any(Request.class), any(Function.class));
+    }
+
+    @Test
+    void shouldFailWhenWellKnownReturnsErrorStatus() {
+        service.registerResolver(resolver(true, ServiceResult.success(COUNTER_PARTY_BASE)));
+        when(httpClient.execute(any(Request.class), any(Function.class))).thenAnswer(invocation -> {
+            Function<Response, Result<?>> fn = invocation.getArgument(1);
+            return fn.apply(httpResponse(invocation.getArgument(0), 500, "boom"));
+        });
+
+        var result = service.discover(PARTICIPANT, new DiscoveryRequest(null, COUNTER_PARTY_BASE));
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.reason()).isEqualTo(ServiceFailure.Reason.BAD_REQUEST);
+        verify(participantProfileService, never()).resolveAll(any());
+    }
+
+    @Test
+    void shouldFailWhenWellKnownReturnsMalformedJson() {
+        service.registerResolver(resolver(true, ServiceResult.success(COUNTER_PARTY_BASE)));
+        stubHttpVersions("not-json");
+
+        var result = service.discover(PARTICIPANT, new DiscoveryRequest(null, COUNTER_PARTY_BASE));
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.reason()).isEqualTo(ServiceFailure.Reason.BAD_REQUEST);
+        verify(participantProfileService, never()).resolveAll(any());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenNoLocalProfilesConfigured() {
+        service.registerResolver(resolver(true, ServiceResult.success(COUNTER_PARTY_BASE)));
+        when(participantProfileService.resolveAll(PARTICIPANT)).thenReturn(List.of());
+        stubHttpVersions("""
+                {"protocolVersions":[{"version":"2025-1","path":"/remote","binding":"http"}]}""");
+
+        var result = service.discover(PARTICIPANT, new DiscoveryRequest(null, COUNTER_PARTY_BASE));
+
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmptyWhenCounterPartyAdvertisesNoVersions() {
+        service.registerResolver(resolver(true, ServiceResult.success(COUNTER_PARTY_BASE)));
+        when(participantProfileService.resolveAll(PARTICIPANT)).thenReturn(List.of(
+                profile("dsp-2025-1", new ProtocolVersion("2025-1", "/local", "http"))
+        ));
+        stubHttpVersions("{\"protocolVersions\":[]}");
+
+        var result = service.discover(PARTICIPANT, new DiscoveryRequest(null, COUNTER_PARTY_BASE));
+
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).isEmpty();
+    }
+
+    private DiscoveryUrlResolver resolver(boolean canResolve, ServiceResult<String> result) {
+        var resolver = mock(DiscoveryUrlResolver.class);
+        when(resolver.canResolve(any())).thenReturn(canResolve);
+        when(resolver.resolve(any())).thenReturn(result);
+        return resolver;
+    }
+
+    private DataspaceProfileContext profile(String name, ProtocolVersion version) {
+        return new DataspaceProfileContext(name, version, mock(), mock(),
+                new JsonLdNamespace("https://example.org/ns/"), List.of());
+    }
+
+    private void stubHttpVersions(String json) {
+        when(httpClient.execute(any(Request.class), any(Function.class))).thenAnswer(invocation -> {
+            Function<Response, Result<?>> fn = invocation.getArgument(1);
+            return fn.apply(httpResponse(invocation.getArgument(0), 200, json));
+        });
+    }
+}

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/discovery/from/JsonObjectFromDiscoveryResponseTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/discovery/from/JsonObjectFromDiscoveryResponseTransformer.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.transform.edc.discovery.from;
+
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_BINDING_IRI;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_COUNTER_PARTY_PATH_IRI;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_PROFILE_IRI;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_TYPE_IRI;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_VERSION_IRI;
+
+public class JsonObjectFromDiscoveryResponseTransformer extends AbstractJsonLdTransformer<DiscoveryResponse, JsonObject> {
+
+    private final JsonBuilderFactory jsonFactory;
+
+    public JsonObjectFromDiscoveryResponseTransformer(JsonBuilderFactory jsonFactory) {
+        super(DiscoveryResponse.class, JsonObject.class);
+        this.jsonFactory = jsonFactory;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull DiscoveryResponse match, @NotNull TransformerContext context) {
+        return jsonFactory.createObjectBuilder()
+                .add(TYPE, DISCOVERY_RESPONSE_TYPE_IRI)
+                .add(DISCOVERY_RESPONSE_PROFILE_IRI, match.profile())
+                .add(DISCOVERY_RESPONSE_VERSION_IRI, match.version())
+                .add(DISCOVERY_RESPONSE_COUNTER_PARTY_PATH_IRI, match.counterPartyPath())
+                .add(DISCOVERY_RESPONSE_BINDING_IRI, match.binding())
+                .build();
+    }
+}

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/discovery/to/JsonObjectToDiscoveryRequestTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/discovery/to/JsonObjectToDiscoveryRequestTransformer.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.transform.edc.discovery.to;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractJsonLdTransformer;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryRequest;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryRequest.DISCOVERY_REQUEST_COUNTER_PARTY_ADDRESS_IRI;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryRequest.DISCOVERY_REQUEST_COUNTER_PARTY_ID_IRI;
+
+public class JsonObjectToDiscoveryRequestTransformer extends AbstractJsonLdTransformer<JsonObject, DiscoveryRequest> {
+
+    public JsonObjectToDiscoveryRequestTransformer() {
+        super(JsonObject.class, DiscoveryRequest.class);
+    }
+
+    @Override
+    public @Nullable DiscoveryRequest transform(@NotNull JsonObject request, @NotNull TransformerContext context) {
+        var counterPartyId = transformString(request.get(DISCOVERY_REQUEST_COUNTER_PARTY_ID_IRI), context);
+        var counterPartyAddress = transformString(request.get(DISCOVERY_REQUEST_COUNTER_PARTY_ADDRESS_IRI), context);
+        return new DiscoveryRequest(counterPartyId, counterPartyAddress);
+    }
+}

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/discovery/from/JsonObjectFromDiscoveryResponseTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/discovery/from/JsonObjectFromDiscoveryResponseTransformerTest.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.transform.edc.discovery.from;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_BINDING_IRI;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_COUNTER_PARTY_PATH_IRI;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_PROFILE_IRI;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_TYPE_IRI;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_VERSION_IRI;
+import static org.mockito.Mockito.mock;
+
+class JsonObjectFromDiscoveryResponseTransformerTest {
+
+    private final TransformerContext context = mock();
+    private final JsonObjectFromDiscoveryResponseTransformer transformer = new JsonObjectFromDiscoveryResponseTransformer(Json.createBuilderFactory(Map.of()));
+
+    @Test
+    void types() {
+        assertThat(transformer.getInputType()).isEqualTo(DiscoveryResponse.class);
+        assertThat(transformer.getOutputType()).isEqualTo(JsonObject.class);
+    }
+
+    @Test
+    void transform() {
+        var match = new DiscoveryResponse("profile-1", "version", "/remote", "http");
+
+        var result = transformer.transform(match, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getString(TYPE)).isEqualTo(DISCOVERY_RESPONSE_TYPE_IRI);
+        assertThat(result.getString(DISCOVERY_RESPONSE_PROFILE_IRI)).isEqualTo("profile-1");
+        assertThat(result.getString(DISCOVERY_RESPONSE_COUNTER_PARTY_PATH_IRI)).isEqualTo("/remote");
+        assertThat(result.getString(DISCOVERY_RESPONSE_VERSION_IRI)).isEqualTo("version");
+        assertThat(result.getString(DISCOVERY_RESPONSE_BINDING_IRI)).isEqualTo("http");
+    }
+}

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/discovery/to/JsonObjectToDiscoveryRequestTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/discovery/to/JsonObjectToDiscoveryRequestTransformerTest.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.transform.edc.discovery.to;
+
+import com.apicatalog.jsonld.document.JsonDocument;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryRequest;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.Test;
+
+import static com.apicatalog.jsonld.JsonLd.expand;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryRequest.DISCOVERY_REQUEST_COUNTER_PARTY_ADDRESS_TERM;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryRequest.DISCOVERY_REQUEST_COUNTER_PARTY_ID_TERM;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryRequest.DISCOVERY_REQUEST_TYPE_TERM;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.mockito.Mockito.mock;
+
+class JsonObjectToDiscoveryRequestTransformerTest {
+
+    private final TransformerContext context = mock();
+    private final JsonObjectToDiscoveryRequestTransformer transformer = new JsonObjectToDiscoveryRequestTransformer();
+
+    @Test
+    void types() {
+        assertThat(transformer.getInputType()).isEqualTo(JsonObject.class);
+        assertThat(transformer.getOutputType()).isEqualTo(DiscoveryRequest.class);
+    }
+
+    @Test
+    void transform_address() {
+        var json = Json.createObjectBuilder()
+                .add("@context", Json.createObjectBuilder().add("@vocab", EDC_NAMESPACE))
+                .add(TYPE, DISCOVERY_REQUEST_TYPE_TERM)
+                .add(DISCOVERY_REQUEST_COUNTER_PARTY_ADDRESS_TERM, "https://example.org")
+                .build();
+
+        var result = transformer.transform(getExpanded(json), context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.counterPartyAddress()).isEqualTo("https://example.org");
+        assertThat(result.counterPartyId()).isNull();
+    }
+
+    @Test
+    void transform_id() {
+        var json = Json.createObjectBuilder()
+                .add("@context", Json.createObjectBuilder().add("@vocab", EDC_NAMESPACE))
+                .add(TYPE, DISCOVERY_REQUEST_TYPE_TERM)
+                .add(DISCOVERY_REQUEST_COUNTER_PARTY_ID_TERM, "did:web:example")
+                .build();
+
+        var result = transformer.transform(getExpanded(json), context);
+
+        assertThat(result.counterPartyId()).isEqualTo("did:web:example");
+        assertThat(result.counterPartyAddress()).isNull();
+    }
+
+    @Test
+    void transform_emptyBody() {
+        var json = Json.createObjectBuilder()
+                .add("@context", Json.createObjectBuilder().add("@vocab", EDC_NAMESPACE))
+                .add(TYPE, DISCOVERY_REQUEST_TYPE_TERM)
+                .build();
+
+        var result = transformer.transform(getExpanded(json), context);
+
+        assertThat(result.counterPartyId()).isNull();
+        assertThat(result.counterPartyAddress()).isNull();
+    }
+
+    private JsonObject getExpanded(JsonObject message) {
+        try {
+            return expand(JsonDocument.of(message)).get().asJsonArray().getJsonObject(0);
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/extensions/common/api/lib/management-api-lib/src/main/java/org/eclipse/edc/api/management/schema/ManagementApiJsonSchema.java
+++ b/extensions/common/api/lib/management-api-lib/src/main/java/org/eclipse/edc/api/management/schema/ManagementApiJsonSchema.java
@@ -52,6 +52,8 @@ public interface ManagementApiJsonSchema {
         String CEL_EXPRESSION_TEST_RESPONSE = EDC_MGMT_V4_SCHEMA_PREFIX + "/cel-expression-test-response-schema.json";
         String DATASPACE_PROFILE_CONTEXT = EDC_MGMT_V4_SCHEMA_PREFIX + "/dataspace-profile-schema.json";
         String ASSOCIATE_DATASPACE_PROFILE_CONTEXT = EDC_MGMT_V4_SCHEMA_PREFIX + "/associate-dataspace-profile-schema.json";
+        String DISCOVERY_REQUEST = EDC_MGMT_V4_SCHEMA_PREFIX + "/discovery-request-schema.json";
+        String DISCOVERY_RESPONSE = EDC_MGMT_V4_SCHEMA_PREFIX + "/discovery-response-schema.json";
 
 
         static String version() {

--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -14,7 +14,7 @@
   {
     "version": "5.0.0-beta",
     "urlPath": "/v5beta",
-    "lastUpdated": "2026-05-19T09:00:00Z",
+    "lastUpdated": "2026-05-21T09:00:00Z",
     "maturity": "beta"
   }
 ]

--- a/extensions/common/api/management-api-schema-validator/src/main/java/org/eclipse/edc/connector/api/management/schema/ManagementApiSchemaValidatorExtension.java
+++ b/extensions/common/api/management-api-schema-validator/src/main/java/org/eclipse/edc/connector/api/management/schema/ManagementApiSchemaValidatorExtension.java
@@ -39,6 +39,7 @@ import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.C
 import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.CONTRACT_REQUEST;
 import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.DATAPLANE_INSTANCE;
 import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.DATASET_REQUEST;
+import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.DISCOVERY_REQUEST;
 import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.EDR_ENTRY;
 import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.ID_RESPONSE;
 import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.V4.PARTICIPANT_CONTEXT;
@@ -120,6 +121,7 @@ public class ManagementApiSchemaValidatorExtension implements ServiceExtension {
             put(CEL_EXPRESSION_TYPE_TERM, CEL_EXPRESSION);
             put(CEL_EXPRESSION_TEST_REQUEST_TYPE_TERM, CEL_EXPRESSION_TEST_REQUEST);
             put("AssociateDataspaceProfile", ASSOCIATE_DATASPACE_PROFILE_CONTEXT);
+            put("DiscoveryRequest", DISCOVERY_REQUEST);
         }
     };
 

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/discovery-request-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/discovery-request-schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "DiscoveryRequestSchema",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/DiscoveryRequest"
+    }
+  ],
+  "$id": "https://w3id.org/edc/connector/management/schema/v4/discovery-request-schema.json",
+  "definitions": {
+    "DiscoveryRequest": {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "$ref": "https://w3id.org/edc/connector/management/schema/v4/context-schema.json"
+        },
+        "@type": {
+          "type": "string",
+          "const": "DiscoveryRequest"
+        },
+        "counterPartyId": {
+          "type": "string",
+          "description": "The counter party's DID. The DID is resolved and the 'DataService' entry of the DID document provides the base URL of the well-known endpoint."
+        },
+        "counterPartyAddress": {
+          "type": "string",
+          "format": "uri",
+          "description": "The counter party's discovery URL pointing directly at the '/.well-known/dspace-version' endpoint, or the host that serves it. Takes precedence over counterPartyId."
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "counterPartyId"
+          ]
+        },
+        {
+          "required": [
+            "counterPartyAddress"
+          ]
+        }
+      ],
+      "required": [
+        "@context",
+        "@type"
+      ]
+    }
+  }
+}

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/discovery-response-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/discovery-response-schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "DiscoveryResponseSchema",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/DiscoveryResponse"
+    }
+  ],
+  "$id": "https://w3id.org/edc/connector/management/schema/v4/discovery-response-schema.json",
+  "definitions": {
+    "DiscoveryResponse": {
+      "type": "object",
+      "properties": {
+        "@context": {
+          "$ref": "https://w3id.org/edc/connector/management/schema/v4/context-schema.json"
+        },
+        "@type": {
+          "type": "string",
+          "const": "DiscoveryResponse"
+        },
+        "profile": {
+          "type": "string",
+          "description": "The local dataspace profile id that matches a protocol version advertised by the counter party."
+        },
+        "version": {
+          "type": "string",
+          "description": "The DSP protocol version shared by the local profile and the counter party entry."
+        },
+        "counterPartyPath": {
+          "type": "string",
+          "description": "The path under the counter party's base URL where the matching DSP version is exposed, as returned in the well-known versions document."
+        },
+        "binding": {
+          "type": "string",
+          "description": "The protocol binding for this match (copied from the counter party version entry)."
+        }
+      },
+      "required": [
+        "@type",
+        "profile",
+        "version",
+        "counterPartyPath",
+        "binding"
+      ]
+    }
+  }
+}

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpCoreExtension.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpCoreExtension.java
@@ -16,6 +16,7 @@
 
 package org.eclipse.edc.iam.decentralizedclaims.core;
 
+import org.eclipse.edc.iam.decentralizedclaims.core.discovery.DidDiscoveryUrlResolver;
 import org.eclipse.edc.iam.decentralizedclaims.core.validation.SelfIssueIdTokenValidationAction;
 import org.eclipse.edc.iam.decentralizedclaims.service.DcpIdentityService;
 import org.eclipse.edc.iam.decentralizedclaims.service.verification.MultiFormatPresentationVerifier;
@@ -34,6 +35,7 @@ import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.jwt.validation.jti.JtiValidationStore;
 import org.eclipse.edc.participant.spi.ParticipantAgentService;
 import org.eclipse.edc.participantcontext.spi.config.ParticipantContextConfig;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
@@ -130,12 +132,16 @@ public class DcpCoreExtension implements ServiceExtension {
     private ExecutorInstrumentation executorInstrumentation;
     @Inject
     private PresentationRequestService presentationRequestService;
+    @Inject
+    private DiscoveryService discoveryService;
 
     private PresentationVerifier presentationVerifier;
     private ScheduledFuture<?> jtiEntryReaperThread;
 
+
     @Override
     public void initialize(ServiceExtensionContext context) {
+        discoveryService.registerResolver(new DidDiscoveryUrlResolver(didResolverRegistry));
 
         // add all rules for self-issued ID tokens
         rulesRegistry.addRule(DCP_SELF_ISSUED_TOKEN_CONTEXT, new IssuerEqualsSubjectRule());

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/discovery/DidDiscoveryUrlResolver.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/discovery/DidDiscoveryUrlResolver.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.decentralizedclaims.core.discovery;
+
+import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryRequest;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryUrlResolver;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+public class DidDiscoveryUrlResolver implements DiscoveryUrlResolver {
+
+    private static final String DSP_SERVICE_TYPE = "DataService";
+    private final DidResolverRegistry didResolverRegistry;
+
+    public DidDiscoveryUrlResolver(DidResolverRegistry didResolverRegistry) {
+        this.didResolverRegistry = didResolverRegistry;
+    }
+
+    @Override
+    public ServiceResult<String> resolve(DiscoveryRequest request) {
+        return resolveDidToDataServiceEndpoint(request.counterPartyId());
+    }
+
+    @Override
+    public boolean canResolve(DiscoveryRequest request) {
+        return request.counterPartyId() != null && !request.counterPartyId().isBlank() && request.counterPartyId().startsWith("did:");
+    }
+
+    private ServiceResult<String> resolveDidToDataServiceEndpoint(String did) {
+        var didDocument = didResolverRegistry.resolve(did);
+        if (didDocument.failed()) {
+            return ServiceResult.badRequest("Failed to resolve DID '%s': %s".formatted(did, didDocument.getFailureDetail()));
+        }
+        return didDocument.getContent().getService().stream()
+                .filter(s -> DSP_SERVICE_TYPE.equals(s.getType()))
+                .findFirst()
+                .map(s -> ServiceResult.success(s.getServiceEndpoint()))
+                .orElseGet(() -> ServiceResult.notFound("No '%s' service endpoint in DID document for '%s'".formatted(DSP_SERVICE_TYPE, did)));
+    }
+
+}

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/discovery/DidDiscoveryUrlResolverTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/discovery/DidDiscoveryUrlResolverTest.java
@@ -1,0 +1,138 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.decentralizedclaims.core.discovery;
+
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.iam.did.spi.document.Service;
+import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryRequest;
+import org.eclipse.edc.spi.result.ServiceFailure;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.spi.result.Result.failure;
+import static org.eclipse.edc.spi.result.Result.success;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class DidDiscoveryUrlResolverTest {
+
+    private static final String DID = "did:web:participant";
+    private static final String DATA_SERVICE_URL = "https://counter-party.example";
+
+    private final DidResolverRegistry didResolverRegistry = mock();
+    private final DidDiscoveryUrlResolver resolver = new DidDiscoveryUrlResolver(didResolverRegistry);
+
+    @Test
+    void canResolve_returnsTrueForDidCounterPartyId() {
+        assertThat(resolver.canResolve(new DiscoveryRequest(DID, null))).isTrue();
+    }
+
+    @Test
+    void canResolve_returnsTrueWhenAddressAlsoSetButIdIsDid() {
+        assertThat(resolver.canResolve(new DiscoveryRequest(DID, "https://x.example"))).isTrue();
+    }
+
+    @Test
+    void canResolve_returnsFalseWhenCounterPartyIdIsNull() {
+        assertThat(resolver.canResolve(new DiscoveryRequest(null, "https://x.example"))).isFalse();
+    }
+
+    @Test
+    void canResolve_returnsFalseWhenCounterPartyIdIsBlank() {
+        assertThat(resolver.canResolve(new DiscoveryRequest("   ", null))).isFalse();
+    }
+
+    @Test
+    void canResolve_returnsFalseWhenCounterPartyIdIsNotDid() {
+        assertThat(resolver.canResolve(new DiscoveryRequest("https://counter-party.example", null))).isFalse();
+    }
+
+    @Test
+    void canResolve_doesNotInvokeRegistry() {
+        resolver.canResolve(new DiscoveryRequest(DID, null));
+
+        verifyNoInteractions(didResolverRegistry);
+    }
+
+    @Test
+    void resolve_returnsDataServiceEndpoint() {
+        when(didResolverRegistry.resolve(eq(DID))).thenReturn(success(didDocumentWith(
+                new Service("svc-1", "DataService", DATA_SERVICE_URL))));
+
+        var result = resolver.resolve(new DiscoveryRequest(DID, null));
+
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).isEqualTo(DATA_SERVICE_URL);
+    }
+
+    @Test
+    void resolve_picksFirstDataServiceWhenMultipleArePresent() {
+        when(didResolverRegistry.resolve(eq(DID))).thenReturn(success(didDocumentWith(
+                new Service("svc-1", "OtherService", "https://other.example"),
+                new Service("svc-2", "DataService", DATA_SERVICE_URL),
+                new Service("svc-3", "DataService", "https://second.example"))));
+
+        var result = resolver.resolve(new DiscoveryRequest(DID, null));
+
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).isEqualTo(DATA_SERVICE_URL);
+    }
+
+    @Test
+    void resolve_failsWithBadRequestWhenDidCannotBeResolved() {
+        when(didResolverRegistry.resolve(eq(DID))).thenReturn(failure("DID method not supported"));
+
+        var result = resolver.resolve(new DiscoveryRequest(DID, null));
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.reason()).isEqualTo(ServiceFailure.Reason.BAD_REQUEST);
+        assertThat(result.getFailureDetail()).contains(DID).contains("DID method not supported");
+    }
+
+    @Test
+    void resolve_failsWithNotFoundWhenDidDocumentHasNoServices() {
+        when(didResolverRegistry.resolve(eq(DID))).thenReturn(success(didDocumentWith()));
+
+        var result = resolver.resolve(new DiscoveryRequest(DID, null));
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.reason()).isEqualTo(ServiceFailure.Reason.NOT_FOUND);
+        assertThat(result.getFailureDetail()).contains("DataService").contains(DID);
+    }
+
+    @Test
+    void resolve_failsWithNotFoundWhenNoDataServiceEntryIsPresent() {
+        when(didResolverRegistry.resolve(eq(DID))).thenReturn(success(didDocumentWith(
+                new Service("svc-1", "OtherService", "https://other.example"))));
+
+        var result = resolver.resolve(new DiscoveryRequest(DID, null));
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.reason()).isEqualTo(ServiceFailure.Reason.NOT_FOUND);
+        assertThat(result.getFailureDetail()).contains("DataService");
+    }
+
+    private static DidDocument didDocumentWith(Service... services) {
+        return DidDocument.Builder.newInstance()
+                .id(DID)
+                .service(List.of(services))
+                .build();
+    }
+}

--- a/extensions/control-plane/api/management-api-v5/build.gradle.kts
+++ b/extensions/control-plane/api/management-api-v5/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     api(project(":extensions:control-plane:api:management-api-v5:participant-context-config-api-v5"))
     api(project(":extensions:control-plane:api:management-api-v5:cel-api-v5"))
     api(project(":extensions:control-plane:api:management-api-v5:dataspace-profile-context-api-v5"))
+    api(project(":extensions:control-plane:api:management-api-v5:discovery-api-v5"))
 }
 
 

--- a/extensions/control-plane/api/management-api-v5/discovery-api-v5/build.gradle.kts
+++ b/extensions/control-plane/api/management-api-v5/discovery-api-v5/build.gradle.kts
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    id(libs.plugins.swagger.get().pluginId)
+}
+
+dependencies {
+    api(project(":spi:common:auth-spi"))
+    api(project(":spi:control-plane:control-plane-spi"))
+
+    implementation(project(":core:common:lib:api-lib"))
+    implementation(project(":core:common:lib:validator-lib"))
+    implementation(project(":core:control-plane:control-plane-transform"))
+    implementation(project(":extensions:common:api:lib:management-api-lib"))
+    implementation(project(":extensions:common:http:lib:jersey-providers-lib"))
+    implementation(libs.jakarta.rsApi)
+    implementation(libs.jakarta.annotation)
+
+    testImplementation(testFixtures(project(":extensions:common:http:jersey-core")))
+    testImplementation(libs.restAssured)
+    testImplementation(libs.awaitility)
+}
+
+edcBuild {
+    swagger {
+        apiGroup("management-api")
+    }
+}

--- a/extensions/control-plane/api/management-api-v5/discovery-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/discovery/DiscoveryApiV5Extension.java
+++ b/extensions/control-plane/api/management-api-v5/discovery-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/discovery/DiscoveryApiV5Extension.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.discovery;
+
+import jakarta.json.Json;
+import org.eclipse.edc.api.auth.spi.AuthorizationService;
+import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
+import org.eclipse.edc.connector.controlplane.api.management.discovery.v5.DiscoveryApiV5Controller;
+import org.eclipse.edc.connector.controlplane.transform.edc.discovery.from.JsonObjectFromDiscoveryResponseTransformer;
+import org.eclipse.edc.connector.controlplane.transform.edc.discovery.to.JsonObjectToDiscoveryRequestTransformer;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryService;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.jersey.providers.jsonld.JerseyJsonLdInterceptor;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.ApiContext;
+
+import java.util.Map;
+
+import static org.eclipse.edc.api.management.ManagementApi.MANAGEMENT_SCOPE_V4;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+@Extension(value = DiscoveryApiV5Extension.NAME)
+public class DiscoveryApiV5Extension implements ServiceExtension {
+
+    public static final String NAME = "Discovery Management API Extension";
+
+    @Inject
+    private WebService webService;
+
+    @Inject
+    private TypeTransformerRegistry transformerRegistry;
+
+    @Inject
+    private JsonObjectValidatorRegistry validatorRegistry;
+
+    @Inject
+    private JsonLd jsonLd;
+
+    @Inject
+    private TypeManager typeManager;
+
+    @Inject
+    private DiscoveryService discoveryService;
+
+    @Inject
+    private Monitor monitor;
+
+    @Inject
+    private AuthorizationService authorizationService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var factory = Json.createBuilderFactory(Map.of());
+        var managementApiTransformerRegistry = transformerRegistry.forContext("management-api");
+        managementApiTransformerRegistry.register(new JsonObjectToDiscoveryRequestTransformer());
+        managementApiTransformerRegistry.register(new JsonObjectFromDiscoveryResponseTransformer(factory));
+
+        webService.registerResource(ApiContext.MANAGEMENT, new DiscoveryApiV5Controller(authorizationService, discoveryService, managementApiTransformerRegistry, monitor));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, DiscoveryApiV5Controller.class,
+                new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
+    }
+}

--- a/extensions/control-plane/api/management-api-v5/discovery-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/discovery/v5/DiscoveryApiV5.java
+++ b/extensions/control-plane/api/management-api-v5/discovery-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/discovery/v5/DiscoveryApiV5.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.discovery.v5;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.core.SecurityContext;
+import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
+
+@OpenAPIDefinition(info = @Info(title = "Discovery Management API", version = "v5beta"))
+@Tag(name = "Discovery v5beta")
+public interface DiscoveryApiV5 {
+
+    @Operation(description = "Discovers the dataspace profiles usable to communicate with a counter party. " +
+            "Resolves the counter party's `.well-known/dspace-version` endpoint (either directly via " +
+            "`counterPartyAddress` or by resolving the `DataService` entry of the DID document for " +
+            "`counterPartyId`) and returns the intersection with the profiles associated to the participant " +
+            "context.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(ref = ManagementApiJsonSchema.V4.DISCOVERY_REQUEST))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The profiles that match the counter party.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.DISCOVERY_RESPONSE)))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed, the counter party could not be reached, or no DID service endpoint was found.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "A ParticipantContext with the given ID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(ref = ManagementApiJsonSchema.V4.API_ERROR)), mediaType = "application/json"))
+            }
+    )
+    JsonArray discoverV5(String participantContextId, JsonObject request, SecurityContext securityContext);
+}

--- a/extensions/control-plane/api/management-api-v5/discovery-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/discovery/v5/DiscoveryApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/discovery-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/discovery/v5/DiscoveryApiV5Controller.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.discovery.v5;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.SecurityContext;
+import org.eclipse.edc.api.auth.spi.AuthorizationService;
+import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
+import org.eclipse.edc.api.auth.spi.RequiredScope;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryRequest;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryService;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
+import org.eclipse.edc.web.spi.validation.SchemaType;
+
+import static jakarta.json.stream.JsonCollectors.toJsonArray;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryRequest.DISCOVERY_REQUEST_TYPE_TERM;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v5beta/participants/{participantContextId}/discover")
+public class DiscoveryApiV5Controller implements DiscoveryApiV5 {
+
+    private final AuthorizationService authorizationService;
+    private final DiscoveryService discoveryService;
+    private final TypeTransformerRegistry transformerRegistry;
+    private final Monitor monitor;
+
+    public DiscoveryApiV5Controller(AuthorizationService authorizationService,
+                                    DiscoveryService discoveryService,
+                                    TypeTransformerRegistry transformerRegistry,
+                                    Monitor monitor) {
+        this.authorizationService = authorizationService;
+        this.discoveryService = discoveryService;
+        this.transformerRegistry = transformerRegistry;
+        this.monitor = monitor;
+    }
+
+    @POST
+    @Path("/request")
+    @RolesAllowed({ParticipantPrincipal.ROLE_ADMIN, ParticipantPrincipal.ROLE_PARTICIPANT})
+    @RequiredScope("management-api:read")
+    @Override
+    public JsonArray discoverV5(@PathParam("participantContextId") String participantContextId,
+                                @SchemaType(DISCOVERY_REQUEST_TYPE_TERM) JsonObject request,
+                                @Context SecurityContext securityContext) {
+
+        authorizationService.authorize(securityContext, participantContextId, participantContextId, ParticipantContext.class)
+                .orElseThrow(exceptionMapper(ParticipantContext.class, participantContextId));
+
+        var discoveryRequest = transformerRegistry.transform(request, DiscoveryRequest.class)
+                .orElseThrow(InvalidRequestException::new);
+
+        var matches = discoveryService.discover(participantContextId, discoveryRequest)
+                .orElseThrow(exceptionMapper(DiscoveryRequest.class, participantContextId));
+
+        return matches.stream()
+                .map(match -> transformerRegistry.transform(match, JsonObject.class)
+                        .onFailure(f -> monitor.warning(f.getFailureDetail())))
+                .filter(Result::succeeded)
+                .map(Result::getContent)
+                .collect(toJsonArray());
+    }
+}

--- a/extensions/control-plane/api/management-api-v5/discovery-api-v5/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/control-plane/api/management-api-v5/discovery-api-v5/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2026 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.connector.controlplane.api.management.discovery.DiscoveryApiV5Extension

--- a/extensions/control-plane/api/management-api-v5/discovery-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/discovery/v5/DiscoveryApiV5ControllerTest.java
+++ b/extensions/control-plane/api/management-api-v5/discovery-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/discovery/v5/DiscoveryApiV5ControllerTest.java
@@ -1,0 +1,145 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.api.management.discovery.v5;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.auth.spi.AuthorizationService;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryRequest;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse;
+import org.eclipse.edc.protocol.spi.discovery.DiscoveryService;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ApiTest
+class DiscoveryApiV5ControllerTest extends RestControllerTestBase {
+
+    private static final String PARTICIPANT_CONTEXT_ID = "test-pc";
+
+    private final AuthorizationService authorizationService = mock();
+    private final DiscoveryService discoveryService = mock();
+    private final TypeTransformerRegistry transformerRegistry = mock();
+
+    private static String requestBody() {
+        return Json.createObjectBuilder()
+                .add("@context", Json.createObjectBuilder().add("@vocab", "https://w3id.org/edc/v0.0.1/ns/"))
+                .add("@type", "DiscoveryRequest")
+                .add("counterPartyAddress", "https://counter-party.example")
+                .build()
+                .toString();
+    }
+
+    @BeforeEach
+    void setUp() {
+        when(authorizationService.authorize(any(), any(), any(), any())).thenReturn(ServiceResult.success());
+    }
+
+    @Test
+    void shouldReturnDiscoveredProfiles() {
+        var request = new DiscoveryRequest(null, "https://counter-party.example");
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(DiscoveryRequest.class))).thenReturn(Result.success(request));
+        var match = new DiscoveryResponse("profile-1", "version", "/remote", "http");
+        when(discoveryService.discover(eq(PARTICIPANT_CONTEXT_ID), eq(request))).thenReturn(ServiceResult.success(List.of(match)));
+        when(transformerRegistry.transform(isA(DiscoveryResponse.class), eq(JsonObject.class)))
+                .thenReturn(Result.success(Json.createObjectBuilder().add("profile", "profile-1").build()));
+
+        given()
+                .port(port)
+                .contentType(JSON)
+                .body(requestBody())
+                .post(baseUrl() + "/request")
+                .then()
+                .statusCode(200)
+                .contentType(JSON)
+                .body("size()", is(1));
+
+        verify(discoveryService).discover(PARTICIPANT_CONTEXT_ID, request);
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenRequestBodyIsMalformed() {
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(DiscoveryRequest.class)))
+                .thenReturn(Result.failure("invalid"));
+
+        given()
+                .port(port)
+                .contentType(JSON)
+                .body(requestBody())
+                .post(baseUrl() + "/request")
+                .then()
+                .statusCode(400);
+
+        verify(discoveryService, never()).discover(any(), any());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenDiscoveryFails() {
+        var request = new DiscoveryRequest(null, "https://counter-party.example");
+        when(transformerRegistry.transform(isA(JsonObject.class), eq(DiscoveryRequest.class))).thenReturn(Result.success(request));
+        when(discoveryService.discover(eq(PARTICIPANT_CONTEXT_ID), eq(request)))
+                .thenReturn(ServiceResult.badRequest("could not reach counter party"));
+
+        given()
+                .port(port)
+                .contentType(JSON)
+                .body(requestBody())
+                .post(baseUrl() + "/request")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void shouldReturnForbiddenWhenAuthorizationFails() {
+        when(authorizationService.authorize(any(), eq(PARTICIPANT_CONTEXT_ID), any(), any()))
+                .thenReturn(ServiceResult.unauthorized("nope"));
+
+        given()
+                .port(port)
+                .contentType(JSON)
+                .body(requestBody())
+                .post(baseUrl() + "/request")
+                .then()
+                .statusCode(403);
+
+        verify(discoveryService, never()).discover(any(), any());
+    }
+
+    @Override
+    protected Object controller() {
+        return new DiscoveryApiV5Controller(authorizationService, discoveryService, transformerRegistry, monitor);
+    }
+
+    private String baseUrl() {
+        return "/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/discover";
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -248,6 +248,7 @@ include(":extensions:control-plane:api:management-api-v5:participant-context-api
 include(":extensions:control-plane:api:management-api-v5:participant-context-config-api-v5")
 include(":extensions:control-plane:api:management-api-v5:cel-api-v5")
 include(":extensions:control-plane:api:management-api-v5:dataspace-profile-context-api-v5")
+include(":extensions:control-plane:api:management-api-v5:discovery-api-v5")
 
 include(":extensions:control-plane:store:sql:asset-index-sql")
 include(":extensions:control-plane:store:sql:contract-definition-store-sql")

--- a/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/discovery/DiscoveryRequest.java
+++ b/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/discovery/DiscoveryRequest.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.spi.discovery;
+
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
+/**
+ * Represents a request to discover the dataspace profiles that can be used to communicate with a
+ * counterparty. Exactly one of {@link #counterPartyId} (a DID) or {@link #counterPartyAddress}
+ * (a URL that exposes {@code /.well-known/dspace-version}) must be provided.
+ *
+ * @param counterPartyId      the counterparty's DID; when set, the DID is resolved and the
+ *                            {@code DataService} entry of the DID document provides the base URL
+ *                            of the well-known endpoint.
+ * @param counterPartyAddress the counterparty's discovery URL pointing directly at the
+ *                            {@code /.well-known/dspace-version} endpoint (or the host that
+ *                            serves it). Takes precedence over {@link #counterPartyId}.
+ */
+public record DiscoveryRequest(@Nullable String counterPartyId,
+                               @Nullable String counterPartyAddress) {
+
+    public static final String DISCOVERY_REQUEST_TYPE_TERM = "DiscoveryRequest";
+    public static final String DISCOVERY_REQUEST_TYPE_IRI = EDC_NAMESPACE + DISCOVERY_REQUEST_TYPE_TERM;
+
+    public static final String DISCOVERY_REQUEST_COUNTER_PARTY_ID_TERM = "counterPartyId";
+    public static final String DISCOVERY_REQUEST_COUNTER_PARTY_ID_IRI = EDC_NAMESPACE + DISCOVERY_REQUEST_COUNTER_PARTY_ID_TERM;
+
+    public static final String DISCOVERY_REQUEST_COUNTER_PARTY_ADDRESS_TERM = "counterPartyAddress";
+    public static final String DISCOVERY_REQUEST_COUNTER_PARTY_ADDRESS_IRI = EDC_NAMESPACE + DISCOVERY_REQUEST_COUNTER_PARTY_ADDRESS_TERM;
+}

--- a/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/discovery/DiscoveryResponse.java
+++ b/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/discovery/DiscoveryResponse.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.spi.discovery;
+
+import org.eclipse.edc.protocol.spi.DataspaceProfileContext;
+
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+
+/**
+ * Result of a discovery request: a local dataspace profile that matches a protocol version
+ * advertised by the counterparty in its {@code /.well-known/dspace-version} document.
+ *
+ * @param profile          the local profile id (i.e. the value of
+ *                         {@link DataspaceProfileContext#name()}).
+ * @param counterPartyPath the path under the counterparty's base URL where the matching DSP
+ *                         version is exposed (as returned in the well-known versions document).
+ * @param binding          the protocol binding for this match (copied from the counterparty
+ *                         version entry).
+ */
+public record DiscoveryResponse(String profile,
+                                String version,
+                                String counterPartyPath,
+                                String binding) {
+
+    public static final String DISCOVERY_RESPONSE_TYPE_TERM = "DiscoveryResponse";
+    public static final String DISCOVERY_RESPONSE_TYPE_IRI = EDC_NAMESPACE + DISCOVERY_RESPONSE_TYPE_TERM;
+
+    public static final String DISCOVERY_RESPONSE_PROFILE_TERM = "profile";
+    public static final String DISCOVERY_RESPONSE_PROFILE_IRI = EDC_NAMESPACE + DISCOVERY_RESPONSE_PROFILE_TERM;
+
+    public static final String DISCOVERY_RESPONSE_VERSION_TERM = "version";
+    public static final String DISCOVERY_RESPONSE_VERSION_IRI = EDC_NAMESPACE + DISCOVERY_RESPONSE_VERSION_TERM;
+
+    public static final String DISCOVERY_RESPONSE_COUNTER_PARTY_PATH_TERM = "counterPartyPath";
+    public static final String DISCOVERY_RESPONSE_COUNTER_PARTY_PATH_IRI = EDC_NAMESPACE + DISCOVERY_RESPONSE_COUNTER_PARTY_PATH_TERM;
+
+    public static final String DISCOVERY_RESPONSE_BINDING_TERM = "binding";
+    public static final String DISCOVERY_RESPONSE_BINDING_IRI = EDC_NAMESPACE + DISCOVERY_RESPONSE_BINDING_TERM;
+}

--- a/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/discovery/DiscoveryService.java
+++ b/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/discovery/DiscoveryService.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.spi.discovery;
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+import java.util.List;
+
+/**
+ * Discovers the dataspace profiles that a participant can use to communicate with a counter * party. The implementation fetches the counterparty's {@code /.well-known/dspace-version}
+ * document (either via direct address or via DID resolution) and intersects the advertised DSP
+ * protocol versions with the profiles associated with the participant context.
+ */
+@ExtensionPoint
+public interface DiscoveryService {
+
+    /**
+     * Returns one {@link DiscoveryResponse} per (local profile, counterparty version) pair that
+     * shares the same {@code version} and {@code binding}.
+     *
+     * @param participantContextId the participant context performing the discovery.
+     * @param request              the discovery request (DID or address).
+     * @return the list of matches; empty when nothing matches.
+     */
+    ServiceResult<List<DiscoveryResponse>> discover(String participantContextId, DiscoveryRequest request);
+
+    /**
+     * Registers a {@link DiscoveryUrlResolver} to be used for resolving discovery requests.
+     *
+     * @param resolver the resolver to register.
+     */
+    void registerResolver(DiscoveryUrlResolver resolver);
+}

--- a/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/discovery/DiscoveryUrlResolver.java
+++ b/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/discovery/DiscoveryUrlResolver.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.protocol.spi.discovery;
+
+import org.eclipse.edc.spi.result.ServiceResult;
+
+public interface DiscoveryUrlResolver {
+
+    /**
+     * Resolves the given discovery request to a URL that can be used to fetch the counterparty's
+     * {@code /.well-known/dspace-version} document.
+     *
+     * @param request the discovery request (DID or address).
+     * @return the discovery result; must not be null.
+     */
+    ServiceResult<String> resolve(DiscoveryRequest request);
+
+    /**
+     * Determines whether this resolver can handle the given discovery request.
+     *
+     * @param request the discovery request (DID or address).
+     * @return true if this resolver can handle the request; false otherwise.
+     */
+    boolean canResolve(DiscoveryRequest request);
+}

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/DiscoveryApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/DiscoveryApiV5EndToEndTest.java
@@ -1,0 +1,209 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi.v5;
+
+import jakarta.json.JsonArray;
+import org.eclipse.edc.api.authentication.OauthServer;
+import org.eclipse.edc.api.authentication.OauthServerEndToEndExtension;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.participantcontext.spi.config.model.ParticipantContextConfiguration;
+import org.eclipse.edc.participantcontext.spi.config.store.ParticipantContextConfigStore;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
+import org.eclipse.edc.participantcontext.spi.types.ParticipantContextState;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.test.e2e.managementapi.Runtimes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
+
+public class DiscoveryApiV5EndToEndTest {
+
+    @SuppressWarnings("JUnitMalformedDeclaration")
+    abstract static class Tests {
+
+
+        private static final List<String> PROFILES = List.of("dsp2025_1", "dsp2025_2");
+
+        @BeforeAll
+        static void setup() {
+
+        }
+
+        @AfterEach
+        void teardown(ParticipantContextService participantContextService) {
+            var list = participantContextService.search(QuerySpec.max())
+                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+            for (var p : list) {
+                participantContextService.deleteParticipantContext(p.getParticipantContextId()).orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+            }
+        }
+
+        @Test
+        void discover(ManagementEndToEndV5TestContext context, ParticipantContextService participantContextService,
+                      ParticipantContextConfigStore configStore,
+                      OauthServer authServer) {
+
+            var providerContextId = "provider-context-" + UUID.randomUUID();
+            var consumerContextId = "consumer-context-" + UUID.randomUUID();
+
+            var participantTokenJwt = authServer.createToken(consumerContextId);
+
+            createParticipant(participantContextService, configStore, consumerContextId, List.of("dsp2025_1"));
+            createParticipant(participantContextService, configStore, providerContextId, PROFILES);
+
+            var discovery = fetchDiscovery(context, providerContextId, participantTokenJwt, consumerContextId);
+
+
+            assertThat(discovery).hasSize(2).allSatisfy(entry -> {
+                assertThat(entry.asJsonObject().getString(TYPE)).isEqualTo("DiscoveryResponse");
+                assertThat(entry.asJsonObject().getString("profile")).isEqualTo("dsp2025_1");
+                assertThat(entry.asJsonObject().getString("version")).isEqualTo("2025-1");
+                assertThat(entry.asJsonObject().getString("counterPartyPath")).isNotNull();
+                assertThat(entry.asJsonObject().getString("binding")).isNotNull();
+            });
+        }
+
+        @Test
+        void discover_validationFails(ManagementEndToEndV5TestContext context, ParticipantContextService participantContextService,
+                                      ParticipantContextConfigStore configStore,
+                                      OauthServer authServer) {
+
+            var providerContextId = "provider-context-" + UUID.randomUUID();
+            var consumerContextId = "consumer-context-" + UUID.randomUUID();
+
+            var participantTokenJwt = authServer.createToken(consumerContextId);
+
+            createParticipant(participantContextService, configStore, consumerContextId, List.of("dsp2025_1"));
+            createParticipant(participantContextService, configStore, providerContextId, PROFILES);
+
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(TYPE, "DiscoveryRequest")
+                    .build()
+                    .toString();
+
+            context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .body(requestBody)
+                    .post("/v5beta/participants/%s/discover/request".formatted(consumerContextId))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(400)
+                    .contentType(JSON);
+        }
+
+
+        private void createParticipant(ParticipantContextService participantContextService,
+                                       ParticipantContextConfigStore configStore, String participantContextId, List<String> profiles) {
+            var pc = ParticipantContext.Builder.newInstance()
+                    .participantContextId(participantContextId)
+                    .state(ParticipantContextState.ACTIVATED)
+                    .identity(participantContextId)
+                    .build();
+
+            var config = ParticipantContextConfiguration.Builder.newInstance()
+                    .participantContextId(participantContextId)
+                    .entries(Map.of("edc.mock.region", "eu",
+                            "edc.participant.id", "did:web:" + participantContextId,
+                            "edc.dataspace.profiles", String.join(",", profiles)
+                    ))
+                    .build();
+
+            configStore.save(config);
+
+            participantContextService.createParticipantContext(pc)
+                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+        }
+
+        private JsonArray fetchDiscovery(ManagementEndToEndV5TestContext context, String providerContextId, String participantTokenJwt, String consumerContextId) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(TYPE, "DiscoveryRequest")
+                    .add("counterPartyAddress", context.providerBaseProtocolUrl(providerContextId))
+                    .build()
+                    .toString();
+
+            return context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .body(requestBody)
+                    .post("/v5beta/participants/%s/discover/request".formatted(consumerContextId))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .extract().body().as(JsonArray.class);
+        }
+
+    }
+
+    @Nested
+    @EndToEndTest
+    class InMemory extends Tests {
+
+        @Order(0)
+        @RegisterExtension
+        static final OauthServerEndToEndExtension AUTH_SERVER_EXTENSION = OauthServerEndToEndExtension.Builder.newInstance().build();
+
+        @Order(1)
+        @RegisterExtension
+        static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()
+                .name(Runtimes.ControlPlane.NAME)
+                .modules(Runtimes.ControlPlane.VIRTUAL_MODULES)
+                .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
+                .configurationProvider(InMemory::config)
+                .configurationProvider(AUTH_SERVER_EXTENSION::getConfig)
+                .paramProvider(ManagementEndToEndV5TestContext.class,
+                        ManagementEndToEndV5TestContext::forContext)
+                .build();
+
+        static Config config() {
+            return ConfigFactory.fromMap(Map.of(
+                            "edc.dataspace.profiles.dsp2025_1.name", "dsp2025_1",
+                            "edc.dataspace.profiles.dsp2025_1.protocolVersion", "2025-1",
+                            "edc.dataspace.profiles.dsp2025_1.protocolBinding", "HTTPS",
+                            "edc.dataspace.profiles.dsp2025_1.protocolNamespace", "https://w3id.org/dspace/2025/1/",
+                            "edc.dataspace.profiles.dsp2025_1.jsonLdContextsUrl", "https://w3id.org/dspace/2025/1/context.jsonld",
+                            "edc.dataspace.profiles.dsp2025_2.name", "dsp2025_2",
+                            "edc.dataspace.profiles.dsp2025_2.protocolVersion", "2025-1",
+                            "edc.dataspace.profiles.dsp2025_2.protocolBinding", "HTTPS",
+                            "edc.dataspace.profiles.dsp2025_2.protocolNamespace", "https://w3id.org/dspace/2025/1/",
+                            "edc.dataspace.profiles.dsp2025_2.jsonLdContextsUrl", "https://w3id.org/dspace/2025/1/context.jsonld"
+                    )
+            );
+        }
+    }
+
+}

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/ManagementEndToEndV5TestContext.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/ManagementEndToEndV5TestContext.java
@@ -58,6 +58,10 @@ public record ManagementEndToEndV5TestContext(LazySupplier<URI> managementApiUri
         return "%s/%s/%s".formatted(protocolApiUri.get(), participantContextId, profile);
     }
 
+    public String providerBaseProtocolUrl(String participantContextId) {
+        return "%s/%s".formatted(protocolApiUri.get(), participantContextId);
+    }
+
     public String profile() {
         return DATASPACE_HTTP_PROFILE_2025_1;
     }


### PR DESCRIPTION
## What this PR changes/adds

Adds a management API for discovering the compatibiliy with a counter party.

The request accept either a: 

- `counterPartyAddress`
- `counterPartyId`


Resolvers are registered to be able given a request to resolve the `well-known/dspace-version` endpoint of the counter party. 


Once resolved the discovery service will fetch the supported protocol version of the counterparty and matching with the local profile supported. The response will return with profile to use and for which counterparty protocol path. Currently it does the match with the protocol version and the binding

## Why it does that

_Briefly state why the change was necessary._

## Further notes


For having a more precise match. We could support in the dspace-version a new property called `profile` which will allow us to match also the specific profile.


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5764 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
