### PR TITLE
feat: scope model (Scope + ScopeMatcher) for scope-based authz

### DIFF
--- a/spi/common/auth-spi/src/main/java/org/eclipse/edc/api/auth/spi/ManagementApiScopes.java
+++ b/spi/common/auth-spi/src/main/java/org/eclipse/edc/api/auth/spi/ManagementApiScopes.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.api.auth.spi;
+
+/**
+ * Well-known scope strings for the Management API. The grammar is {@code management-api:[resource:]action}; the constants
+ * below are the coarse, resource-wildcard tier (see the
+ * <a href="https://github.com/eclipse-edc/Connector/tree/main/docs/developer/decision-records/2026-06-06-scope-based-api-authorization">decision record</a>).
+ */
+public interface ManagementApiScopes {
+
+    /**
+     * The namespace (scope prefix) for all Management API scopes.
+     */
+    String NAMESPACE = "management-api";
+
+    /**
+     * Read access to (any) resource: shorthand for {@code management-api:*:read}.
+     */
+    String READ = NAMESPACE + ":read";
+
+    /**
+     * Write access to (any) resource: shorthand for {@code management-api:*:write}. Implies {@link #READ}.
+     */
+    String WRITE = NAMESPACE + ":write";
+
+    /**
+     * Cross-tenant elevation / superuser access: shorthand for {@code management-api:*:admin}. Implies {@link #WRITE}
+     * and {@link #READ}, and additionally bypasses the resource-ownership check.
+     */
+    String ADMIN = NAMESPACE + ":admin";
+}

--- a/spi/common/auth-spi/src/main/java/org/eclipse/edc/api/auth/spi/Scope.java
+++ b/spi/common/auth-spi/src/main/java/org/eclipse/edc/api/auth/spi/Scope.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.api.auth.spi;
+
+import org.eclipse.edc.spi.result.Result;
+
+import java.util.Arrays;
+
+import static org.eclipse.edc.spi.result.Result.failure;
+
+/**
+ * A parsed access-control scope following the grammar {@code prefix[:resource]:action}, for example
+ * {@code management-api:read} (≡ {@code management-api:*:read}) or {@code management-api:policies:write}.
+ * <p>
+ * The {@code resource} defaults to the {@link #WILDCARD} when omitted. A {@link Scope} carried in a token (the
+ * <em>granted</em> scope) satisfies a {@link Scope} required by an endpoint when {@link #satisfies(Scope)} returns
+ * {@code true}.
+ */
+public record Scope(String prefix, String resource, Action action) {
+
+    public static final String WILDCARD = "*";
+    public static final String DELIMITER = ":";
+
+    /**
+     * Parses a raw scope string. Accepts two- ({@code prefix:action}) or three-segment
+     * ({@code prefix:resource:action}) forms; no segment may be blank and the action must be one of {@link Action}.
+     */
+    public static Result<Scope> parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return failure("Scope must not be null or blank");
+        }
+        var parts = raw.trim().split(DELIMITER, -1);
+        if (parts.length < 2 || parts.length > 3) {
+            return failure("Scope '%s' must have the form 'prefix[:resource]:action'".formatted(raw));
+        }
+        if (Arrays.stream(parts).anyMatch(String::isBlank)) {
+            return failure("Scope '%s' must not contain blank segments".formatted(raw));
+        }
+
+        var prefix = parts[0];
+        var resource = parts.length == 3 ? parts[1] : WILDCARD;
+        var actionToken = parts[parts.length - 1];
+
+        return Action.parse(actionToken)
+                .map(action -> new Scope(prefix, resource, action));
+    }
+
+    /**
+     * Whether this (granted) scope satisfies the {@code required} scope: the prefixes must be equal, this scope's
+     * resource must equal the required resource or be the {@link #WILDCARD}, and this scope's action must be at least as
+     * strong as the required action (see {@link Action#satisfies(Action)}).
+     */
+    public boolean satisfies(Scope required) {
+        return prefix.equals(required.prefix) &&
+                (resource.equals(required.resource) || resource.equals(WILDCARD)) &&
+                action.satisfies(required.action);
+    }
+
+    /**
+     * The action component, ordered by increasing strength: {@code ADMIN ⊇ WRITE ⊇ READ}.
+     */
+    public enum Action {
+        READ(0),
+        WRITE(1),
+        ADMIN(2);
+
+        private final int level;
+
+        Action(int level) {
+            this.level = level;
+        }
+
+        /**
+         * Whether this action is at least as strong as the {@code required} one, i.e. {@code admin} satisfies any
+         * required action, {@code write} satisfies {@code write} and {@code read}, and {@code read} satisfies only
+         * {@code read}.
+         */
+        public boolean satisfies(Action required) {
+            return this.level >= required.level;
+        }
+
+        static Result<Action> parse(String token) {
+            return Arrays.stream(values())
+                    .filter(a -> a.name().equalsIgnoreCase(token))
+                    .findFirst()
+                    .map(Result::success)
+                    .orElseGet(() -> failure("Unknown scope action '%s'".formatted(token)));
+        }
+    }
+}

--- a/spi/common/auth-spi/src/main/java/org/eclipse/edc/api/auth/spi/Scope.java
+++ b/spi/common/auth-spi/src/main/java/org/eclipse/edc/api/auth/spi/Scope.java
@@ -30,6 +30,10 @@ import static org.eclipse.edc.spi.result.Result.failure;
  */
 public record Scope(String prefix, String resource, Action action) {
 
+    public Scope(String prefix, Action action) {
+        this(prefix, WILDCARD, action);
+    }
+
     public static final String WILDCARD = "*";
     public static final String DELIMITER = ":";
 

--- a/spi/common/auth-spi/src/main/java/org/eclipse/edc/api/auth/spi/ScopeMatcher.java
+++ b/spi/common/auth-spi/src/main/java/org/eclipse/edc/api/auth/spi/ScopeMatcher.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.api.auth.spi;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * Evaluates whether a set of granted scopes (the space-delimited {@code scope} claim of an access token) satisfies a
+ * required scope. The grammar and matching rules are defined by {@link Scope}.
+ */
+public class ScopeMatcher {
+
+    private static final String SCOPE_SEPARATOR = " ";
+
+    /**
+     * Whether any of the {@code grantedScopes} (a space-delimited scope claim) satisfies the {@code requiredScope}.
+     * A malformed {@code requiredScope} or unparseable granted entries never grant access.
+     */
+    public boolean isSatisfiedBy(String requiredScope, String grantedScopes) {
+        var required = Scope.parse(requiredScope);
+        if (required.failed()) {
+            return false;
+        }
+        return parse(grantedScopes).stream().anyMatch(granted -> granted.satisfies(required.getContent()));
+    }
+
+    /**
+     * Whether the {@code grantedScopes} convey full cross-tenant elevation, i.e. satisfy {@link ManagementApiScopes#ADMIN}
+     * ({@code management-api:*:admin}).
+     */
+    public boolean isAdmin(String grantedScopes) {
+        return isSatisfiedBy(ManagementApiScopes.ADMIN, grantedScopes);
+    }
+
+    private List<Scope> parse(String grantedScopes) {
+        if (grantedScopes == null || grantedScopes.isBlank()) {
+            return emptyList();
+        }
+        return Arrays.stream(grantedScopes.trim().split(SCOPE_SEPARATOR))
+                .filter(s -> !s.isBlank())
+                .map(Scope::parse)
+                .filter(result -> result.succeeded())
+                .map(result -> result.getContent())
+                .toList();
+    }
+}

--- a/spi/common/auth-spi/src/test/java/org/eclipse/edc/api/auth/spi/ScopeMatcherTest.java
+++ b/spi/common/auth-spi/src/test/java/org/eclipse/edc/api/auth/spi/ScopeMatcherTest.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.api.auth.spi;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScopeMatcherTest {
+
+    private final ScopeMatcher matcher = new ScopeMatcher();
+
+    @ParameterizedTest
+    // requiredScope, grantedScopes, expected
+    @CsvSource({
+            // required read is satisfied by read, write or admin
+            "management-api:read,  management-api:read,  true",
+            "management-api:read,  management-api:write, true",
+            "management-api:read,  management-api:admin, true",
+            // required write is satisfied by write or admin, not by read
+            "management-api:write, management-api:read,  false",
+            "management-api:write, management-api:write, true",
+            "management-api:write, management-api:admin, true",
+            // required admin only by admin
+            "management-api:admin, management-api:write, false",
+            "management-api:admin, management-api:admin, true",
+            // wildcard (coarse) granted scope satisfies a specific (fine-grained) required scope
+            "management-api:policies:write, management-api:write, true",
+            "management-api:policies:read,  management-api:admin, true",
+            // a specific granted scope does not satisfy a different resource
+            "management-api:assets:write, management-api:policies:write, false"
+    })
+    void isSatisfiedBy(String requiredScope, String grantedScopes, boolean expected) {
+        assertThat(matcher.isSatisfiedBy(requiredScope, grantedScopes)).isEqualTo(expected);
+    }
+
+    @Test
+    void isSatisfiedBy_picksMatchingScopeFromMultiValuedClaim() {
+        var granted = "openid profile management-api:assets:read management-api:policies:write";
+
+        assertThat(matcher.isSatisfiedBy("management-api:policies:write", granted)).isTrue();
+        assertThat(matcher.isSatisfiedBy("management-api:assets:read", granted)).isTrue();
+        assertThat(matcher.isSatisfiedBy("management-api:assets:write", granted)).isFalse();
+    }
+
+    @Test
+    void isSatisfiedBy_ignoresUnparseableGrantedEntries() {
+        var granted = "not-a-scope another:bad:one:here management-api:write";
+
+        assertThat(matcher.isSatisfiedBy("management-api:read", granted)).isTrue();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { "   ", "openid profile" })
+    void isSatisfiedBy_noMatchingGrantedScope_isFalse(String granted) {
+        assertThat(matcher.isSatisfiedBy("management-api:read", granted)).isFalse();
+    }
+
+    @Test
+    void isSatisfiedBy_malformedRequiredScope_isFalse() {
+        assertThat(matcher.isSatisfiedBy("not-a-valid-scope", "management-api:admin")).isFalse();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "management-api:admin,                 true",
+            "openid management-api:admin,          true",
+            "management-api:write,                 false",
+            "management-api:read,                  false",
+            // resource-scoped admin is NOT full cross-tenant elevation
+            "management-api:participants:admin,    false"
+    })
+    void isAdmin(String grantedScopes, boolean expected) {
+        assertThat(matcher.isAdmin(grantedScopes)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void isAdmin_blank_isFalse(String granted) {
+        assertThat(matcher.isAdmin(granted)).isFalse();
+    }
+}

--- a/spi/common/auth-spi/src/test/java/org/eclipse/edc/api/auth/spi/ScopeTest.java
+++ b/spi/common/auth-spi/src/test/java/org/eclipse/edc/api/auth/spi/ScopeTest.java
@@ -89,6 +89,24 @@ class ScopeTest {
     }
 
     @Test
+    void satisfies_withoutResource() {
+        var granted = new Scope("management-api", Action.READ);
+        var required = new Scope("management-api", "policies", Action.READ);
+        assertThat(granted.satisfies(required)).isTrue();
+    }
+
+    @Test
+    void satisfied_scopedAdminGranted() {
+        var granted = new Scope("management-api", "policies", Action.ADMIN);
+
+        assertThat(granted.satisfies(new Scope("management-api", "policies", Action.READ))).isTrue();
+        assertThat(granted.satisfies(new Scope("management-api", "policies", Action.WRITE))).isTrue();
+        assertThat(granted.satisfies(new Scope("management-api", Action.WRITE))).isFalse();
+        assertThat(granted.satisfies(new Scope("management-api", Action.READ))).isFalse();
+        assertThat(granted.satisfies(new Scope("management-api", "assets", Action.READ))).isFalse();
+    }
+
+    @Test
     void satisfies_differentPrefix_isFalse() {
         var granted = new Scope("other-api", "*", Action.ADMIN);
         var required = new Scope("management-api", "assets", Action.READ);

--- a/spi/common/auth-spi/src/test/java/org/eclipse/edc/api/auth/spi/ScopeTest.java
+++ b/spi/common/auth-spi/src/test/java/org/eclipse/edc/api/auth/spi/ScopeTest.java
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.api.auth.spi;
+
+import org.eclipse.edc.api.auth.spi.Scope.Action;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScopeTest {
+
+    @Test
+    void parse_twoSegment_defaultsResourceToWildcard() {
+        var result = Scope.parse("management-api:read");
+
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).isEqualTo(new Scope("management-api", Scope.WILDCARD, Action.READ));
+    }
+
+    @Test
+    void parse_threeSegment_keepsResource() {
+        var result = Scope.parse("management-api:policies:write");
+
+        assertThat(result.succeeded()).isTrue();
+        assertThat(result.getContent()).isEqualTo(new Scope("management-api", "policies", Action.WRITE));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "management-api:ADMIN", "management-api:Admin", "management-api:assets:WRITE" })
+    void parse_actionIsCaseInsensitive(String raw) {
+        assertThat(Scope.parse(raw).succeeded()).isTrue();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {
+            "   ",
+            "management-api",                 // single segment
+            "management-api:assets:foo:read", // too many segments
+            "management-api:read:",           // blank trailing segment
+            "management-api::read",           // blank resource
+            "management-api:unknown",         // unknown action
+            "management-api:assets:list"      // unknown action (3-segment)
+    })
+    void parse_invalid(String raw) {
+        assertThat(Scope.parse(raw).failed()).isTrue();
+    }
+
+    @ParameterizedTest
+    // grantedResource, grantedAction, requiredResource, requiredAction, expected
+    @CsvSource({
+            // exact resource, action hierarchy admin ⊇ write ⊇ read
+            "assets, READ,  assets, READ,  true",
+            "assets, WRITE, assets, READ,  true",
+            "assets, ADMIN, assets, READ,  true",
+            "assets, READ,  assets, WRITE, false",
+            "assets, WRITE, assets, WRITE, true",
+            "assets, ADMIN, assets, WRITE, true",
+            "assets, WRITE, assets, ADMIN, false",
+            "assets, ADMIN, assets, ADMIN, true",
+            // wildcard granted resource covers any required resource
+            "*,      WRITE, assets, WRITE, true",
+            "*,      READ,  policies, READ, true",
+            // specific granted resource does NOT cover a different (or wildcard) required resource
+            "assets, WRITE, policies, WRITE, false",
+            "assets, READ,  *,      READ,  false"
+    })
+    void satisfies(String grantedResource, Action grantedAction, String requiredResource, Action requiredAction, boolean expected) {
+        var granted = new Scope("management-api", grantedResource, grantedAction);
+        var required = new Scope("management-api", requiredResource, requiredAction);
+
+        assertThat(granted.satisfies(required)).isEqualTo(expected);
+    }
+
+    @Test
+    void satisfies_differentPrefix_isFalse() {
+        var granted = new Scope("other-api", "*", Action.ADMIN);
+        var required = new Scope("management-api", "assets", Action.READ);
+
+        assertThat(granted.satisfies(required)).isFalse();
+    }
+}


### PR DESCRIPTION
Part of #5799 — closes #5800. **Step 1 of 4** toward [scope-based API authorization](https://github.com/eclipse-edc/Connector/tree/main/docs/developer/decision-records/2026-06-06-scope-based-api-authorization).

## What this does

Adds the **additive** scope model that later steps build on — no wiring, no behavioural change yet.

New in `spi/common/auth-spi`:
- **`Scope`** — parses `prefix[:resource]:action` (e.g. `management-api:read` ≡ `management-api:*:read`, or `management-api:policies:write`). `resource` defaults to the `*` wildcard; `action` hierarchy is `admin ⊇ write ⊇ read`. `satisfies(required)` matches when prefixes are equal, the granted resource equals the required one or is `*`, and the granted action is at least as strong as required.
- **`ScopeMatcher`** — evaluates a space-delimited granted `scope` claim against a required scope (`isSatisfiedBy`), tolerating malformed/extra entries; `isAdmin()` detects full cross-tenant elevation (`management-api:*:admin`).
- **`ManagementApiScopes`** — `READ` / `WRITE` / `ADMIN` constants for the coarse tier.

## Notes

- A coarse (wildcard) granted scope satisfies a fine-grained required scope, but not vice-versa — this is what lets finer-grained scopes be introduced later by changing only what the IdP issues.
- Resource-scoped admin (e.g. `management-api:participants:admin`) is deliberately **not** treated as full elevation by `isAdmin()`.
