### PR TITLE
feat: user @Configuration context instead of @SettingContext

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPoint.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPoint.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.boot.system.injection;
 
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.spi.result.AbstractResult;
@@ -102,8 +103,7 @@ public class ConfigurationInjectionPoint<T> implements InjectionPoint<T> {
 
     @Override
     public Object resolve(ServiceExtensionContext context, DefaultServiceSupplier defaultServiceSupplier) {
-        var keyPrefix = configurationField.getAnnotation(SettingContext.class) != null
-                ? configurationField.getAnnotation(SettingContext.class).value() : null;
+        var keyPrefix = getPrefix();
         return configurationObjectFactory.instantiate(context, keyPrefix, configurationField.getType());
     }
 
@@ -118,6 +118,16 @@ public class ConfigurationInjectionPoint<T> implements InjectionPoint<T> {
                 .toList();
 
         return violators.isEmpty() ? Result.success(List.of()) : Result.failure("%s, through nested %s".formatted(asString(), violators));
+    }
+
+    private @Nullable String getPrefix() {
+        var configurationContext = configurationField.getAnnotation(Configuration.class).context();
+        if (!configurationContext.isEmpty()) {
+            return configurationContext;
+        }
+
+        var settingContext = configurationField.getAnnotation(SettingContext.class);
+        return settingContext != null ? settingContext.value() : null;
     }
 
     private String asString() {

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationMapInjectionPoint.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationMapInjectionPoint.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.boot.system.injection;
 
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -29,7 +30,7 @@ import java.util.Map;
 /**
  * Injection point for configuration maps. A configuration map field is annotated with {@link org.eclipse.edc.runtime.metamodel.annotation.Configuration}
  * and has type {@link Map}{@code <String, T>} where {@code T} is a type annotated with {@link org.eclipse.edc.runtime.metamodel.annotation.Settings}.
- * The map keys are derived from the configuration path segments under the {@link SettingContext} prefix.
+ * The map keys are derived from the configuration path segments defined in the context attribute.
  * <p>
  * For example, given prefix {@code edc.iam.publickeys} and settings:
  * <pre>
@@ -92,8 +93,7 @@ public class ConfigurationMapInjectionPoint<T> implements InjectionPoint<T> {
 
     @Override
     public Object resolve(ServiceExtensionContext context, DefaultServiceSupplier defaultServiceSupplier) {
-        var settingContext = mapField.getAnnotation(SettingContext.class);
-        var prefix = settingContext != null ? settingContext.value() : null;
+        var prefix = getPrefix();
 
         var baseConfig = prefix != null ? context.getConfig(prefix) : context.getConfig();
 
@@ -110,5 +110,15 @@ public class ConfigurationMapInjectionPoint<T> implements InjectionPoint<T> {
     @Override
     public Result<List<InjectionContainer<T>>> getProviders(Map<Class<?>, List<InjectionContainer<T>>> dependencyMap, ServiceExtensionContext context) {
         return Result.success(List.of());
+    }
+
+    private @Nullable String getPrefix() {
+        var configurationContext = mapField.getAnnotation(Configuration.class).context();
+        if (!configurationContext.isEmpty()) {
+            return configurationContext;
+        }
+
+        var settingContext = mapField.getAnnotation(SettingContext.class);
+        return settingContext != null ? settingContext.value() : null;
     }
 }

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPointTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPointTest.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.boot.system.injection;
 import org.eclipse.edc.junit.extensions.TestExtensionContext;
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
@@ -132,8 +131,7 @@ class ConfigurationInjectionPointTest {
         @Configuration
         private ConfigurationRecord configuration;
 
-        @SettingContext("prefix")
-        @Configuration
+        @Configuration(context = "prefix")
         private ConfigurationRecord configurationWithPrefix;
 
         @Settings

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ConfigurationMapInjectionPointTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ConfigurationMapInjectionPointTest.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.boot.system.injection;
 import org.eclipse.edc.junit.extensions.TestExtensionContext;
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -134,8 +133,7 @@ class ConfigurationMapInjectionPointTest {
 
     private static class TestExtension implements ServiceExtension {
 
-        @SettingContext("prefix")
-        @Configuration
+        @Configuration(context = "prefix")
         private Map<String, ConfigurationRecord> configurations;
 
         public Map<String, ConfigurationRecord> getConfigurations() {

--- a/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/LocalPublicKeyDefaultExtension.java
+++ b/core/common/connector-core/src/main/java/org/eclipse/edc/connector/core/LocalPublicKeyDefaultExtension.java
@@ -22,7 +22,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
-import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.security.Vault;
@@ -47,8 +46,7 @@ public class LocalPublicKeyDefaultExtension implements ServiceExtension {
     @Inject
     public KeyParserRegistry keyParserRegistry;
 
-    @SettingContext(EDC_PUBLIC_KEYS_PREFIX)
-    @Configuration
+    @Configuration(context = EDC_PUBLIC_KEYS_PREFIX)
     private Map<String, PublicKeyConfiguration> configurations;
 
     private LocalPublicKeyServiceImpl localPublicKeyService;

--- a/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/ContractManagerExtension.java
+++ b/core/control-plane/control-plane-contract-manager/src/main/java/org/eclipse/edc/connector/controlplane/contract/ContractManagerExtension.java
@@ -26,7 +26,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
-import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ExecutorInstrumentation;
@@ -43,8 +42,7 @@ public class ContractManagerExtension implements ServiceExtension {
 
     public static final String NAME = "Contract Manager";
 
-    @SettingContext("edc.negotiation")
-    @Configuration
+    @Configuration(context = "edc.negotiation")
     private StateMachineConfiguration stateMachineConfiguration;
 
     @Inject

--- a/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/ContractCoreExtension.java
+++ b/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/ContractCoreExtension.java
@@ -41,7 +41,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
-import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -66,8 +65,7 @@ public class ContractCoreExtension implements ServiceExtension {
 
     public static final String NAME = "Contract Core";
 
-    @SettingContext("edc.negotiation")
-    @Configuration
+    @Configuration(context = "edc.negotiation")
     private StateMachineConfiguration stateMachineConfiguration;
 
     @Inject

--- a/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferManagerExtension.java
+++ b/core/control-plane/control-plane-transfer-manager/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferManagerExtension.java
@@ -24,7 +24,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
-import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.spi.system.ExecutorInstrumentation;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -42,8 +41,7 @@ public class TransferManagerExtension implements ServiceExtension {
 
     public static final String NAME = "Transfer Manager";
 
-    @SettingContext("edc.transfer")
-    @Configuration
+    @Configuration(context = "edc.transfer")
     private StateMachineConfiguration stateMachineConfiguration;
 
     @Inject

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferCoreExtension.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/TransferCoreExtension.java
@@ -30,7 +30,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
-import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -57,8 +56,7 @@ public class TransferCoreExtension implements ServiceExtension {
 
     public static final String NAME = "Transfer Core";
 
-    @SettingContext("edc.transfer")
-    @Configuration
+    @Configuration(context = "edc.transfer")
     private StateMachineConfiguration stateMachineConfiguration;
 
     @Inject

--- a/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneFrameworkExtension.java
+++ b/core/data-plane/data-plane-core/src/main/java/org/eclipse/edc/connector/dataplane/framework/DataPlaneFrameworkExtension.java
@@ -31,7 +31,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 import org.eclipse.edc.spi.system.ExecutorInstrumentation;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -58,8 +57,7 @@ public class DataPlaneFrameworkExtension implements ServiceExtension {
     public static final String NAME = "Data Plane Framework";
     private static final int DEFAULT_TRANSFER_THREADS = 20;
 
-    @SettingContext("edc.dataplane")
-    @Configuration
+    @Configuration(context = "edc.dataplane")
     private StateMachineConfiguration stateMachineConfiguration;
 
     @Setting(

--- a/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorExtension.java
+++ b/core/policy-monitor/policy-monitor-core/src/main/java/org/eclipse/edc/connector/policy/monitor/PolicyMonitorExtension.java
@@ -31,7 +31,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
-import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.system.ExecutorInstrumentation;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -52,8 +51,7 @@ public class PolicyMonitorExtension implements ServiceExtension {
 
     public static final String NAME = "Policy Monitor";
 
-    @SettingContext("edc.policy.monitor")
-    @Configuration
+    @Configuration(context = "edc.policy.monitor")
     private PolicyMonitorConfiguration configuration;
 
     @Inject

--- a/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/main/java/org/eclipse/edc/protocol/dsp/http/profile/DataspaceProfileConfigurationExtension.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/main/java/org/eclipse/edc/protocol/dsp/http/profile/DataspaceProfileConfigurationExtension.java
@@ -24,7 +24,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -45,8 +44,7 @@ public class DataspaceProfileConfigurationExtension implements ServiceExtension 
     public static final String PROTOCOL_NAMESPACE = "protocolNamespace";
     public static final String PROFILE_JSON_LD_CONTEXT = "jsonLdContextsUrl";
 
-    @SettingContext(EDC_DATASPACE_PROFILES_PREFIX)
-    @Configuration
+    @Configuration(context = EDC_DATASPACE_PROFILES_PREFIX)
     private Map<String, DataspaceProfileConfiguration> profileConfiguration;
 
     @Inject

--- a/extensions/common/auth/auth-configuration/src/main/java/org/eclipse/edc/api/auth/configuration/ApiAuthenticationConfigurationExtension.java
+++ b/extensions/common/auth/auth-configuration/src/main/java/org/eclipse/edc/api/auth/configuration/ApiAuthenticationConfigurationExtension.java
@@ -22,7 +22,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -41,8 +40,7 @@ public class ApiAuthenticationConfigurationExtension implements ServiceExtension
 
     public static final String NAME = "Api Authentication Configuration Extension";
 
-    @SettingContext("web.http")
-    @Configuration
+    @Configuration(context = "web.http")
     private Map<String, AuthenticationConfiguration> authenticationConfigurationMap;
 
     @Inject

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-issuers-configuration/src/main/java/org/eclipse/edc/iam/decentralizedclaims/issuer/configuration/TrustedIssuerConfigurationExtension.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-issuers-configuration/src/main/java/org/eclipse/edc/iam/decentralizedclaims/issuer/configuration/TrustedIssuerConfigurationExtension.java
@@ -21,7 +21,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -45,11 +44,9 @@ public class TrustedIssuerConfigurationExtension implements ServiceExtension {
     protected static final String NAME = "Trusted Issuers Configuration Extensions";
 
     @Deprecated(since = "0.17.0")
-    @SettingContext(DEPRECATED_CONFIG_PREFIX)
-    @Configuration
+    @Configuration(context = DEPRECATED_CONFIG_PREFIX)
     private Map<String, TrustedIssuerConfiguration> deprecatedTrustedIssuers;
-    @SettingContext(CONFIG_PREFIX)
-    @Configuration
+    @Configuration(context = CONFIG_PREFIX)
     private Map<String, TrustedIssuerConfiguration> trustedIssuers;
 
     @Inject

--- a/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
+++ b/extensions/common/json-ld/src/main/java/org/eclipse/edc/jsonld/JsonLdExtension.java
@@ -22,7 +22,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 import org.eclipse.edc.spi.constants.CoreConstants;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -47,8 +46,7 @@ public class JsonLdExtension implements ServiceExtension {
     public static final String NAME = "JSON-LD Extension";
     public static final String EDC_JSONLD_DOCUMENT_PREFIX = "edc.jsonld.document";
 
-    @SettingContext(EDC_JSONLD_DOCUMENT_PREFIX)
-    @Configuration
+    @Configuration(context = EDC_JSONLD_DOCUMENT_PREFIX)
     private Map<String, JsonLdDocumentConfiguration> jsonLdConfigurations = new HashMap<>();
 
     private static final boolean DEFAULT_HTTP_HTTPS_RESOLUTION = false;

--- a/extensions/common/sql/sql-pool/sql-pool-apache-commons/src/main/java/org/eclipse/edc/sql/pool/commons/CommonsConnectionPoolServiceExtension.java
+++ b/extensions/common/sql/sql-pool/sql-pool-apache-commons/src/main/java/org/eclipse/edc/sql/pool/commons/CommonsConnectionPoolServiceExtension.java
@@ -18,7 +18,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.runtime.metamodel.annotation.SettingContext;
 import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -60,8 +59,7 @@ public class CommonsConnectionPoolServiceExtension implements ServiceExtension {
     public static final String POOL_CONNECTION_TEST_WHILE_IDLE = "pool.connection.test.while-idle";
     public static final String POOL_CONNECTION_TEST_QUERY = "pool.connection.test.query";
 
-    @SettingContext(EDC_DATASOURCE_PREFIX)
-    @Configuration
+    @Configuration(context = EDC_DATASOURCE_PREFIX)
     private Map<String, DatasourceConfiguration> datasources;
 
     @Inject


### PR DESCRIPTION
## What this PR changes/adds

Uses `@Configuration.context` attribute to resolve configuration context prefix as a first class citizen, using the deprecated `@SettingContext.value` as fallback

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5784

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
