### PR TITLE
fix: properly map name and description in JwtToVerifiableCredentialTransformer

### DIFF
--- a/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/main/java/org/eclipse/edc/iam/decentralizedclaims/transform/to/JwtToVerifiableCredentialTransformer.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/main/java/org/eclipse/edc/iam/decentralizedclaims/transform/to/JwtToVerifiableCredentialTransformer.java
@@ -48,6 +48,8 @@ public class JwtToVerifiableCredentialTransformer extends AbstractJwtTransformer
     private static final String ISSUANCE_DATE_PROPERTY = "issuanceDate";
     private static final String VALID_FROM_PROPERTY = "validFrom";
     private static final String VALID_UNTIL_PROPERTY = "validUntil";
+    private static final String NAME_PROPERTY = "name";
+    private static final String DESCRIPTION_PROPERTY = "description";
 
     private final Monitor monitor;
 
@@ -101,10 +103,15 @@ public class JwtToVerifiableCredentialTransformer extends AbstractJwtTransformer
                 // issuance date
                 extractDate(vc.get(ISSUANCE_DATE_PROPERTY), claims.getNotBeforeTime()).or(() -> extractDate(vc.get(VALID_FROM_PROPERTY), claims.getNotBeforeTime())).ifPresent(builder::issuanceDate);
 
+                // extract name
+                var name = ofNullable(vc.get(NAME_PROPERTY)).map(Object::toString).orElse(null);
+                var description = ofNullable(vc.get(DESCRIPTION_PROPERTY)).map(Object::toString).orElse(null);
+                builder.name(name)
+                        .description(description);
+
                 // take issuer from JWT claim of from VC object
                 var issuer = ofNullable(claims.getIssuer()).or(() -> ofNullable(vc.get("issuer")).map(Object::toString)).orElse(null);
                 builder.issuer(new Issuer(issuer, Map.of()));
-                builder.name(claims.getSubject());
                 return builder.build();
             }
         } catch (ParseException e) {

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/test/java/org/eclipse/edc/iam/decentralizedclaims/transform/to/JwtToVerifiableCredentialTransformerTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/test/java/org/eclipse/edc/iam/decentralizedclaims/transform/to/JwtToVerifiableCredentialTransformerTest.java
@@ -15,11 +15,20 @@
 
 package org.eclipse.edc.iam.decentralizedclaims.transform.to;
 
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.edc.iam.decentralizedclaims.transform.TestData;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -84,5 +93,62 @@ class JwtToVerifiableCredentialTransformerTest {
         assertThat(vc.getType()).containsExactlyInAnyOrder("VerifiableCredential", "ExampleDegreeCredential", "ExamplePersonCredential");
         assertThat(vc.getIssuer().id()).isEqualTo("https://university.example/issuers/14");
         assertThat(vc.getValidFrom().toString()).isEqualTo("2010-01-01T19:23:24Z");
+    }
+
+    @Test
+    @DisplayName("VC has name and description in payload, both should be used")
+    void transform_withNameAndDescription_usesVcValues() {
+        var jwt = createJwt(Map.of("name", "My Credential Name", "description", "My Credential Description"));
+
+        var vc = transformer.transform(jwt, context);
+
+        assertThat(vc).isNotNull();
+        assertThat(vc.getName()).isEqualTo("My Credential Name");
+        assertThat(vc.getDescription()).isEqualTo("My Credential Description");
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    @DisplayName("VC has no name property, should be null")
+    void transform_withoutNameInVc_fallsBackToJwtSubject() {
+        var vc = transformer.transform(EXAMPLE_JWT_VC, context);
+
+        assertThat(vc).isNotNull();
+        assertThat(vc.getName()).isNull();
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    @DisplayName("VC has no description property, description should be null")
+    void transform_withoutDescriptionInVc_descriptionIsNull() {
+        var vc = transformer.transform(EXAMPLE_JWT_VC, context);
+
+        assertThat(vc).isNotNull();
+        assertThat(vc.getDescription()).isNull();
+        verifyNoInteractions(context);
+    }
+
+    private String createJwt(Map<String, Object> additionalVcProps) {
+        try {
+            var vcClaims = new HashMap<String, Object>();
+            vcClaims.put("@context", List.of("https://www.w3.org/2018/credentials/v1"));
+            vcClaims.put("type", List.of("VerifiableCredential"));
+            vcClaims.put("issuanceDate", "2010-01-01T19:23:24Z");
+            vcClaims.put("credentialSubject", Map.of("id", "did:example:test123", "foo", "bar"));
+            vcClaims.putAll(additionalVcProps);
+
+            var claimsSet = new JWTClaimsSet.Builder()
+                    .issuer("https://example.edu/issuers/14")
+                    .subject("did:example:test123")
+                    .claim("nbf", 1262373804L)
+                    .claim("vc", vcClaims)
+                    .build();
+
+            var jwt = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), claimsSet);
+            jwt.sign(new MACSigner("test-secret-test-secret-test-secret-12345".getBytes()));
+            return jwt.serialize();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `JwtToVerifiableCredentialTransformer` was incorrectly setting `name` to the JWT `sub` claim instead of reading it from the VC object
- Now both `name` and `description` are read directly from the `vc` payload properties
- Added tests covering the new behaviour (name+description present, name absent, description absent)

Contributes to https://github.com/eclipse-edc/IdentityHub/issues/701