### PR TITLE
feat: adopt conformsTo from dct

### DIFF
--- a/core/common/lib/json-ld-lib/src/main/resources/document/dspace-edc-context-v1.jsonld
+++ b/core/common/lib/json-ld-lib/src/main/resources/document/dspace-edc-context-v1.jsonld
@@ -2,6 +2,7 @@
   "@context": {
     "@version": 1.1,
     "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "dct": "http://purl.org/dc/terms/",
     "QuerySpec": {
       "@id": "edc:QuerySpec",
       "@context": {
@@ -26,6 +27,10 @@
     "inForceDate": "edc:inForceDate",
     "id": "edc:id",
     "description": "edc:description",
-    "isCatalog": "edc:isCatalog"
+    "isCatalog": "edc:isCatalog",
+    "conformsTo": {
+      "@id": "dct:conformsTo",
+      "@type": "@id"
+    }
   }
 }

--- a/core/common/lib/json-ld-lib/src/main/resources/document/management-context-v2.jsonld
+++ b/core/common/lib/json-ld-lib/src/main/resources/document/management-context-v2.jsonld
@@ -2,13 +2,18 @@
   "@context": {
     "@version": 1.1,
     "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "dct": "http://purl.org/dc/terms/",
     "Asset": {
       "@id": "edc:Asset",
       "@context": {
         "properties": {
           "@id": "edc:properties",
           "@context": {
-            "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+            "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+            "conformsTo": {
+              "@id": "dct:conformsTo",
+              "@type": "@id"
+            }
           }
         },
         "privateProperties": {

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/asset-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/asset-schema.json
@@ -24,11 +24,20 @@
         },
         "properties": {
           "type": "object",
-          "example": { "key": "value" }
+          "example": {
+            "key": "value"
+          },
+          "properties": {
+            "conformsTo": {
+              "type": "string"
+            }
+          }
         },
         "privateProperties": {
           "type": "object",
-          "example": { "privateKey": "privateValue" }
+          "example": {
+            "privateKey": "privateValue"
+          }
         },
         "dataplaneMetadata": {
           "$ref": "https://w3id.org/edc/connector/management/schema/v4/dataplane-metadata-schema.json"

--- a/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
+++ b/spi/common/json-ld-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
@@ -41,6 +41,7 @@ public interface PropertyAndTypeNames {
 
     //DCT
     String DCT_FORMAT_ATTRIBUTE = DCT_SCHEMA + "format";
+    String DCT_CONFORMS_TO_ATTRIBUTE = DCT_SCHEMA + "conformsTo";
 
     String ODRL_POLICY_ATTRIBUTE = ODRL_SCHEMA + "hasPolicy";
     String ODRL_POLICY_TYPE_SET = ODRL_SCHEMA + "Set";

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/AssetApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/AssetApiV5EndToEndTest.java
@@ -50,6 +50,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_CONFORMS_TO_ATTRIBUTE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.query.Criterion.criterion;
@@ -406,7 +407,10 @@ public class AssetApiV5EndToEndTest {
                     .add(CONTEXT, jsonLdContext())
                     .add(TYPE, "Asset")
                     .add(ID, id)
-                    .add("properties", createPropertiesBuilder().add("isCatalog", "true").build())
+                    .add("properties", createPropertiesBuilder()
+                            .add("isCatalog", "true")
+                            .add("conformsTo", "http://example.com/spec")
+                            .build())
                     .add("privateProperties", createObjectBuilder()
                             .add("anotherProp", "anotherVal")
                             .build())
@@ -434,6 +438,8 @@ public class AssetApiV5EndToEndTest {
             var asset = assetIndex.findById(id);
             assertThat(asset).isNotNull();
             assertThat(asset.isCatalog()).isTrue();
+            assertThat(asset.getProperty(DCT_CONFORMS_TO_ATTRIBUTE)).isEqualTo(Map.of(ID, "http://example.com/spec"));
+
             assertThat(asset.getPrivateProperty(EDC_NAMESPACE + "anotherProp")).isEqualTo("anotherVal");
             assertThat(asset.getDataAddress().getProperty("complex"))
                     .asInstanceOf(MAP)
@@ -652,6 +658,7 @@ public class AssetApiV5EndToEndTest {
 
             var id = UUID.randomUUID().toString();
             var asset = createAsset().id(id)
+                    .property(DCT_CONFORMS_TO_ATTRIBUTE, Map.of(ID, "http://example.com/spec"))
                     .dataAddress(createDataAddress().type("addressType").build())
                     .build();
             assetIndex.create(asset);
@@ -666,8 +673,9 @@ public class AssetApiV5EndToEndTest {
             assertThat(body).isNotNull();
             assertThat(body.getString(ID)).isEqualTo(id);
             assertThat(body.getMap("properties"))
-                    .hasSize(2)
-                    .containsEntry("description", "test description");
+                    .hasSize(3)
+                    .containsEntry("description", "test description")
+                    .containsEntry("conformsTo", "http://example.com/spec");
             assertThat(body.getMap("'dataAddress'"))
                     .containsEntry("type", "addressType");
             assertThat(body.getMap("'dataAddress'.'complex'"))

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CatalogApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CatalogApiV5EndToEndTest.java
@@ -58,6 +58,7 @@ import static jakarta.json.Json.createObjectBuilder;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.DCT_CONFORMS_TO_ATTRIBUTE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -219,7 +220,11 @@ public class CatalogApiV5EndToEndTest {
                                                               ContractDefinitionStore contractDefinitionStore) {
 
             assetIndex.create(createAsset("id-1", "test-type").build());
-            assetIndex.create(createAsset("id-2", "test-type").build());
+
+            var asset2 = createAsset("id-2", "test-type")
+                    .property(DCT_CONFORMS_TO_ATTRIBUTE, Map.of(ID, "https://example.org/schema")).build();
+            
+            assetIndex.create(asset2);
             createContractOffer(policyDefinitionStore, contractDefinitionStore, List.of());
 
             var criteria = createArrayBuilder()
@@ -255,7 +260,8 @@ public class CatalogApiV5EndToEndTest {
                     .statusCode(200)
                     .contentType(JSON)
                     .body(TYPE, is("Catalog"))
-                    .body("dataset[0].id", is("id-2"));
+                    .body("dataset[0].id", is("id-2"))
+                    .body("dataset[0].conformsTo", is("https://example.org/schema"));
         }
 
         @Test


### PR DESCRIPTION
## What this PR changes/adds

Adopt conformsTo from dct.

A new known property has been added into the Asset#properties `conformsTo` which is namespaced on dublin core (dct).

The property can be set on the asset and it will be shown in the Catalog `Dataset` . The `conformTo` term definition
has been added in edc management api context and in the additional edc jsonld context in dsp protocol.

Since it's not a term adopted yet by the upstream dsp protocol it's custom to edc profile of the dsp protocol.


Potential breaking change might arise if people were storing a `conformTo` property in the assets which previous of this PR where expanded into default edc namespace `https://w3id.org/edc/v0.0.1/ns/` which could affect how the property is presented in the catalog and management api.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5774 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
