### PR TITLE
feat: add configurable json-schema

### DIFF
--- a/extensions/common/api/management-api-schema-validator/build.gradle.kts
+++ b/extensions/common/api/management-api-schema-validator/build.gradle.kts
@@ -29,6 +29,9 @@ dependencies {
     implementation(project(":extensions:common:api:lib:management-api-lib"))
 
     implementation(libs.jsonschema)
+
+    testImplementation(project(":core:common:junit"))
+    testImplementation(project(":core:common:lib:json-ld-lib"))
 }
 
 

--- a/extensions/common/api/management-api-schema-validator/src/main/java/org/eclipse/edc/connector/api/management/schema/CustomSchemaValidatorConfigParser.java
+++ b/extensions/common/api/management-api-schema-validator/src/main/java/org/eclipse/edc/connector/api/management/schema/CustomSchemaValidatorConfigParser.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.schema;
+
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.configuration.Config;
+
+import java.util.List;
+
+import static org.eclipse.edc.connector.api.management.schema.ManagementApiSchemaValidatorExtension.MAPPING_FROM_KEY;
+import static org.eclipse.edc.connector.api.management.schema.ManagementApiSchemaValidatorExtension.MAPPING_TO_KEY;
+import static org.eclipse.edc.connector.api.management.schema.ManagementApiSchemaValidatorExtension.VALIDATOR_KEY;
+import static org.eclipse.edc.connector.api.management.schema.ManagementApiSchemaValidatorExtension.VALIDATOR_SCHEMA_KEY;
+import static org.eclipse.edc.connector.api.management.schema.ManagementApiSchemaValidatorExtension.VALIDATOR_TYPE_KEY;
+import static org.eclipse.edc.connector.api.management.schema.ManagementApiSchemaValidatorExtension.VERSION_KEY;
+
+public final class CustomSchemaValidatorConfigParser {
+
+    private CustomSchemaValidatorConfigParser() {
+    }
+
+    public static List<CustomValidatorGroup> parse(Config root, Monitor monitor) {
+        return root.partition()
+                .map(groupConfig -> parseGroup(groupConfig, monitor))
+                .toList();
+    }
+
+    private static CustomValidatorGroup parseGroup(Config groupConfig, Monitor monitor) {
+        var groupName = groupConfig.currentNode();
+        var version = groupConfig.getString(VERSION_KEY);
+        var mapping = parseMapping(groupConfig, groupName, monitor);
+        var bindings = groupConfig.getConfig(VALIDATOR_KEY).partition()
+                .map(CustomSchemaValidatorConfigParser::parseBinding)
+                .toList();
+        return new CustomValidatorGroup(groupName, version, mapping, bindings);
+    }
+
+    private static PrefixMapping parseMapping(Config groupConfig, String groupName, Monitor monitor) {
+        var from = groupConfig.getString(MAPPING_FROM_KEY, null);
+        var to = groupConfig.getString(MAPPING_TO_KEY, null);
+        if (from == null && to == null) {
+            return null;
+        }
+        if (from == null || to == null) {
+            monitor.warning("Custom schema validator group '%s' has only one of '%s'/'%s' set; ignoring mapping."
+                    .formatted(groupName, MAPPING_FROM_KEY, MAPPING_TO_KEY));
+            return null;
+        }
+        return new PrefixMapping(from, to);
+    }
+
+    private static ValidatorBinding parseBinding(Config entryConfig) {
+        return new ValidatorBinding(entryConfig.getString(VALIDATOR_TYPE_KEY), entryConfig.getString(VALIDATOR_SCHEMA_KEY));
+    }
+
+    public record PrefixMapping(String from, String to) {
+    }
+
+    public record ValidatorBinding(String type, String schema) {
+    }
+
+    public record CustomValidatorGroup(String groupName, String version, PrefixMapping mapping, List<ValidatorBinding> bindings) {
+    }
+
+}

--- a/extensions/common/api/management-api-schema-validator/src/main/java/org/eclipse/edc/connector/api/management/schema/ManagementApiSchemaValidatorExtension.java
+++ b/extensions/common/api/management-api-schema-validator/src/main/java/org/eclipse/edc/connector/api/management/schema/ManagementApiSchemaValidatorExtension.java
@@ -14,15 +14,19 @@
 
 package org.eclipse.edc.connector.api.management.schema;
 
+import org.eclipse.edc.connector.api.management.schema.CustomSchemaValidatorConfigParser.CustomValidatorGroup;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.DSPACE_2025_SCHEMA_PREFIX;
 import static org.eclipse.edc.api.management.schema.ManagementApiJsonSchema.EDC_MGMT_V4_SCHEMA_PREFIX;
@@ -87,6 +91,20 @@ public class ManagementApiSchemaValidatorExtension implements ServiceExtension {
     public static final String NAME = "Management API Schema Validator";
     public static final String V_4 = "v4";
     public static final String V_4_PREFIX = V_4 + ":";
+    public static final String CONFIG_PREFIX = "edc.mgmt.api.schema";
+    public static final String VALIDATOR_KEY = "validator";
+
+    @Setting(context = CONFIG_PREFIX + ".<groupAlias>.", description = "Namespace prefix used when registering custom validators on JsonObjectValidatorRegistry, e.g. 'v4'.")
+    public static final String VERSION_KEY = "version";
+    @Setting(context = CONFIG_PREFIX + ".<groupAlias>.", description = "Optional schema URL prefix to remap to a local location (paired with 'mapping.to').", required = false)
+    public static final String MAPPING_FROM_KEY = "mapping.from";
+    @Setting(context = CONFIG_PREFIX + ".<groupAlias>.", description = "Optional local URI the schema prefix is remapped to, e.g. 'file:///path' or 'classpath:/path' (paired with 'mapping.from').", required = false)
+    public static final String MAPPING_TO_KEY = "mapping.to";
+    @Setting(context = CONFIG_PREFIX + ".<groupAlias>." + VALIDATOR_KEY + ".<entryAlias>.", description = "JSON-LD @type term the schema is registered against.")
+    public static final String VALIDATOR_TYPE_KEY = "type";
+    @Setting(context = CONFIG_PREFIX + ".<groupAlias>." + VALIDATOR_KEY + ".<entryAlias>.", description = "Absolute schema URL (resolved through 'mapping.from'/'mapping.to' when configured).")
+    public static final String VALIDATOR_SCHEMA_KEY = "schema";
+
     private static final String EDC_CLASSPATH_SCHEMA = "classpath:schema/management/v4";
     private static final String DSPACE_CLASSPATH_SCHEMA = "classpath:schema/dspace/2025";
 
@@ -132,18 +150,31 @@ public class ManagementApiSchemaValidatorExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
+        var customGroups = CustomSchemaValidatorConfigParser.parse(context.getConfig(CONFIG_PREFIX), context.getMonitor());
 
-        var schemaValidatorProvider = ManagementApiSchemaValidatorProvider.Builder.newInstance()
+        var builder = ManagementApiSchemaValidatorProvider.Builder.newInstance()
                 .objectMapper(() -> typeManager.getMapper(JSON_LD))
                 .prefixMapping(EDC_MGMT_V4_SCHEMA_PREFIX, EDC_CLASSPATH_SCHEMA)
-                .prefixMapping(DSPACE_2025_SCHEMA_PREFIX, DSPACE_CLASSPATH_SCHEMA)
-                .build();
+                .prefixMapping(DSPACE_2025_SCHEMA_PREFIX, DSPACE_CLASSPATH_SCHEMA);
+
+        customGroups.stream()
+                .map(CustomValidatorGroup::mapping)
+                .filter(Objects::nonNull)
+                .forEach(mapping -> builder.prefixMapping(mapping.from(), mapping.to()));
+
+        var schemaValidatorProvider = builder.build();
 
         registerValidatorsV4(schemaValidatorProvider);
+        registerCustomValidators(schemaValidatorProvider, customGroups);
     }
 
     void registerValidatorsV4(ManagementApiSchemaValidatorProvider validatorProvider) {
         schemaV4.forEach((type, schema) -> validator.register(V_4_PREFIX + type, validatorProvider.validatorFor(schema)));
+    }
+
+    void registerCustomValidators(ManagementApiSchemaValidatorProvider validatorProvider, List<CustomValidatorGroup> groups) {
+        groups.forEach(group -> group.bindings().forEach(binding ->
+                validator.register(group.version() + ":" + binding.type(), validatorProvider.validatorFor(binding.schema()))));
     }
 
 }

--- a/extensions/common/api/management-api-schema-validator/src/main/java/org/eclipse/edc/connector/api/management/schema/ManagementApiSchemaValidatorProvider.java
+++ b/extensions/common/api/management-api-schema-validator/src/main/java/org/eclipse/edc/connector/api/management/schema/ManagementApiSchemaValidatorProvider.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.SchemaLocation;
 import com.networknt.schema.SchemaRegistry;
 import com.networknt.schema.dialect.Dialects;
+import com.networknt.schema.resource.IriResourceLoader;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
@@ -83,8 +84,10 @@ public class ManagementApiSchemaValidatorProvider {
 
         public ManagementApiSchemaValidatorProvider build() {
             Objects.requireNonNull(provider.objectMapperSupplier);
-            provider.schemaFactory = SchemaRegistry.withDialect(Dialects.getDraft201909(), builder ->
-                    builder.schemaIdResolvers(schemaIdResolvers -> prefixMappings.forEach(schemaIdResolvers::mapPrefix)));
+            provider.schemaFactory = SchemaRegistry.withDialect(Dialects.getDraft201909(), builder -> builder
+                    .schemaIdResolvers(schemaIdResolvers -> prefixMappings.forEach(schemaIdResolvers::mapPrefix))
+                    .resourceLoaders(resourceLoaders -> resourceLoaders.add(IriResourceLoader.getInstance())));
+
             return provider;
         }
 

--- a/extensions/common/api/management-api-schema-validator/src/test/java/org/eclipse/edc/connector/api/management/schema/CustomSchemaValidatorConfigParserTest.java
+++ b/extensions/common/api/management-api-schema-validator/src/test/java/org/eclipse/edc/connector/api/management/schema/CustomSchemaValidatorConfigParserTest.java
@@ -1,0 +1,184 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.schema;
+
+import org.eclipse.edc.connector.api.management.schema.CustomSchemaValidatorConfigParser.PrefixMapping;
+import org.eclipse.edc.connector.api.management.schema.CustomSchemaValidatorConfigParser.ValidatorBinding;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.connector.api.management.schema.ManagementApiSchemaValidatorExtension.CONFIG_PREFIX;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class CustomSchemaValidatorConfigParserTest {
+
+    private final Monitor monitor = mock(Monitor.class);
+
+    @Test
+    void parse_emptyConfig_returnsEmptyList() {
+        var config = ConfigFactory.fromMap(Map.of()).getConfig(CONFIG_PREFIX);
+
+        var result = CustomSchemaValidatorConfigParser.parse(config, monitor);
+
+        assertThat(result).isEmpty();
+        verifyNoInteractions(monitor);
+    }
+
+    @Test
+    void parse_singleGroup_withMappingAndMultipleBindings() {
+        var config = ConfigFactory.fromMap(Map.of(
+                "edc.mgmt.api.schema.custom.version", "v4",
+                "edc.mgmt.api.schema.custom.mapping.from", "https://example.org/schema/v4",
+                "edc.mgmt.api.schema.custom.mapping.to", "file:///tmp/schema/v4",
+                "edc.mgmt.api.schema.custom.validator.policy.type", "PolicyDefinition",
+                "edc.mgmt.api.schema.custom.validator.policy.schema", "https://example.org/schema/v4/policy-def-schema.json",
+                "edc.mgmt.api.schema.custom.validator.asset.type", "Asset",
+                "edc.mgmt.api.schema.custom.validator.asset.schema", "https://example.org/schema/v4/asset-def-schema.json"
+        )).getConfig(CONFIG_PREFIX);
+
+        var result = CustomSchemaValidatorConfigParser.parse(config, monitor);
+
+        assertThat(result).hasSize(1);
+        var group = result.get(0);
+        assertThat(group.groupName()).isEqualTo("custom");
+        assertThat(group.version()).isEqualTo("v4");
+        assertThat(group.mapping()).isEqualTo(new PrefixMapping("https://example.org/schema/v4", "file:///tmp/schema/v4"));
+        assertThat(group.bindings()).containsExactlyInAnyOrder(
+                new ValidatorBinding("PolicyDefinition", "https://example.org/schema/v4/policy-def-schema.json"),
+                new ValidatorBinding("Asset", "https://example.org/schema/v4/asset-def-schema.json")
+        );
+        verifyNoInteractions(monitor);
+    }
+
+    @Test
+    void parse_multipleGroups_independentVersions() {
+        var config = ConfigFactory.fromMap(Map.of(
+                "edc.mgmt.api.schema.first.version", "v4",
+                "edc.mgmt.api.schema.first.validator.policy.type", "PolicyDefinition",
+                "edc.mgmt.api.schema.first.validator.policy.schema", "https://example.org/v4/policy.json",
+                "edc.mgmt.api.schema.second.version", "v5",
+                "edc.mgmt.api.schema.second.validator.asset.type", "Asset",
+                "edc.mgmt.api.schema.second.validator.asset.schema", "https://example.org/v5/asset.json"
+        )).getConfig(CONFIG_PREFIX);
+
+        var result = CustomSchemaValidatorConfigParser.parse(config, monitor);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).anySatisfy(g -> {
+            assertThat(g.groupName()).isEqualTo("first");
+            assertThat(g.version()).isEqualTo("v4");
+            assertThat(g.mapping()).isNull();
+            assertThat(g.bindings()).containsExactly(new ValidatorBinding("PolicyDefinition", "https://example.org/v4/policy.json"));
+        });
+        assertThat(result).anySatisfy(g -> {
+            assertThat(g.groupName()).isEqualTo("second");
+            assertThat(g.version()).isEqualTo("v5");
+            assertThat(g.mapping()).isNull();
+            assertThat(g.bindings()).containsExactly(new ValidatorBinding("Asset", "https://example.org/v5/asset.json"));
+        });
+    }
+
+    @Test
+    void parse_missingVersion_throws() {
+        var config = ConfigFactory.fromMap(Map.of(
+                "edc.mgmt.api.schema.broken.validator.policy.type", "PolicyDefinition",
+                "edc.mgmt.api.schema.broken.validator.policy.schema", "https://example.org/policy.json"
+        )).getConfig(CONFIG_PREFIX);
+
+        assertThatThrownBy(() -> CustomSchemaValidatorConfigParser.parse(config, monitor))
+                .isInstanceOf(EdcException.class)
+                .hasMessageContaining("version");
+    }
+
+    @Test
+    void parse_validatorEntryMissingType_throws() {
+        var config = ConfigFactory.fromMap(Map.of(
+                "edc.mgmt.api.schema.custom.version", "v4",
+                "edc.mgmt.api.schema.custom.validator.policy.schema", "https://example.org/policy.json"
+        )).getConfig(CONFIG_PREFIX);
+
+        assertThatThrownBy(() -> CustomSchemaValidatorConfigParser.parse(config, monitor))
+                .isInstanceOf(EdcException.class)
+                .hasMessageContaining("type");
+    }
+
+    @Test
+    void parse_validatorEntryMissingSchema_throws() {
+        var config = ConfigFactory.fromMap(Map.of(
+                "edc.mgmt.api.schema.custom.version", "v4",
+                "edc.mgmt.api.schema.custom.validator.policy.type", "PolicyDefinition"
+        )).getConfig(CONFIG_PREFIX);
+
+        assertThatThrownBy(() -> CustomSchemaValidatorConfigParser.parse(config, monitor))
+                .isInstanceOf(EdcException.class)
+                .hasMessageContaining("schema");
+    }
+
+    @Test
+    void parse_onlyMappingFromSet_warnsAndDropsMapping() {
+        var config = ConfigFactory.fromMap(Map.of(
+                "edc.mgmt.api.schema.custom.version", "v4",
+                "edc.mgmt.api.schema.custom.mapping.from", "https://example.org/schema/v4",
+                "edc.mgmt.api.schema.custom.validator.policy.type", "PolicyDefinition",
+                "edc.mgmt.api.schema.custom.validator.policy.schema", "https://example.org/policy.json"
+        )).getConfig(CONFIG_PREFIX);
+
+        var result = CustomSchemaValidatorConfigParser.parse(config, monitor);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).mapping()).isNull();
+        assertThat(result.get(0).bindings()).hasSize(1);
+        verify(monitor).warning(org.mockito.ArgumentMatchers.contains("custom"));
+    }
+
+    @Test
+    void parse_onlyMappingToSet_warnsAndDropsMapping() {
+        var config = ConfigFactory.fromMap(Map.of(
+                "edc.mgmt.api.schema.custom.version", "v4",
+                "edc.mgmt.api.schema.custom.mapping.to", "file:///tmp/schema/v4",
+                "edc.mgmt.api.schema.custom.validator.policy.type", "PolicyDefinition",
+                "edc.mgmt.api.schema.custom.validator.policy.schema", "https://example.org/policy.json"
+        )).getConfig(CONFIG_PREFIX);
+
+        var result = CustomSchemaValidatorConfigParser.parse(config, monitor);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).mapping()).isNull();
+        verify(monitor).warning(org.mockito.ArgumentMatchers.contains("custom"));
+    }
+
+    @Test
+    void parse_groupWithMappingOnly_returnsGroupWithEmptyBindings() {
+        var config = ConfigFactory.fromMap(Map.of(
+                "edc.mgmt.api.schema.mapper.version", "v4",
+                "edc.mgmt.api.schema.mapper.mapping.from", "https://example.org/schema/v4",
+                "edc.mgmt.api.schema.mapper.mapping.to", "file:///tmp/schema/v4"
+        )).getConfig(CONFIG_PREFIX);
+
+        var result = CustomSchemaValidatorConfigParser.parse(config, monitor);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).bindings()).isEmpty();
+        assertThat(result.get(0).mapping()).isEqualTo(new PrefixMapping("https://example.org/schema/v4", "file:///tmp/schema/v4"));
+    }
+}

--- a/extensions/common/api/management-api-schema-validator/src/test/java/org/eclipse/edc/connector/api/management/schema/ManagementApiSchemaValidatorExtensionTest.java
+++ b/extensions/common/api/management-api-schema-validator/src/test/java/org/eclipse/edc/connector/api/management/schema/ManagementApiSchemaValidatorExtensionTest.java
@@ -1,0 +1,130 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.schema;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.boot.system.injection.ObjectFactory;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.junit.extensions.TestExtensionContext;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class ManagementApiSchemaValidatorExtensionTest {
+
+    private final JsonObjectValidatorRegistry validatorRegistry = mock(JsonObjectValidatorRegistry.class);
+    private final TypeManager typeManager = mock(TypeManager.class);
+
+    private ManagementApiSchemaValidatorExtension extension;
+
+    @BeforeEach
+    void setUp(TestExtensionContext context, ObjectFactory factory) {
+        when(typeManager.getMapper(any())).thenReturn(new ObjectMapper());
+        context.registerService(JsonObjectValidatorRegistry.class, validatorRegistry);
+        context.registerService(TypeManager.class, typeManager);
+        extension = factory.constructInstance(ManagementApiSchemaValidatorExtension.class);
+    }
+
+    @Test
+    void initialize_registersBuiltInV4Validators(ServiceExtensionContext context) {
+        extension.initialize(context);
+
+        verify(validatorRegistry, atLeastOnce()).register(eq("v4:Asset"), any());
+        verify(validatorRegistry, atLeastOnce()).register(eq("v4:PolicyDefinition"), any());
+        verify(validatorRegistry, atLeastOnce()).register(eq("v4:ContractDefinition"), any());
+    }
+
+    @Test
+    void initialize_registersCustomValidators_composedWithBuiltIn(TestExtensionContext context) {
+        context.setConfig(ConfigFactory.fromMap(Map.of(
+                "edc.mgmt.api.schema.custom.version", "v4",
+                "edc.mgmt.api.schema.custom.validator.policy.type", "PolicyDefinition",
+                "edc.mgmt.api.schema.custom.validator.policy.schema", "https://w3id.org/edc/connector/management/schema/v4/policy-definition-schema.json"
+        )));
+
+        extension.initialize(context);
+
+        verify(validatorRegistry, times(2)).register(eq("v4:PolicyDefinition"), any());
+    }
+
+    @Test
+    void initialize_registersCustomValidators_withDistinctVersionPrefix(TestExtensionContext context) {
+        context.setConfig(ConfigFactory.fromMap(Map.of(
+                "edc.mgmt.api.schema.custom.version", "v5",
+                "edc.mgmt.api.schema.custom.validator.asset.type", "Asset",
+                "edc.mgmt.api.schema.custom.validator.asset.schema", "https://w3id.org/edc/connector/management/schema/v4/asset-schema.json"
+        )));
+
+        extension.initialize(context);
+
+        verify(validatorRegistry).register(eq("v5:Asset"), any());
+    }
+
+    @Test
+    void initialize_appliesCustomPrefixMapping(TestExtensionContext context) {
+        context.setConfig(ConfigFactory.fromMap(Map.of(
+                "edc.mgmt.api.schema.custom.version", "v4",
+                "edc.mgmt.api.schema.custom.mapping.from", "https://example.org/schema/v4",
+                "edc.mgmt.api.schema.custom.mapping.to", "classpath:schema/management/v4",
+                "edc.mgmt.api.schema.custom.validator.asset.type", "Asset",
+                "edc.mgmt.api.schema.custom.validator.asset.schema", "https://example.org/schema/v4/asset-schema.json"
+        )));
+
+        extension.initialize(context);
+
+        var key = ArgumentCaptor.forClass(String.class);
+        verify(validatorRegistry, atLeastOnce()).register(key.capture(), any());
+        assertThat(key.getAllValues()).contains("v4:Asset");
+    }
+
+    @Test
+    void initialize_throws_whenVersionMissing(TestExtensionContext context) {
+        context.setConfig(ConfigFactory.fromMap(Map.of(
+                "edc.mgmt.api.schema.custom.validator.policy.type", "PolicyDefinition",
+                "edc.mgmt.api.schema.custom.validator.policy.schema", "https://example.org/policy.json"
+        )));
+
+        assertThatThrownBy(() -> extension.initialize(context)).isInstanceOf(EdcException.class);
+    }
+
+    @Test
+    void initialize_throws_whenValidatorEntryIncomplete(TestExtensionContext context) {
+        context.setConfig(ConfigFactory.fromMap(Map.of(
+                "edc.mgmt.api.schema.custom.version", "v4",
+                "edc.mgmt.api.schema.custom.validator.policy.type", "PolicyDefinition"
+        )));
+
+        assertThatThrownBy(() -> extension.initialize(context)).isInstanceOf(EdcException.class);
+    }
+}

--- a/extensions/common/api/management-api-schema-validator/src/test/java/org/eclipse/edc/connector/api/management/schema/ManagementApiSchemaValidatorProviderTest.java
+++ b/extensions/common/api/management-api-schema-validator/src/test/java/org/eclipse/edc/connector/api/management/schema/ManagementApiSchemaValidatorProviderTest.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.api.management.schema;
+
+import jakarta.json.Json;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ManagementApiSchemaValidatorProviderTest {
+
+    private static final String SCHEMA_CONTENT = """
+            {
+              "$schema": "https://json-schema.org/draft/2019-09/schema",
+              "type": "object",
+              "required": ["name"],
+              "properties": {
+                "name": { "type": "string" }
+              }
+            }
+            """;
+
+    @Test
+    void validatorFor_resolvesSchemaThroughFileUriPrefixMapping(@TempDir Path tempDir) throws Exception {
+        var schemaFile = tempDir.resolve("test-schema.json");
+        Files.writeString(schemaFile, SCHEMA_CONTENT);
+
+        var provider = ManagementApiSchemaValidatorProvider.Builder.newInstance()
+                .objectMapper(JacksonJsonLd::createObjectMapper)
+                .prefixMapping("https://example.org/schema/", tempDir.toUri().toString())
+                .build();
+
+        var validator = provider.validatorFor("https://example.org/schema/test-schema.json");
+
+        var valid = Json.createObjectBuilder().add("name", "asset-1").build();
+        assertThat(validator.validate(valid).succeeded()).isTrue();
+
+        var invalid = Json.createObjectBuilder().build();
+        assertThat(validator.validate(invalid).succeeded()).isFalse();
+    }
+
+    @Test
+    void validatorFor_resolvesSchemaDirectlyFromFileUri(@TempDir Path tempDir) throws Exception {
+        var schemaFile = tempDir.resolve("direct-schema.json");
+        Files.writeString(schemaFile, SCHEMA_CONTENT);
+
+        var provider = ManagementApiSchemaValidatorProvider.Builder.newInstance()
+                .objectMapper(JacksonJsonLd::createObjectMapper)
+                .build();
+
+        var validator = provider.validatorFor(schemaFile.toUri().toString());
+
+        var valid = Json.createObjectBuilder().add("name", "asset-1").build();
+        assertThat(validator.validate(valid).succeeded()).isTrue();
+    }
+}

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/PolicyDefinitionApiCustomSchemaV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/PolicyDefinitionApiCustomSchemaV5EndToEndTest.java
@@ -1,0 +1,175 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.managementapi.v5;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.api.authentication.OauthServer;
+import org.eclipse.edc.api.authentication.OauthServerEndToEndExtension;
+import org.eclipse.edc.connector.controlplane.policy.spi.store.PolicyDefinitionStore;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
+import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.test.e2e.managementapi.Runtimes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Map;
+
+import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createArrayBuilder;
+import static jakarta.json.Json.createObjectBuilder;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.test.e2e.managementapi.v5.TestFunction.createParticipant;
+import static org.eclipse.edc.test.e2e.managementapi.v5.TestFunction.jsonLdContext;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * End-to-end tests for the policy definition API with a custom JSON schema validator configured.
+ * We load a custom policy definition schema where the `profile` field of a policy is required
+ */
+public class PolicyDefinitionApiCustomSchemaV5EndToEndTest {
+
+
+    @SuppressWarnings("JUnitMalformedDeclaration")
+    abstract static class Tests {
+
+        private static final String PARTICIPANT_CONTEXT_ID = "test-participant";
+
+        private String participantTokenJwt;
+
+        @BeforeEach
+        void setup(OauthServer authServer, ParticipantContextService participantContextService) {
+            createParticipant(participantContextService, PARTICIPANT_CONTEXT_ID);
+
+            participantTokenJwt = authServer.createToken(PARTICIPANT_CONTEXT_ID);
+        }
+
+        @AfterEach
+        void teardown(ParticipantContextService participantContextService, PolicyDefinitionStore store) {
+            participantContextService.deleteParticipantContext(PARTICIPANT_CONTEXT_ID)
+                    .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+
+            store.findAll(QuerySpec.max()).forEach(pd -> store.delete(pd.getId()));
+        }
+
+        @Test
+        void create_validationFails(ManagementEndToEndV5TestContext context) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "PolicyDefinition")
+                    .add("policy", sampleOdrlPolicy())
+                    .build();
+
+            context.baseRequest(participantTokenJwt)
+                    .body(requestBody.toString())
+                    .contentType(JSON)
+                    .post("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/policydefinitions")
+                    .then()
+                    .log().ifValidationFails()
+                    .contentType(JSON)
+                    .statusCode(400)
+                    .body("[0].message", containsString("required property 'profile' not found"));
+        }
+
+        @Test
+        void update_whenSchemaValidationFails(ManagementEndToEndV5TestContext context) {
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "PolicyDefinition")
+                    .add("policy", sampleOdrlPolicy())
+                    .build();
+
+            context.baseRequest(participantTokenJwt)
+                    .body(requestBody.toString())
+                    .contentType(JSON)
+                    .put("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/policydefinitions/id")
+                    .then()
+                    .log().ifValidationFails()
+                    .contentType(JSON)
+                    .statusCode(400)
+                    .body("[0].message", containsString("required property 'profile' not found"));
+        }
+
+        private JsonObject sampleOdrlPolicy() {
+            return createObjectBuilder()
+                    .add(TYPE, "Set")
+                    .add("permission", createArrayBuilder()
+                            .add(createObjectBuilder()
+                                    .add("action", "use")
+                                    .add("constraint", createArrayBuilder().add(createObjectBuilder()
+                                                    .add("leftOperand", "inForceDate")
+                                                    .add("operator", "gteq")
+                                                    .add("rightOperand", "contractAgreement+0s"))
+                                            .build()))
+                            .build())
+                    .add("prohibition", createArrayBuilder()
+                            .add(createObjectBuilder()
+                                    .add("action", "use")
+                            ))
+                    .add("obligation", createArrayBuilder()
+                            .add(createObjectBuilder()
+                                    .add("action", "use")
+                            )
+                    )
+                    .build();
+        }
+
+    }
+
+    @Nested
+    @EndToEndTest
+    class InMemory extends Tests {
+
+        @Order(0)
+        @RegisterExtension
+        static final OauthServerEndToEndExtension AUTH_SERVER_EXTENSION = OauthServerEndToEndExtension.Builder.newInstance().build();
+
+        @Order(1)
+        @RegisterExtension
+        static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()
+                .name(Runtimes.ControlPlane.NAME)
+                .modules(Runtimes.ControlPlane.VIRTUAL_MODULES)
+                .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
+                .configurationProvider(Runtimes.ControlPlane::config)
+                .configurationProvider(InMemory::schemaValidatorConfig)
+                .paramProvider(ManagementEndToEndV5TestContext.class, ManagementEndToEndV5TestContext::forContext)
+                .configurationProvider(AUTH_SERVER_EXTENSION::getConfig)
+                .build();
+
+        static Config schemaValidatorConfig() {
+            var uri = TestUtils.getFileFromResourceName("schema/v4").toURI().toString();
+            uri = uri.endsWith("/") ? uri.substring(0, uri.length() - 1) : uri;
+            return ConfigFactory.fromMap(Map.of(
+                    "edc.mgmt.api.schema.custom.version", "v4",
+                    "edc.mgmt.api.schema.custom.mapping.from", "https://example.org/schema/v4",
+                    "edc.mgmt.api.schema.custom.mapping.to", uri,
+                    "edc.mgmt.api.schema.custom.validator.policy.type", "PolicyDefinition",
+                    "edc.mgmt.api.schema.custom.validator.policy.schema", "https://example.org/schema/v4/policy-definition-custom-schema.json"
+            ));
+        }
+
+    }
+
+}

--- a/system-tests/management-api/management-api-test-runner/src/test/resources/schema/v4/policy-definition-custom-schema.json
+++ b/system-tests/management-api/management-api-test-runner/src/test/resources/schema/v4/policy-definition-custom-schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "PolicyDefinitionSchema",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/PolicyDefinition"
+    }
+  ],
+  "$id": "https://example.org/schema/v4/policy-definition-schema.json",
+  "definitions": {
+    "PolicyDefinition": {
+      "type": "object",
+      "properties": {
+        "policy": {
+          "$ref": "https://example.org/schema/v4/policy-definition-schema.json#/definitions/PolicyClass"
+        }
+      }
+    },
+    "PolicyClass": {
+      "type": "object",
+      "properties": {
+        "profile": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "required": [
+        "profile"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## What this PR changes/adds

Add configurable json-schema. To enable loading schema file from local disk we had to enable  `IriResourceLoader` there is no distinction between file or http loader. Users should prefer mounting files and configure the mapping instead of letting the remote fetching.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

The current limitation is that the schema applies to all dataspace profiles. We do not have yet a profile aware validation layer.


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5769 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
