### PR TITLE
refactor: discovery response improvements

### DIFF
--- a/core/common/lib/json-ld-lib/src/main/resources/document/management-context-v2.jsonld
+++ b/core/common/lib/json-ld-lib/src/main/resources/document/management-context-v2.jsonld
@@ -591,8 +591,12 @@
         "version": {
           "@id": "edc:version"
         },
-        "counterPartyPath": {
-          "@id": "edc:counterPartyPath"
+        "counterParty": {
+          "@id": "edc:counterParty",
+          "@context": {
+            "path": "edc:path",
+            "dataServiceEndpoint": "edc:dataServiceEndpoint"
+          }
         },
         "binding": {
           "@id": "edc:binding"

--- a/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/discovery/DiscoveryServiceImpl.java
+++ b/core/control-plane/control-plane-core/src/main/java/org/eclipse/edc/connector/controlplane/discovery/DiscoveryServiceImpl.java
@@ -70,27 +70,32 @@ public class DiscoveryServiceImpl implements DiscoveryService {
 
     private ServiceResult<List<DiscoveryResponse>> resolveMatches(String participantContextId, DiscoveryRequest request, DiscoveryUrlResolver resolver) {
 
-        var versionsResult = resolver.resolve(request).compose(this::fetchProtocolVersions);
+        var wellKnownUrlResult = resolver.resolve(request);
+        if (wellKnownUrlResult.failed()) {
+            return ServiceResult.badRequest(wellKnownUrlResult.getFailureDetail());
+        }
+        var wellKnownUrl = wellKnownUrlResult.getContent();
+        var versionsResult = fetchProtocolVersions(wellKnownUrl);
         if (versionsResult.failed()) {
             return ServiceResult.badRequest(versionsResult.getFailureDetail());
         }
 
         var localProfiles = participantProfileService.resolveAll(participantContextId);
         var matches = localProfiles.stream()
-                .flatMap(profileMatcher(versionsResult.getContent()))
+                .flatMap(profileMatcher(wellKnownUrl, versionsResult.getContent()))
                 .toList();
 
         return ServiceResult.success(matches);
     }
 
-    private Function<DataspaceProfileContext, Stream<? extends DiscoveryResponse>> profileMatcher(List<ProtocolVersion> versions) {
+    private Function<DataspaceProfileContext, Stream<? extends DiscoveryResponse>> profileMatcher(String wellKnownUrl, List<ProtocolVersion> versions) {
         return profile -> versions.stream()
                 .filter(v -> v.version().equals(profile.protocolVersion().version()) &&
                         v.binding().equals(profile.protocolVersion().binding()))
                 .map(v -> new DiscoveryResponse(
                         profile.name(),
                         v.version(),
-                        v.path(),
+                        new DiscoveryResponse.CounterParty(v.path(), wellKnownUrl),
                         v.binding()));
     }
 

--- a/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/controlplane/discovery/DiscoveryServiceImplTest.java
+++ b/core/control-plane/control-plane-core/src/test/java/org/eclipse/edc/connector/controlplane/discovery/DiscoveryServiceImplTest.java
@@ -120,13 +120,13 @@ class DiscoveryServiceImplTest {
                 .anySatisfy(m -> {
                     assertThat(m.profile()).isEqualTo("dsp-2025-1");
                     assertThat(m.version()).isEqualTo("2025-1");
-                    assertThat(m.counterPartyPath()).isEqualTo("/remote-2025");
+                    assertThat(m.counterParty().path()).isEqualTo("/remote-2025");
                     assertThat(m.binding()).isEqualTo("http");
                 })
                 .anySatisfy(m -> {
                     assertThat(m.profile()).isEqualTo("dsp-2024-1");
                     assertThat(m.version()).isEqualTo("2024-1");
-                    assertThat(m.counterPartyPath()).isEqualTo("/remote-2024");
+                    assertThat(m.counterParty().path()).isEqualTo("/remote-2024");
                 });
     }
 
@@ -148,7 +148,7 @@ class DiscoveryServiceImplTest {
         assertThat(result.getContent()).singleElement().satisfies(m -> {
             assertThat(m.profile()).isEqualTo("dsp-2025-1");
             assertThat(m.binding()).isEqualTo("http");
-            assertThat(m.counterPartyPath()).isEqualTo("/remote-http");
+            assertThat(m.counterParty().path()).isEqualTo("/remote-http");
         });
     }
     

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/discovery/from/JsonObjectFromDiscoveryResponseTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/discovery/from/JsonObjectFromDiscoveryResponseTransformer.java
@@ -23,8 +23,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.COUNTER_PARTY_DATASERVICE_ENDPOINT_IRI;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.COUNTER_PARTY_PATH_IRI;
 import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_BINDING_IRI;
-import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_COUNTER_PARTY_PATH_IRI;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_COUNTER_PARTY_IRI;
 import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_PROFILE_IRI;
 import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_TYPE_IRI;
 import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_VERSION_IRI;
@@ -40,11 +42,16 @@ public class JsonObjectFromDiscoveryResponseTransformer extends AbstractJsonLdTr
 
     @Override
     public @Nullable JsonObject transform(@NotNull DiscoveryResponse match, @NotNull TransformerContext context) {
+        var counterParty = jsonFactory.createObjectBuilder()
+                .add(COUNTER_PARTY_PATH_IRI, match.counterParty().path())
+                .add(COUNTER_PARTY_DATASERVICE_ENDPOINT_IRI, match.counterParty().dataServiceEndpoint())
+                .build();
+
         return jsonFactory.createObjectBuilder()
                 .add(TYPE, DISCOVERY_RESPONSE_TYPE_IRI)
                 .add(DISCOVERY_RESPONSE_PROFILE_IRI, match.profile())
                 .add(DISCOVERY_RESPONSE_VERSION_IRI, match.version())
-                .add(DISCOVERY_RESPONSE_COUNTER_PARTY_PATH_IRI, match.counterPartyPath())
+                .add(DISCOVERY_RESPONSE_COUNTER_PARTY_IRI, counterParty)
                 .add(DISCOVERY_RESPONSE_BINDING_IRI, match.binding())
                 .build();
     }

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/discovery/from/JsonObjectFromDiscoveryResponseTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/discovery/from/JsonObjectFromDiscoveryResponseTransformerTest.java
@@ -24,8 +24,10 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.COUNTER_PARTY_DATASERVICE_ENDPOINT_IRI;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.COUNTER_PARTY_PATH_IRI;
 import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_BINDING_IRI;
-import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_COUNTER_PARTY_PATH_IRI;
+import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_COUNTER_PARTY_IRI;
 import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_PROFILE_IRI;
 import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_TYPE_IRI;
 import static org.eclipse.edc.protocol.spi.discovery.DiscoveryResponse.DISCOVERY_RESPONSE_VERSION_IRI;
@@ -44,15 +46,20 @@ class JsonObjectFromDiscoveryResponseTransformerTest {
 
     @Test
     void transform() {
-        var match = new DiscoveryResponse("profile-1", "version", "/remote", "http");
+        var match = new DiscoveryResponse("profile-1", "version",
+                new DiscoveryResponse.CounterParty("/remote", "http://remote/dataservice"), "http");
 
         var result = transformer.transform(match, context);
 
         assertThat(result).isNotNull();
         assertThat(result.getString(TYPE)).isEqualTo(DISCOVERY_RESPONSE_TYPE_IRI);
         assertThat(result.getString(DISCOVERY_RESPONSE_PROFILE_IRI)).isEqualTo("profile-1");
-        assertThat(result.getString(DISCOVERY_RESPONSE_COUNTER_PARTY_PATH_IRI)).isEqualTo("/remote");
         assertThat(result.getString(DISCOVERY_RESPONSE_VERSION_IRI)).isEqualTo("version");
         assertThat(result.getString(DISCOVERY_RESPONSE_BINDING_IRI)).isEqualTo("http");
+
+        var counterParty = result.getJsonObject(DISCOVERY_RESPONSE_COUNTER_PARTY_IRI);
+        assertThat(counterParty).isNotNull();
+        assertThat(counterParty.getString(COUNTER_PARTY_PATH_IRI)).isEqualTo("/remote");
+        assertThat(counterParty.getString(COUNTER_PARTY_DATASERVICE_ENDPOINT_IRI)).isEqualTo("http://remote/dataservice");
     }
 }

--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -14,7 +14,7 @@
   {
     "version": "5.0.0-beta",
     "urlPath": "/v5beta",
-    "lastUpdated": "2026-05-28T09:00:00Z",
+    "lastUpdated": "2026-05-29T09:00:00Z",
     "maturity": "beta"
   }
 ]

--- a/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/discovery-response-schema.json
+++ b/extensions/common/api/management-api-schema-validator/src/main/resources/schema/management/v4/discovery-response-schema.json
@@ -27,9 +27,8 @@
           "type": "string",
           "description": "The DSP protocol version shared by the local profile and the counter party entry."
         },
-        "counterPartyPath": {
-          "type": "string",
-          "description": "The path under the counter party's base URL where the matching DSP version is exposed, as returned in the well-known versions document."
+        "counterParty": {
+          "$ref": "#/definitions/CounterParty"
         },
         "binding": {
           "type": "string",
@@ -40,8 +39,25 @@
         "@type",
         "profile",
         "version",
-        "counterPartyPath",
+        "counterParty",
         "binding"
+      ]
+    },
+    "CounterParty": {
+      "type": "object",
+      "description": "Counter party coordinates for a matched protocol version.",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "The path under the counter party's base URL where the matching DSP version is exposed, as returned in the well-known versions document."
+        },
+        "dataServiceEndpoint": {
+          "type": "string",
+          "description": "The counter party's data service endpoint URL."
+        }
+      },
+      "required": [
+        "path"
       ]
     }
   }

--- a/extensions/control-plane/api/management-api-v5/discovery-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/discovery/v5/DiscoveryApiV5ControllerTest.java
+++ b/extensions/control-plane/api/management-api-v5/discovery-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/discovery/v5/DiscoveryApiV5ControllerTest.java
@@ -68,7 +68,8 @@ class DiscoveryApiV5ControllerTest extends RestControllerTestBase {
     void shouldReturnDiscoveredProfiles() {
         var request = new DiscoveryRequest(null, "https://counter-party.example");
         when(transformerRegistry.transform(isA(JsonObject.class), eq(DiscoveryRequest.class))).thenReturn(Result.success(request));
-        var match = new DiscoveryResponse("profile-1", "version", "/remote", "http");
+        var match = new DiscoveryResponse("profile-1", "version",
+                new DiscoveryResponse.CounterParty("/remote", "http://remote/dataservice"), "http");
         when(discoveryService.discover(eq(PARTICIPANT_CONTEXT_ID), eq(request))).thenReturn(ServiceResult.success(List.of(match)));
         when(transformerRegistry.transform(isA(DiscoveryResponse.class), eq(JsonObject.class)))
                 .thenReturn(Result.success(Json.createObjectBuilder().add("profile", "profile-1").build()));

--- a/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/discovery/DiscoveryResponse.java
+++ b/spi/common/protocol-spi/src/main/java/org/eclipse/edc/protocol/spi/discovery/DiscoveryResponse.java
@@ -22,16 +22,17 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
  * Result of a discovery request: a local dataspace profile that matches a protocol version
  * advertised by the counterparty in its {@code /.well-known/dspace-version} document.
  *
- * @param profile          the local profile id (i.e. the value of
- *                         {@link DataspaceProfileContext#name()}).
- * @param counterPartyPath the path under the counterparty's base URL where the matching DSP
- *                         version is exposed (as returned in the well-known versions document).
- * @param binding          the protocol binding for this match (copied from the counterparty
- *                         version entry).
+ * @param profile      the local profile id (i.e. the value of
+ *                     {@link DataspaceProfileContext#name()}).
+ * @param version      the DSP protocol version shared by the local profile and the
+ *                     counterparty entry.
+ * @param counterParty the counterparty coordinates for this match, see {@link CounterParty}.
+ * @param binding      the protocol binding for this match (copied from the counterparty
+ *                     version entry).
  */
 public record DiscoveryResponse(String profile,
                                 String version,
-                                String counterPartyPath,
+                                CounterParty counterParty,
                                 String binding) {
 
     public static final String DISCOVERY_RESPONSE_TYPE_TERM = "DiscoveryResponse";
@@ -43,9 +44,25 @@ public record DiscoveryResponse(String profile,
     public static final String DISCOVERY_RESPONSE_VERSION_TERM = "version";
     public static final String DISCOVERY_RESPONSE_VERSION_IRI = EDC_NAMESPACE + DISCOVERY_RESPONSE_VERSION_TERM;
 
-    public static final String DISCOVERY_RESPONSE_COUNTER_PARTY_PATH_TERM = "counterPartyPath";
-    public static final String DISCOVERY_RESPONSE_COUNTER_PARTY_PATH_IRI = EDC_NAMESPACE + DISCOVERY_RESPONSE_COUNTER_PARTY_PATH_TERM;
+    public static final String DISCOVERY_RESPONSE_COUNTER_PARTY_TERM = "counterParty";
+    public static final String DISCOVERY_RESPONSE_COUNTER_PARTY_IRI = EDC_NAMESPACE + DISCOVERY_RESPONSE_COUNTER_PARTY_TERM;
 
     public static final String DISCOVERY_RESPONSE_BINDING_TERM = "binding";
     public static final String DISCOVERY_RESPONSE_BINDING_IRI = EDC_NAMESPACE + DISCOVERY_RESPONSE_BINDING_TERM;
+
+    public static final String COUNTER_PARTY_PATH_TERM = "path";
+    public static final String COUNTER_PARTY_PATH_IRI = EDC_NAMESPACE + COUNTER_PARTY_PATH_TERM;
+
+    public static final String COUNTER_PARTY_DATASERVICE_ENDPOINT_TERM = "dataServiceEndpoint";
+    public static final String COUNTER_PARTY_DATASERVICE_ENDPOINT_IRI = EDC_NAMESPACE + COUNTER_PARTY_DATASERVICE_ENDPOINT_TERM;
+
+    /**
+     * Counterparty coordinates for a matched protocol version.
+     *
+     * @param path                the path under the counterparty's base URL where the matching DSP
+     *                            version is exposed (as returned in the well-known versions document).
+     * @param dataServiceEndpoint the counterparty's data service endpoint URL.
+     */
+    public record CounterParty(String path, String dataServiceEndpoint) {
+    }
 }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/DiscoveryApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/DiscoveryApiV5EndToEndTest.java
@@ -91,8 +91,11 @@ public class DiscoveryApiV5EndToEndTest {
                 assertThat(entry.asJsonObject().getString(TYPE)).isEqualTo("DiscoveryResponse");
                 assertThat(entry.asJsonObject().getString("profile")).isEqualTo("dsp2025_1");
                 assertThat(entry.asJsonObject().getString("version")).isEqualTo("2025-1");
-                assertThat(entry.asJsonObject().getString("counterPartyPath")).isNotNull();
                 assertThat(entry.asJsonObject().getString("binding")).isNotNull();
+                var counterParty = entry.asJsonObject().getJsonObject("counterParty");
+                assertThat(counterParty).isNotNull();
+                assertThat(counterParty.getString("path")).isNotNull();
+                assertThat(counterParty.getString("dataServiceEndpoint")).isNotNull();
             });
         }
 


### PR DESCRIPTION
## What this PR changes/adds

Discovery response improvements:

Changed the shape of the discovery response by having a `counterParty` object with two fields `path` and `dataServiceEndpoint`

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
