### PR TITLE
fix: start message inverted fields

### DIFF
--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowController.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowController.java
@@ -123,8 +123,8 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
 
         var builder = DataFlowStartMessage.Builder.newInstance()
                 .messageId(UUID.randomUUID().toString())
-                .participantId(policy.getAssignee())
-                .counterPartyId(policy.getAssigner())
+                .participantId(policy.getAssigner())
+                .counterPartyId(policy.getAssignee())
                 .dataspaceContext(transferProcess.getProtocol())
                 .processId(transferProcess.getId())
                 .agreementId(transferProcess.getContractId())

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowControllerTest.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowControllerTest.java
@@ -74,6 +74,35 @@ public class DataPlaneSignalingFlowControllerTest {
             URI.create("http://localhost"), selectorService,
             typeTransformerRegistry, clientFactory, dataAddressStore, assetIndex);
 
+    @NotNull
+    private DataPlaneInstance.Builder dataPlaneInstanceBuilder() {
+        return DataPlaneInstance.Builder.newInstance().url("http://any");
+    }
+
+    private DataAddress testDataAddress() {
+        return DataAddress.Builder.newInstance().type("test-type").build();
+    }
+
+    private TransferProcess.Builder transferProcessBuilder() {
+        return TransferProcess.Builder.newInstance()
+                .correlationId(UUID.randomUUID().toString())
+                .protocol("test-protocol")
+                .contractId(UUID.randomUUID().toString())
+                .assetId(UUID.randomUUID().toString())
+                .counterPartyAddress("test.connector.address")
+                .transferType("transferType");
+    }
+
+    private Policy.Builder policyBuilder() {
+        return Policy.Builder.newInstance()
+                .assignee("consumer")
+                .assigner("provider");
+    }
+
+    private @NonNull DspDataAddress createDspDataAddress() {
+        return DspDataAddress.Builder.newInstance().build();
+    }
+
     @Nested
     class Prepare {
 
@@ -101,6 +130,9 @@ public class DataPlaneSignalingFlowControllerTest {
             verify(dataPlaneClient).prepare(captor.capture());
             var message = captor.getValue();
             assertThat(message.getClaims()).isSameAs(claims);
+            assertThat(message.getParticipantId()).isEqualTo("consumer");
+            assertThat(message.getCounterPartyId()).isEqualTo("provider");
+
         }
 
         @Test
@@ -120,7 +152,9 @@ public class DataPlaneSignalingFlowControllerTest {
     class Start {
         @Test
         void shouldSelectAndCallStartOnDataplane() {
-            var policy = Policy.Builder.newInstance().assignee("participantId").build();
+            var policy = Policy.Builder.newInstance().assignee("consumer")
+                    .assigner("provider")
+                    .build();
             Map<String, Object> claims = Map.of("key", "value");
             var transferProcess = transferProcessBuilder()
                     .claims(claims)
@@ -147,6 +181,8 @@ public class DataPlaneSignalingFlowControllerTest {
             verify(dataPlaneClient).start(captor.capture());
             var message = captor.getValue();
             assertThat(message.getClaims()).isSameAs(claims);
+            assertThat(message.getParticipantId()).isEqualTo("provider");
+            assertThat(message.getCounterPartyId()).isEqualTo("consumer");
         }
 
         @Test
@@ -225,8 +261,8 @@ public class DataPlaneSignalingFlowControllerTest {
             assertThat(result).isFailed().detail().isEqualTo("not found");
         }
 
-        @Test
         // a null dataPlaneId means that the flow has not been started so it can be considered as already terminated
+        @Test
         void shouldReturnSuccess_whenDataPlaneIdIsNull() {
             var transferProcess = transferProcessBuilder()
                     .id("transferProcessId")
@@ -589,32 +625,5 @@ public class DataPlaneSignalingFlowControllerTest {
             assertThat(transferTypes).isEmpty();
             verifyNoInteractions(selectorService);
         }
-    }
-
-    @NotNull
-    private DataPlaneInstance.Builder dataPlaneInstanceBuilder() {
-        return DataPlaneInstance.Builder.newInstance().url("http://any");
-    }
-
-    private DataAddress testDataAddress() {
-        return DataAddress.Builder.newInstance().type("test-type").build();
-    }
-
-    private TransferProcess.Builder transferProcessBuilder() {
-        return TransferProcess.Builder.newInstance()
-                .correlationId(UUID.randomUUID().toString())
-                .protocol("test-protocol")
-                .contractId(UUID.randomUUID().toString())
-                .assetId(UUID.randomUUID().toString())
-                .counterPartyAddress("test.connector.address")
-                .transferType("transferType");
-    }
-
-    private Policy.Builder policyBuilder() {
-        return Policy.Builder.newInstance();
-    }
-
-    private @NonNull DspDataAddress createDspDataAddress() {
-        return DspDataAddress.Builder.newInstance().build();
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

On start message fix participantId and counterPartyId

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
