### PR TITLE
feat: bind Asset to Distribution

### DIFF
--- a/core/common/lib/json-ld-lib/src/main/resources/document/management-context-v2.jsonld
+++ b/core/common/lib/json-ld-lib/src/main/resources/document/management-context-v2.jsonld
@@ -38,6 +38,10 @@
         "properties": {
           "@id": "edc:properties",
           "@type": "@json"
+        },
+        "profiles": {
+          "@id": "edc:profiles",
+          "@container": "@set"
         }
       }
     },

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/from/JsonObjectFromDataplaneMetadataTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/from/JsonObjectFromDataplaneMetadataTransformer.java
@@ -55,6 +55,13 @@ public class JsonObjectFromDataplaneMetadataTransformer extends AbstractJsonLdTr
                     .build());
         }
 
+        var profiles = dataplaneMetadata.getProfiles();
+        if (!profiles.isEmpty()) {
+            var arrayBuilder = jsonFactory.createArrayBuilder();
+            profiles.forEach(arrayBuilder::add);
+            builder.add(DataplaneMetadata.EDC_DATAPLANE_METADATA_PROFILES, arrayBuilder);
+        }
+
         return builder.build();
     }
 }

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToDataplaneMetadataTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToDataplaneMetadataTransformer.java
@@ -44,7 +44,7 @@ public class JsonObjectToDataplaneMetadataTransformer extends AbstractJsonLdTran
         if (labels != null) {
             labels.stream()
                     .map(this::nodeJsonValue)
-                    .map(value -> deserializeLabel(value, context))
+                    .map(value -> deserializeListItem("labels", value, context))
                     .filter(Objects::nonNull)
                     .forEach(builder::label);
         }
@@ -67,15 +67,25 @@ public class JsonObjectToDataplaneMetadataTransformer extends AbstractJsonLdTran
             }
         }
 
+        var profiles = jsonObject.getJsonArray(DataplaneMetadata.EDC_DATAPLANE_METADATA_PROFILES);
+        if (profiles != null) {
+            profiles.stream()
+                    .map(this::nodeJsonValue)
+                    .map(value -> deserializeListItem("profiles", value, context))
+                    .filter(Objects::nonNull)
+                    .forEach(builder::profile);
+        }
+
         return builder.build();
     }
 
-    private @Nullable String deserializeLabel(JsonValue value, @NotNull TransformerContext context) {
+    private @Nullable String deserializeListItem(String listAttribute, JsonValue value, @NotNull TransformerContext context) {
         if (value instanceof JsonString string) {
             return string.getString();
         }
 
-        context.reportProblem("DataplaneMetadata labels should be strings, but label '%s' is a '%s'".formatted(value, value.getValueType()));
+        context.reportProblem(("DataplaneMetadata %s should be strings, but profile '%s' is a '%s'")
+                .formatted(listAttribute, value, value.getValueType()));
         return null;
     }
 }

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/from/JsonObjectFromDataplaneMetadataTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/from/JsonObjectFromDataplaneMetadataTransformerTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata.EDC_DATAPLANE_METADATA_LABELS;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata.EDC_DATAPLANE_METADATA_PROFILES;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata.EDC_DATAPLANE_METADATA_PROPERTIES;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata.EDC_DATAPLANE_METADATA_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
@@ -52,5 +53,19 @@ class JsonObjectFromDataplaneMetadataTransformerTest {
                             assertThat(jsonString.getString()).isEqualTo("value"));
                 }
         );
+        assertThat(result.get(EDC_DATAPLANE_METADATA_PROFILES)).isNull();
+    }
+
+    @Test
+    void shouldTransformProfilesToJson() {
+        var context = new TransformerContextImpl(mock());
+        var dataplaneMetadata = DataplaneMetadata.Builder.newInstance().profile("profile1").profile("profile2").build();
+
+        var result = transformer.transform(dataplaneMetadata, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getJsonArray(EDC_DATAPLANE_METADATA_PROFILES)).hasSize(2)
+                .extracting(JsonString.class::cast).extracting(JsonString::getString)
+                .containsExactlyInAnyOrder("profile1", "profile2");
     }
 }

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToDataplaneMetadataTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToDataplaneMetadataTransformerTest.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata.EDC_DATAPLANE_METADATA_LABELS;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata.EDC_DATAPLANE_METADATA_PROFILES;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata.EDC_DATAPLANE_METADATA_PROPERTIES;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata.EDC_DATAPLANE_METADATA_SIMPLE_TYPE;
 import static org.eclipse.edc.connector.controlplane.transform.TestInput.getExpanded;
@@ -112,6 +113,36 @@ class JsonObjectToDataplaneMetadataTransformerTest {
                 .add(CONTEXT, context)
                 .add(TYPE, EDC_DATAPLANE_METADATA_SIMPLE_TYPE)
                 .add(EDC_DATAPLANE_METADATA_LABELS, jsonFactory.createArrayBuilder().add(1))
+                .build();
+
+        var result = typeTransformerRegistry.transform(getExpanded(jsonObj), DataplaneMetadata.class);
+
+        assertThat(result).isFailed();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(Contexts.class)
+    void shouldTransformProfiles(JsonValue context) {
+        var jsonObj = jsonFactory.createObjectBuilder()
+                .add(CONTEXT, context)
+                .add(TYPE, EDC_DATAPLANE_METADATA_SIMPLE_TYPE)
+                .add("profiles", jsonFactory.createArrayBuilder().add("profile1").add("profile2"))
+                .build();
+
+        var result = typeTransformerRegistry.transform(getExpanded(jsonObj), DataplaneMetadata.class);
+
+        assertThat(result).isSucceeded().satisfies(metadata -> {
+            assertThat(metadata.getProfiles()).containsExactly("profile1", "profile2");
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(Contexts.class)
+    void shouldFail_whenProfileIsNotString(JsonValue context) {
+        var jsonObj = jsonFactory.createObjectBuilder()
+                .add(CONTEXT, context)
+                .add(TYPE, EDC_DATAPLANE_METADATA_SIMPLE_TYPE)
+                .add(EDC_DATAPLANE_METADATA_PROFILES, jsonFactory.createArrayBuilder().add(1))
                 .build();
 
         var result = typeTransformerRegistry.transform(getExpanded(jsonObj), DataplaneMetadata.class);

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowController.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowController.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.signaling.logic;
 
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowController;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataAddressStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataFlowResponse;
@@ -37,6 +38,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -251,17 +255,21 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
 
     @Override
     public Set<String> transferTypesFor(Asset asset) {
-        return transferTypes();
+        var profiles = Optional.ofNullable(asset.getDataplaneMetadata())
+                .map(DataplaneMetadata::getProfiles)
+                .orElse(List.of());
+        return transferTypes(profiles);
     }
 
     @Override
     public Set<String> transferTypesFor(String assetId) {
-        return transferTypes();
+        return transferTypes(List.of());
     }
 
-    private @NotNull Set<String> transferTypes() {
+    private @NotNull Set<String> transferTypes(List<String> profiles) {
         return selectorClient.getAll().map(Collection::stream)
-                .map(it -> it.map(DataPlaneInstance::getAllowedTransferTypes)
+                .map(dataPlane -> dataPlane.map(DataPlaneInstance::getAllowedTransferTypes)
+                        .filter(allowedTransferTypes -> profiles.isEmpty() || !Collections.disjoint(allowedTransferTypes, profiles))
                         .flatMap(Collection::stream).collect(toSet()))
                 .orElse(f -> emptySet());
     }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowControllerTest.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowControllerTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.signaling.logic;
 
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataAddressStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataFlowResponse;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
@@ -505,6 +506,38 @@ public class DataPlaneSignalingFlowControllerTest {
             var transferTypes = flowController.transferTypesFor(asset);
 
             assertThat(transferTypes).isEmpty();
+        }
+
+        @Test
+        void shouldFilterByAssetProfile_whenProfilesAreSet() {
+            when(selectorService.getAll()).thenReturn(ServiceResult.success(List.of(
+                    dataPlaneInstanceBuilder().allowedTransferType("Http-PULL").build(),
+                    dataPlaneInstanceBuilder().allowedTransferType("S3-PULL").build()
+            )));
+            var metadata = DataplaneMetadata.Builder.newInstance().profile("Http-PULL").build();
+            var asset = Asset.Builder.newInstance()
+                    .dataAddress(DataAddress.Builder.newInstance().type("TargetSrc").build())
+                    .dataplaneMetadata(metadata)
+                    .build();
+
+            var transferTypes = flowController.transferTypesFor(asset);
+
+            assertThat(transferTypes).containsExactly("Http-PULL");
+        }
+
+        @Test
+        void shouldReturnAllTypes_whenAssetHasNoProfiles() {
+            when(selectorService.getAll()).thenReturn(ServiceResult.success(List.of(
+                    dataPlaneInstanceBuilder().allowedTransferType("Http-PULL").build(),
+                    dataPlaneInstanceBuilder().allowedTransferType("S3-PULL").build()
+            )));
+            var asset = Asset.Builder.newInstance()
+                    .dataAddress(DataAddress.Builder.newInstance().type("TargetSrc").build())
+                    .build();
+
+            var transferTypes = flowController.transferTypesFor(asset);
+
+            assertThat(transferTypes).containsExactlyInAnyOrder("Http-PULL", "S3-PULL");
         }
     }
 

--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -6,15 +6,15 @@
     "maturity": "deprecated"
   },
   {
-    "version": "4.0.0",
+    "version": "4.1.0",
     "urlPath": "/v4",
-    "lastUpdated": "2026-04-17T09:43:01Z",
+    "lastUpdated": "2026-05-25T09:43:01Z",
     "maturity": "stable"
   },
   {
     "version": "5.0.0-beta",
     "urlPath": "/v5beta",
-    "lastUpdated": "2026-05-21T09:00:00Z",
+    "lastUpdated": "2026-05-25T09:00:00Z",
     "maturity": "beta"
   }
 ]

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/dataplane-metadata-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/dataplane-metadata-schema.json
@@ -25,6 +25,12 @@
         "properties": {
           "type": "object",
           "example": { "key": "value" }
+        },
+        "profiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": ["@type"]

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/LegacyDataPlaneSignalingFlowController.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/main/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/LegacyDataPlaneSignalingFlowController.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.controlplane.transfer.dataplane.flow;
 
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata;
 import org.eclipse.edc.connector.controlplane.asset.spi.index.AssetIndex;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowController;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowPropertiesProvider;
@@ -38,6 +39,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -220,9 +222,14 @@ public class LegacyDataPlaneSignalingFlowController implements DataFlowControlle
             return emptySet();
         }
 
+        var assetProfiles = Optional.ofNullable(asset.getDataplaneMetadata())
+                .map(DataplaneMetadata::getProfiles)
+                .orElse(List.of());
+
         var assetDataAddress = asset.getDataAddress();
         if (assetDataAddress == null) {
             return allDataPlanes.getContent().stream()
+                    .filter(dataPlane -> assetProfiles.isEmpty() || !Collections.disjoint(dataPlane.getAllowedTransferTypes(), assetProfiles))
                     .flatMap(dataPlane -> dataPlane.getAllowedTransferTypes().stream())
                     .collect(toSet());
         }
@@ -233,6 +240,7 @@ public class LegacyDataPlaneSignalingFlowController implements DataFlowControlle
 
         return allDataPlanes.getContent().stream()
                 .filter(dataPlane -> dataPlane.getAllowedSourceTypes().contains(assetDataAddress.getType()))
+                .filter(dataPlane -> assetProfiles.isEmpty() || !Collections.disjoint(dataPlane.getAllowedTransferTypes(), assetProfiles))
                 .flatMap(dataPlane -> dataPlane.getAllowedTransferTypes().stream())
                 .filter(transferType -> isCompatibleTransferType(transferType, expectedResponseChannelType))
                 .collect(toSet());

--- a/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/LegacyDataPlaneSignalingFlowControllerTest.java
+++ b/extensions/control-plane/transfer/transfer-data-plane-signaling/src/test/java/org/eclipse/edc/connector/controlplane/transfer/dataplane/flow/LegacyDataPlaneSignalingFlowControllerTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.connector.controlplane.transfer.dataplane.flow;
 
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowPropertiesProvider;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.TransferTypeParser;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataAddressStore;
@@ -486,6 +487,40 @@ public class LegacyDataPlaneSignalingFlowControllerTest {
             var transferTypes = flowController.transferTypesFor(asset);
 
             assertThat(transferTypes).isEmpty();
+        }
+
+        @Test
+        void shouldFilterByAssetProfile_whenProfilesAreSet() {
+            when(transferTypeParser.parse(any())).thenReturn(Result.success(new TransferType("any", FlowType.PULL)));
+            when(selectorService.getAll()).thenReturn(ServiceResult.success(List.of(
+                    dataPlaneInstanceBuilder().allowedTransferType("Http-PULL").allowedSourceType("TargetSrc").build(),
+                    dataPlaneInstanceBuilder().allowedTransferType("S3-PULL").allowedSourceType("TargetSrc").build()
+            )));
+            var metadata = DataplaneMetadata.Builder.newInstance().profile("Http-PULL").build();
+            var asset = Asset.Builder.newInstance()
+                    .dataAddress(DataAddress.Builder.newInstance().type("TargetSrc").build())
+                    .dataplaneMetadata(metadata)
+                    .build();
+
+            var transferTypes = flowController.transferTypesFor(asset);
+
+            assertThat(transferTypes).containsExactly("Http-PULL");
+        }
+
+        @Test
+        void shouldReturnAllTypes_whenAssetHasNoProfiles() {
+            when(transferTypeParser.parse(any())).thenReturn(Result.success(new TransferType("any", FlowType.PULL)));
+            when(selectorService.getAll()).thenReturn(ServiceResult.success(List.of(
+                    dataPlaneInstanceBuilder().allowedTransferType("Http-PULL").allowedSourceType("TargetSrc").build(),
+                    dataPlaneInstanceBuilder().allowedTransferType("S3-PULL").allowedSourceType("TargetSrc").build()
+            )));
+            var asset = Asset.Builder.newInstance()
+                    .dataAddress(DataAddress.Builder.newInstance().type("TargetSrc").build())
+                    .build();
+
+            var transferTypes = flowController.transferTypesFor(asset);
+
+            assertThat(transferTypes).containsExactlyInAnyOrder("Http-PULL", "S3-PULL");
         }
     }
 

--- a/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/DataplaneMetadata.java
+++ b/spi/control-plane/asset-spi/src/main/java/org/eclipse/edc/connector/controlplane/asset/spi/domain/DataplaneMetadata.java
@@ -32,9 +32,11 @@ public class DataplaneMetadata {
     public static final String EDC_DATAPLANE_METADATA_TYPE = EDC_NAMESPACE + EDC_DATAPLANE_METADATA_SIMPLE_TYPE;
     public static final String EDC_DATAPLANE_METADATA_LABELS = EDC_NAMESPACE + "labels";
     public static final String EDC_DATAPLANE_METADATA_PROPERTIES = EDC_NAMESPACE + "properties";
+    public static final String EDC_DATAPLANE_METADATA_PROFILES = EDC_NAMESPACE + "profiles";
 
     private final List<String> labels = new ArrayList<>();
     private final Map<String, Object> properties = new HashMap<>();
+    private final List<String> profiles = new ArrayList<>();
 
     private DataplaneMetadata() {
 
@@ -46,6 +48,10 @@ public class DataplaneMetadata {
 
     public Map<String, Object> getProperties() {
         return properties;
+    }
+
+    public List<String> getProfiles() {
+        return profiles;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -79,6 +85,16 @@ public class DataplaneMetadata {
 
         public Builder label(String label) {
             instance.labels.add(label);
+            return this;
+        }
+
+        public Builder profiles(List<String> profiles) {
+            instance.profiles.addAll(profiles);
+            return this;
+        }
+
+        public Builder profile(String profile) {
+            instance.profiles.add(profile);
             return this;
         }
     }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v4/AssetApiV4EndToEndTest.java
@@ -66,6 +66,7 @@ public class AssetApiV4EndToEndTest {
                     .dataplaneMetadata(DataplaneMetadata.Builder.newInstance()
                             .label("label")
                             .property(EDC_NAMESPACE + "property", "value")
+                            .profile("http-profile")
                             .build())
                     .build();
             assetIndex.create(asset);
@@ -93,7 +94,8 @@ public class AssetApiV4EndToEndTest {
                     .containsEntry("innerValue", "value");
             assertThat(body.getMap("'dataplaneMetadata'"))
                     .containsEntry("labels", List.of("label"))
-                    .containsEntry("properties", Map.of("edc:property", "value"));
+                    .containsEntry("properties", Map.of("edc:property", "value"))
+                    .containsEntry("profiles", List.of("http-profile"));
         }
 
         @Test
@@ -114,6 +116,7 @@ public class AssetApiV4EndToEndTest {
                                     .add("another-key", "another-value")
                             )
                             .add("labels", createArrayBuilder().add("label1").add("label2"))
+                            .add("profiles", createArrayBuilder().add("profile1").add("profile2"))
                     )
                     .build();
 
@@ -133,6 +136,7 @@ public class AssetApiV4EndToEndTest {
             assertThat(asset.getDataplaneMetadata().getProperties()).containsExactlyInAnyOrderEntriesOf(
                     Map.of("key", "value", "another-key", "another-value"));
             assertThat(asset.getDataplaneMetadata().getLabels()).containsExactly("label1", "label2");
+            assertThat(asset.getDataplaneMetadata().getProfiles()).containsExactly("profile1", "profile2");
             assertThat(asset.getParticipantContextId()).isNotNull();
         }
 
@@ -363,6 +367,7 @@ public class AssetApiV4EndToEndTest {
                     .add("dataplaneMetadata", createObjectBuilder()
                             .add(TYPE, "DataplaneMetadata")
                             .add("labels", createArrayBuilder().add("updated-label"))
+                            .add("profiles", createArrayBuilder().add("updated-profile"))
                             .add("properties", createObjectBuilder()
                                .add("complex", createObjectBuilder()
                                        .add("nested", "value").build()))
@@ -382,6 +387,7 @@ public class AssetApiV4EndToEndTest {
             assertThat(dbAsset).isNotNull();
             assertThat(dbAsset.getProperties()).containsEntry(EDC_NAMESPACE + "some-new-property", "some-new-value");
             assertThat(dbAsset.getDataplaneMetadata().getLabels()).containsExactly("updated-label");
+            assertThat(dbAsset.getDataplaneMetadata().getProfiles()).containsExactly("updated-profile");
             assertThat(dbAsset.getDataplaneMetadata().getProperties())
                     .containsKey("complex").extracting(m -> m.get("complex"))
                     .satisfies(complex -> {

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/AssetApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/AssetApiV5EndToEndTest.java
@@ -20,6 +20,7 @@ import jakarta.json.JsonObjectBuilder;
 import org.eclipse.edc.api.authentication.OauthServer;
 import org.eclipse.edc.api.authentication.OauthServerEndToEndExtension;
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata;
 import org.eclipse.edc.connector.controlplane.asset.spi.index.AssetIndex;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
@@ -442,6 +443,58 @@ public class AssetApiV5EndToEndTest {
                             List.of(Map.of(EDC_NAMESPACE + "innerValue",
                                     List.of(Map.of(VALUE, "value")))));
             assertThat(asset.getParticipantContextId()).isEqualTo(PARTICIPANT_CONTEXT_ID);
+        }
+
+        @Test
+        void createAsset_withDataplaneMetadataProfiles_shouldBeStored(ManagementEndToEndV5TestContext context, AssetIndex assetIndex) {
+            var id = UUID.randomUUID().toString();
+            var assetJson = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "Asset")
+                    .add(ID, id)
+                    .add("properties", createPropertiesBuilder().build())
+                    .add("dataplaneMetadata", createObjectBuilder()
+                            .add(TYPE, "DataplaneMetadata")
+                            .add("profiles", createArrayBuilder().add("profile1").add("profile2"))
+                    )
+                    .add("dataAddress", createObjectBuilder()
+                            .add(TYPE, "DataAddress")
+                            .add("type", "test-type")
+                            .build())
+                    .build()
+                    .toString();
+
+            context.baseRequest(participantTokenJwt)
+                    .contentType(ContentType.JSON)
+                    .body(assetJson)
+                    .post("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/assets")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .body(ID, is(id));
+
+            var asset = assetIndex.findById(id);
+            assertThat(asset).isNotNull();
+            assertThat(asset.getDataplaneMetadata()).isNotNull();
+            assertThat(asset.getDataplaneMetadata().getProfiles()).containsExactly("profile1", "profile2");
+        }
+
+        @Test
+        void findById_withDataplaneMetadataProfiles_shouldReturnProfiles(ManagementEndToEndV5TestContext context, AssetIndex assetIndex) {
+            var id = UUID.randomUUID().toString();
+            var metadata = DataplaneMetadata.Builder.newInstance().profile("http-profile").profile("s3-profile").build();
+            var asset = createAsset().id(id).dataplaneMetadata(metadata).build();
+            assetIndex.create(asset);
+
+            var body = context.baseRequest(participantTokenJwt)
+                    .get("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/assets/" + id)
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .extract().body().jsonPath();
+
+            assertThat(body.getList("'dataplaneMetadata'.'profiles'", String.class))
+                    .containsExactlyInAnyOrder("http-profile", "s3-profile");
         }
 
         @Test

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CatalogApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CatalogApiV5EndToEndTest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.test.e2e.managementapi.v5;
 import org.eclipse.edc.api.authentication.OauthServer;
 import org.eclipse.edc.api.authentication.OauthServerEndToEndExtension;
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
+import org.eclipse.edc.connector.controlplane.asset.spi.domain.DataplaneMetadata;
 import org.eclipse.edc.connector.controlplane.asset.spi.index.AssetIndex;
 import org.eclipse.edc.connector.controlplane.contract.spi.offer.store.ContractDefinitionStore;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
@@ -87,13 +88,15 @@ public class CatalogApiV5EndToEndTest {
         }
 
         @AfterEach
-        void teardown(ParticipantContextService participantContextService) {
+        void teardown(ParticipantContextService participantContextService, DataPlaneInstanceStore dataPlaneInstanceStore) {
             var list = participantContextService.search(QuerySpec.max())
                     .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
 
             for (var p : list) {
                 participantContextService.deleteParticipantContext(p.getParticipantContextId()).orElseThrow(f -> new AssertionError(f.getFailureDetail()));
             }
+
+            dataPlaneInstanceStore.getAll().toList().forEach(dp -> dataPlaneInstanceStore.deleteById(dp.getId()));
         }
 
         @Test
@@ -454,6 +457,82 @@ public class CatalogApiV5EndToEndTest {
                     .body(ID, is("asset-response"))
                     .body(TYPE, is("Dataset"))
                     .body("distribution[0].format", is("any-PULL-response"));
+        }
+
+        @Test
+        void getDataset_shouldFilterDistributionsByAssetProfiles(ManagementEndToEndV5TestContext context, AssetIndex assetIndex,
+                                                                  DataPlaneInstanceStore dataPlaneInstanceStore,
+                                                                  PolicyDefinitionStore policyDefinitionStore,
+                                                                  ContractDefinitionStore contractDefinitionStore) {
+            var httpDataPlane = DataPlaneInstance.Builder.newInstance().url("http://localhost/any")
+                    .allowedSourceType("test-type").allowedTransferType("Http-PULL").build();
+            var s3DataPlane = DataPlaneInstance.Builder.newInstance().url("http://localhost/any-s3")
+                    .allowedSourceType("test-type").allowedTransferType("S3-PULL").build();
+            dataPlaneInstanceStore.save(httpDataPlane);
+            dataPlaneInstanceStore.save(s3DataPlane);
+
+            createContractOffer(policyDefinitionStore, contractDefinitionStore, List.of());
+            var metadata = DataplaneMetadata.Builder.newInstance().profile("Http-PULL").build();
+            assetIndex.create(createAsset("asset-with-profile", "test-type").dataplaneMetadata(metadata).build());
+
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(TYPE, "DatasetRequest")
+                    .add(ID, "asset-with-profile")
+                    .add("counterPartyAddress", context.providerProtocolUrl(COUNTER_PARTY_ID, context.profile()))
+                    .add("counterPartyId", COUNTER_PARTY_ID)
+                    .add("profile", context.profile())
+                    .build()
+                    .toString();
+
+            context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .body(requestBody)
+                    .post("/v5beta/participants/%s/catalog/dataset/request".formatted(PARTICIPANT_CONTEXT_ID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body(ID, is("asset-with-profile"))
+                    .body("distribution.size()", is(1))
+                    .body("distribution[0].format", is("Http-PULL"));
+        }
+
+        @Test
+        void getDataset_shouldReturnAllDistributions_whenAssetHasNoProfiles(ManagementEndToEndV5TestContext context, AssetIndex assetIndex,
+                                                                             DataPlaneInstanceStore dataPlaneInstanceStore,
+                                                                             PolicyDefinitionStore policyDefinitionStore,
+                                                                             ContractDefinitionStore contractDefinitionStore) {
+            var httpDataPlane = DataPlaneInstance.Builder.newInstance().url("http://localhost/any")
+                    .allowedSourceType("test-type").allowedTransferType("Http-PULL").build();
+            var s3DataPlane = DataPlaneInstance.Builder.newInstance().url("http://localhost/any-s3")
+                    .allowedSourceType("test-type").allowedTransferType("S3-PULL").build();
+            dataPlaneInstanceStore.save(httpDataPlane);
+            dataPlaneInstanceStore.save(s3DataPlane);
+
+            createContractOffer(policyDefinitionStore, contractDefinitionStore, List.of());
+            assetIndex.create(createAsset("asset-no-profile", "test-type").build());
+
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
+                    .add(TYPE, "DatasetRequest")
+                    .add(ID, "asset-no-profile")
+                    .add("counterPartyAddress", context.providerProtocolUrl(COUNTER_PARTY_ID, context.profile()))
+                    .add("counterPartyId", COUNTER_PARTY_ID)
+                    .add("profile", context.profile())
+                    .build()
+                    .toString();
+
+            context.baseRequest(participantTokenJwt)
+                    .contentType(JSON)
+                    .body(requestBody)
+                    .post("/v5beta/participants/%s/catalog/dataset/request".formatted(PARTICIPANT_CONTEXT_ID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body(ID, is("asset-no-profile"))
+                    .body("distribution.size()", is(2));
         }
 
         @Test


### PR DESCRIPTION
## What this PR changes/adds

Add the `dataplaneMetadata.profiles` attribute, with which it's possible to bind an `Asset` to specific data-plane profiles

## Why it does that

DPS

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5776

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
