### PR TITLE
build: update hashicorp/vault test image to 2.0.1

### DIFF
--- a/extensions/common/vault/vault-hashicorp/src/test/java/org/eclipse/edc/vault/hashicorp/HashicorpVaultIntegrationTest.java
+++ b/extensions/common/vault/vault-hashicorp/src/test/java/org/eclipse/edc/vault/hashicorp/HashicorpVaultIntegrationTest.java
@@ -36,7 +36,6 @@ import org.testcontainers.vault.VaultContainer;
 import java.util.UUID;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.vault.hashicorp.client.HashicorpVaultConfig.VAULT_API_HEALTH_PATH_DEFAULT;
@@ -46,7 +45,8 @@ import static org.mockito.Mockito.mock;
 @ComponentTest
 @Testcontainers
 class HashicorpVaultIntegrationTest {
-    static final String DOCKER_IMAGE_NAME = "hashicorp/vault:1.18.3";
+
+    static final String DOCKER_IMAGE_NAME = "hashicorp/vault:2.0.1";
     static final String VAULT_ENTRY_KEY = "testing";
     static final String VAULT_ENTRY_VALUE = UUID.randomUUID().toString();
     static final String VAULT_DATA_ENTRY_NAME = "content";
@@ -54,11 +54,10 @@ class HashicorpVaultIntegrationTest {
     @Container
     private static final VaultContainer<?> VAULTCONTAINER = new VaultContainer<>(DOCKER_IMAGE_NAME)
             .withVaultToken(TOKEN)
-            .withSecretInVault("secret/" + VAULT_ENTRY_KEY, format("%s=%s", VAULT_DATA_ENTRY_NAME, VAULT_ENTRY_VALUE));
+            .withInitCommand("kv put secret/%s %s=%s".formatted(VAULT_ENTRY_KEY, VAULT_DATA_ENTRY_NAME, VAULT_ENTRY_VALUE));
     public final Monitor monitor = mock();
     private final ObjectMapper objectMapper = new ObjectMapper().configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
     private HashicorpVaultClient vault;
-
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
## What this PR changes/adds

Bumps hashicorp/vault image used for IT to 2.0.1
Avoid deprecated call

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5724

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
