### PR TITLE
feat: set encryption disabled by default

### DIFF
--- a/core/common/lib/encryption-lib/build.gradle.kts
+++ b/core/common/lib/encryption-lib/build.gradle.kts
@@ -18,6 +18,8 @@ plugins {
 
 dependencies {
     api(project(":spi:common:encryption-spi"))
+
+    testImplementation(project(":core:common:junit"))
 }
 
 

--- a/core/common/lib/encryption-lib/src/main/java/org/eclipse/edc/encryption/EncryptionAlgorithmRegistryImpl.java
+++ b/core/common/lib/encryption-lib/src/main/java/org/eclipse/edc/encryption/EncryptionAlgorithmRegistryImpl.java
@@ -19,15 +19,13 @@ import org.eclipse.edc.spi.result.Result;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 public class EncryptionAlgorithmRegistryImpl implements EncryptionAlgorithmRegistry {
 
     private final Map<String, EncryptionAlgorithm> algorithms = new ConcurrentHashMap<>();
 
-    private final boolean failOnUnsupported;
-
-    public EncryptionAlgorithmRegistryImpl(boolean failOnUnsupported) {
-        this.failOnUnsupported = failOnUnsupported;
+    public EncryptionAlgorithmRegistryImpl() {
     }
 
     @Override
@@ -42,23 +40,22 @@ public class EncryptionAlgorithmRegistryImpl implements EncryptionAlgorithmRegis
 
     @Override
     public Result<String> encrypt(String algorithm, String plainText) {
-        return Optional.ofNullable(algorithms.get(algorithm))
-                .map(encryptionAlgorithm -> encryptionAlgorithm.encrypt(plainText))
-                .orElseGet(() -> unsupportedAlgorithm(plainText, algorithm));
+        return apply(algorithm, plainText, a -> a.encrypt(plainText));
     }
 
     @Override
     public Result<String> decrypt(String algorithm, String cipherText) {
-        return Optional.ofNullable(algorithms.get(algorithm))
-                .map(encryptionAlgorithm -> encryptionAlgorithm.decrypt(cipherText))
-                .orElseGet(() -> unsupportedAlgorithm(cipherText, algorithm));
+        return apply(algorithm, cipherText, a -> a.decrypt(cipherText));
     }
 
-    private Result<String> unsupportedAlgorithm(String text, String algorithm) {
-        if (failOnUnsupported) {
-            return Result.failure("Unsupported encryption algorithm: " + algorithm);
-        } else {
-            return Result.success(text);
+    private Result<String> apply(String algorithm, String input, Function<EncryptionAlgorithm, Result<String>> crypto) {
+        if (algorithm == null) {
+            return Result.success(input);
         }
+        return Optional.ofNullable(algorithms.get(algorithm))
+                .map(Result::success)
+                .orElseGet(() -> Result.failure("Unsupported encryption algorithm: " + algorithm))
+                .compose(crypto);
     }
+
 }

--- a/core/common/lib/encryption-lib/src/test/java/org/eclipse/edc/encryption/EncryptionAlgorithmRegistryImplTest.java
+++ b/core/common/lib/encryption-lib/src/test/java/org/eclipse/edc/encryption/EncryptionAlgorithmRegistryImplTest.java
@@ -17,8 +17,9 @@ package org.eclipse.edc.encryption;
 import org.eclipse.edc.spi.result.Result;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -27,46 +28,36 @@ import static org.mockito.Mockito.when;
 class EncryptionAlgorithmRegistryImplTest {
 
     private final EncryptionAlgorithm algorithm = mock();
+    private final EncryptionAlgorithmRegistryImpl registry = new EncryptionAlgorithmRegistryImpl();
 
     @Test
     void registerAndSupports() {
-        var registry = new EncryptionAlgorithmRegistryImpl(true);
-        assertFalse(registry.supports("echo"));
+        assertThat(registry.supports("echo")).isFalse();
 
         registry.register("echo", algorithm);
-        assertTrue(registry.supports("echo"));
+        assertThat(registry.supports("echo")).isTrue();
     }
 
     @Test
     void encryptAndDecryptWithRegisteredAlgorithm() {
-        var registry = new EncryptionAlgorithmRegistryImpl(true);
         when(algorithm.encrypt(anyString())).then(a -> Result.success("enc:" + a.getArgument(0)));
         when(algorithm.decrypt(anyString())).then(a -> Result.success("dec:" + a.getArgument(0)));
         registry.register("echo", algorithm);
 
-        Result<String> encryptResult = registry.encrypt("echo", "hello");
+        var encryptResult = registry.encrypt("echo", "hello");
         assertTrue(encryptResult.succeeded());
         assertEquals("enc:hello", encryptResult.getContent());
 
-        Result<String> decryptResult = registry.decrypt("echo", "ciph");
+        var decryptResult = registry.decrypt("echo", "ciph");
         assertTrue(decryptResult.succeeded());
         assertEquals("dec:ciph", decryptResult.getContent());
     }
 
     @Test
-    void unsupportedAlgorithm_whenFailOnUnsupported_true_returnsFailure() {
-        var registry = new EncryptionAlgorithmRegistryImpl(true);
+    void shouldReturnInput_whenAlgorithmIsNull() {
+        assertThat(registry.encrypt(null, "any")).isSucceeded().isEqualTo("any");
 
-        Result<String> res = registry.encrypt("unknown", "plain");
-        assertFalse(res.succeeded());
+        assertThat(registry.decrypt(null, "any")).isSucceeded().isEqualTo("any");
     }
 
-    @Test
-    void unsupportedAlgorithm_whenFailOnUnsupported_false_returnsPlainText() {
-        var registry = new EncryptionAlgorithmRegistryImpl(false);
-
-        Result<String> res = registry.encrypt("unknown", "plain");
-        assertTrue(res.succeeded());
-        assertEquals("plain", res.getContent());
-    }
 }

--- a/core/common/participant-context-config-core/src/main/java/org/eclipse/edc/participantcontext/config/ParticipantContextConfigServicesExtension.java
+++ b/core/common/participant-context-config-core/src/main/java/org/eclipse/edc/participantcontext/config/ParticipantContextConfigServicesExtension.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.transaction.spi.TransactionContext;
@@ -37,7 +38,7 @@ public class ParticipantContextConfigServicesExtension implements ServiceExtensi
     @Setting(
             description = "The encryption algorithm used for encrypting and decrypting sensitive config.",
             key = "edc.participants.config.encryption.algorithm",
-            defaultValue = "aes"
+            required = false
     )
     private String encryptionAlgorithm;
 
@@ -63,4 +64,10 @@ public class ParticipantContextConfigServicesExtension implements ServiceExtensi
         return new ParticipantContextConfigImpl(encryptionRegistry, encryptionAlgorithm, configStore, transactionContext);
     }
 
+    @Override
+    public void prepare() {
+        if (encryptionAlgorithm != null && !encryptionRegistry.supports(encryptionAlgorithm)) {
+            throw new EdcException("The configured '%s' encryption algorithm is not supported".formatted(encryptionAlgorithm));
+        }
+    }
 }

--- a/core/common/runtime-core/src/main/java/org/eclipse/edc/runtime/core/RuntimeCoreServicesExtension.java
+++ b/core/common/runtime-core/src/main/java/org/eclipse/edc/runtime/core/RuntimeCoreServicesExtension.java
@@ -63,13 +63,6 @@ public class RuntimeCoreServicesExtension implements ServiceExtension {
     )
     public String hostname;
 
-    @Setting(
-            description = "Whether to fail when an unsupported encryption algorithm is requested.",
-            defaultValue = "true",
-            key = "edc.encryption.strict"
-    )
-    private boolean failOnUnsupported;
-
     @Inject
     private OkHttpClient okHttpClient;
     @Inject
@@ -126,7 +119,7 @@ public class RuntimeCoreServicesExtension implements ServiceExtension {
 
     @Provider
     public EncryptionAlgorithmRegistry encryptionAlgorithmRegistry() {
-        return new EncryptionAlgorithmRegistryImpl(failOnUnsupported);
+        return new EncryptionAlgorithmRegistryImpl();
     }
 
     @Provider

--- a/spi/common/encryption-spi/src/main/java/org/eclipse/edc/encryption/EncryptionAlgorithmRegistry.java
+++ b/spi/common/encryption-spi/src/main/java/org/eclipse/edc/encryption/EncryptionAlgorithmRegistry.java
@@ -42,7 +42,7 @@ public interface EncryptionAlgorithmRegistry {
     /**
      * Encrypts the given plain text.
      *
-     * @param algorithm the algorithm to use for encryption
+     * @param algorithm the algorithm to use for encryption. If 'null', plainText will be returned as it is.
      * @param plainText the text to encrypt
      * @return the encrypted text if successful, or a failure result
      */
@@ -51,7 +51,7 @@ public interface EncryptionAlgorithmRegistry {
     /**
      * Decrypts the given cipher text.
      *
-     * @param algorithm  the algorithm to use for decryption
+     * @param algorithm  the algorithm to use for decryption. If 'null', cipherText will be returned as it is.
      * @param cipherText the text to decrypt
      * @return the decrypted text if successful, or a failure result
      */

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualTransferEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualTransferEndToEndTest.java
@@ -58,7 +58,6 @@ class VirtualTransferEndToEndTest {
             {
                 put("edc.iam.oauth2.jwks.url", "https://example.com/jwks");
                 put("edc.iam.oauth2.issuer", "test-issuer");
-                put("edc.encryption.strict", "false");
                 put("web.http.protocol.virtual", "true");
                 put("edc.dataspace.enable.profiles.all", "true");
             }


### PR DESCRIPTION
## What this PR changes/adds

Set encryption disabled by default, unless it gets explicitly configured.

The `strict` setting at this point is unnecessary: if a feature (e.g. `ParticipantContextConfigService`) does not have an algorithm configured (==`null`), no encryption will be applied by the encryption registry.

## Why it does that

encryption is an additional feature that needs explicit configuration (algorythm, keys), it shouldn't be enabled by default.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5767

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
