### PR TITLE
feat: move authorization elevation from roles to scopes

### DIFF
--- a/extensions/common/auth/auth-authentication-oauth2-lib/src/testFixtures/java/org/eclipse/edc/api/authentication/OauthServer.java
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/src/testFixtures/java/org/eclipse/edc/api/authentication/OauthServer.java
@@ -19,6 +19,7 @@ import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import org.eclipse.edc.api.auth.spi.ManagementApiScopes;
 import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
 
 import java.time.Instant;
@@ -88,11 +89,10 @@ public class OauthServer implements OauthTokenProvider {
     }
 
     public String createAdminToken() {
-        return createToken(null, ParticipantPrincipal.ROLE_ADMIN);
+        return createToken(null, ManagementApiScopes.ADMIN, ParticipantPrincipal.ROLE_ADMIN);
     }
 
     public String createProvisionerToken() {
-        return createToken(null, ParticipantPrincipal.ROLE_PROVISIONER);
-
+        return createToken(null, ManagementApiScopes.ADMIN, ParticipantPrincipal.ROLE_PROVISIONER);
     }
 }

--- a/extensions/common/auth/auth-authorization-oauth2-lib/src/main/java/org/eclipse/edc/api/authorization/filter/ScopeBasedAccessFilter.java
+++ b/extensions/common/auth/auth-authorization-oauth2-lib/src/main/java/org/eclipse/edc/api/authorization/filter/ScopeBasedAccessFilter.java
@@ -20,13 +20,14 @@ import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
+import org.eclipse.edc.api.auth.spi.ScopeMatcher;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 @Priority(Priorities.AUTHORIZATION)
 class ScopeBasedAccessFilter implements ContainerRequestFilter {
     private final String requiredScope;
+    private final ScopeMatcher scopeMatcher = new ScopeMatcher();
 
     ScopeBasedAccessFilter(String requiredScope) {
         this.requiredScope = requiredScope;
@@ -46,7 +47,7 @@ class ScopeBasedAccessFilter implements ContainerRequestFilter {
             return;
         }
         if (principal instanceof ParticipantPrincipal participantPrincipal) {
-            var matches = Arrays.asList(participantPrincipal.scope().split(" ")).contains(requiredScope);
+            var matches = scopeMatcher.isSatisfiedBy(requiredScope, participantPrincipal.scope());
             if (!matches) {
                 containerRequestContext.abortWith(Response.status(Response.Status.FORBIDDEN.getStatusCode(), "Required scope '%s' missing".formatted(requiredScope)).build());
             }

--- a/extensions/common/auth/auth-authorization-oauth2-lib/src/main/java/org/eclipse/edc/api/authorization/service/AuthorizationServiceImpl.java
+++ b/extensions/common/auth/auth-authorization-oauth2-lib/src/main/java/org/eclipse/edc/api/authorization/service/AuthorizationServiceImpl.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.api.authorization.service;
 import jakarta.ws.rs.core.SecurityContext;
 import org.eclipse.edc.api.auth.spi.AuthorizationService;
 import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
+import org.eclipse.edc.api.auth.spi.ScopeMatcher;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantResource;
 import org.eclipse.edc.spi.result.ServiceResult;
 
@@ -27,10 +28,12 @@ import java.util.function.BiFunction;
 
 public class AuthorizationServiceImpl implements AuthorizationService {
     private final Map<Class<?>, BiFunction<String, String, ParticipantResource>> resourceLookupFunctions = new HashMap<>();
+    private final ScopeMatcher scopeMatcher = new ScopeMatcher();
 
     @Override
     public ServiceResult<Void> authorize(SecurityContext securityContext, String resourceOwnerId, String resourceId, Class<? extends ParticipantResource> resourceClass) {
-        var securityPrincipalName = securityContext.getUserPrincipal().getName();
+        var principal = securityContext.getUserPrincipal();
+        var securityPrincipalName = principal.getName();
 
         if (resourceOwnerId == null) {
             return ServiceResult.unauthorized("resourceOwnerId is mandatory but was null when querying for object with ID '%s' of type '%s'. Security Principal: '%s'".formatted(resourceId, resourceClass, securityPrincipalName));
@@ -46,7 +49,8 @@ public class AuthorizationServiceImpl implements AuthorizationService {
             return ServiceResult.notFound("No Resource of type '%s' with ID '%s' was found for owner '%s'.".formatted(resourceClass, resourceId, resourceOwnerId));
         }
 
-        if (securityContext.isUserInRole(ParticipantPrincipal.ROLE_ADMIN) || securityContext.isUserInRole(ParticipantPrincipal.ROLE_PROVISIONER)) {
+        // a principal holding the admin scope is elevated and may access resources across participant contexts
+        if (principal instanceof ParticipantPrincipal participantPrincipal && scopeMatcher.isAdmin(participantPrincipal.scope())) {
             return ServiceResult.success();
         }
 

--- a/extensions/common/auth/auth-authorization-oauth2-lib/src/test/java/org/eclipse/edc/api/authorization/filter/ScopeBasedAccessFilterTest.java
+++ b/extensions/common/auth/auth-authorization-oauth2-lib/src/test/java/org/eclipse/edc/api/authorization/filter/ScopeBasedAccessFilterTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 
 class ScopeBasedAccessFilterTest {
 
-    private final ScopeBasedAccessFilter filter = new ScopeBasedAccessFilter("required-scope");
+    private final ScopeBasedAccessFilter filter = new ScopeBasedAccessFilter("management-api:read");
 
     @Test
     void filter_abortsWithForbidden_whenSecurityContextIsNull() throws Exception {
@@ -78,7 +78,7 @@ class ScopeBasedAccessFilterTest {
     void filter_allowsWhenRequiredScopePresent() throws Exception {
         var request = mock(ContainerRequestContext.class);
         var securityContext = mock(SecurityContext.class);
-        var participant = new ParticipantPrincipal("some-id", ParticipantPrincipal.ROLE_PARTICIPANT, "foo required-scope bar");
+        var participant = new ParticipantPrincipal("some-id", ParticipantPrincipal.ROLE_PARTICIPANT, "openid management-api:read profile");
         when(securityContext.getUserPrincipal()).thenReturn(participant);
         when(request.getSecurityContext()).thenReturn(securityContext);
 
@@ -90,10 +90,26 @@ class ScopeBasedAccessFilterTest {
     }
 
     @Test
-    void filter_abortsWithUnauthorized_whenRequiredScopeMissingForParticipant() throws Exception {
+    void filter_allowsWhenHigherActionGranted() throws Exception {
         var request = mock(ContainerRequestContext.class);
         var securityContext = mock(SecurityContext.class);
-        var participant = new ParticipantPrincipal("some-id", ParticipantPrincipal.ROLE_PARTICIPANT, "foo bar");
+        // required is management-api:read; a write (or admin) grant satisfies it via the action hierarchy
+        var participant = new ParticipantPrincipal("some-id", ParticipantPrincipal.ROLE_PARTICIPANT, "management-api:write");
+        when(securityContext.getUserPrincipal()).thenReturn(participant);
+        when(request.getSecurityContext()).thenReturn(securityContext);
+
+        filter.filter(request);
+
+        verify(request).getSecurityContext();
+        verify(securityContext).getUserPrincipal();
+        verifyNoMoreInteractions(request, securityContext);
+    }
+
+    @Test
+    void filter_abortsWithForbidden_whenRequiredScopeMissingForParticipant() throws Exception {
+        var request = mock(ContainerRequestContext.class);
+        var securityContext = mock(SecurityContext.class);
+        var participant = new ParticipantPrincipal("some-id", ParticipantPrincipal.ROLE_PARTICIPANT, "openid profile");
         when(securityContext.getUserPrincipal()).thenReturn(participant);
         when(request.getSecurityContext()).thenReturn(securityContext);
 
@@ -106,7 +122,7 @@ class ScopeBasedAccessFilterTest {
     }
 
     @Test
-    void filter_abortsWithUnauthorized_whenParticipantScopeIsEmpty() throws Exception {
+    void filter_abortsWithForbidden_whenParticipantScopeIsEmpty() throws Exception {
         var request = mock(ContainerRequestContext.class);
         var securityContext = mock(SecurityContext.class);
         var participant = new ParticipantPrincipal("some-id", ParticipantPrincipal.ROLE_PARTICIPANT, " ");
@@ -122,11 +138,11 @@ class ScopeBasedAccessFilterTest {
     }
 
     @Test
-    void filter_doesNotMatchPartialNames() throws Exception {
+    void filter_abortsWithForbidden_whenGrantedScopeIsResourceSpecific() throws Exception {
         var request = mock(ContainerRequestContext.class);
         var securityContext = mock(SecurityContext.class);
-        // include similar token "required-scope-extra" to ensure exact token matching is required
-        var participant = new ParticipantPrincipal("some-id", ParticipantPrincipal.ROLE_PARTICIPANT, "required-scope-extra");
+        // a resource-specific grant does not satisfy the wildcard-resource requirement (management-api:read ≡ *:read)
+        var participant = new ParticipantPrincipal("some-id", ParticipantPrincipal.ROLE_PARTICIPANT, "management-api:assets:read");
         when(securityContext.getUserPrincipal()).thenReturn(participant);
         when(request.getSecurityContext()).thenReturn(securityContext);
 
@@ -137,6 +153,4 @@ class ScopeBasedAccessFilterTest {
         verify(request).abortWith(argThat(r -> r.getStatus() == 403));
         verifyNoMoreInteractions(request, securityContext);
     }
-
-
 }

--- a/extensions/common/auth/auth-authorization-oauth2-lib/src/test/java/org/eclipse/edc/api/authorization/service/AuthorizationServiceImplTest.java
+++ b/extensions/common/auth/auth-authorization-oauth2-lib/src/test/java/org/eclipse/edc/api/authorization/service/AuthorizationServiceImplTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.api.authorization.service;
 
 import jakarta.ws.rs.core.SecurityContext;
+import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
 import org.eclipse.edc.participantcontext.spi.types.AbstractParticipantResource;
 import org.eclipse.edc.spi.result.ServiceFailure;
 import org.junit.jupiter.api.Test;
@@ -25,12 +26,7 @@ import java.security.Principal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class AuthorizationServiceImplTest {
@@ -93,26 +89,38 @@ class AuthorizationServiceImplTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "admin", "provisioner" })
-    void isAuthorized_whenRoleIsElevated(String role) {
+    @ValueSource(strings = { "management-api:admin", "openid management-api:admin" })
+    void authorize_whenAdminScope_bypassesOwnership(String scope) {
         authorizationService.addLookupFunction(TestResource.class, (owner, id) -> new AbstractParticipantResource() {
             @Override
             public String getParticipantContextId() {
-                return "test-id";
+                return "owner-id";
             }
         });
-        var principal = mock(Principal.class);
-        when(principal.getName()).thenReturn("test-id");
+        // principal name differs from the resource owner: only the admin scope grants access
+        var principal = new ParticipantPrincipal("a-different-principal", ParticipantPrincipal.ROLE_PARTICIPANT, scope);
         var securityContext = mock(SecurityContext.class);
         when(securityContext.getUserPrincipal()).thenReturn(principal);
-        when(securityContext.isUserInRole(eq(role))).thenReturn(true);
 
-        assertThat(authorizationService.authorize(securityContext, "test-id", "test-resource-id", TestResource.class))
+        assertThat(authorizationService.authorize(securityContext, "owner-id", "test-resource-id", TestResource.class))
                 .isSucceeded();
+    }
 
-        verify(securityContext, atLeastOnce()).isUserInRole(anyString());
-        verify(securityContext).getUserPrincipal();
-        verifyNoMoreInteractions(securityContext);
+    @Test
+    void authorize_whenParticipantPrincipalWithoutAdminScope_isNotElevated() {
+        authorizationService.addLookupFunction(TestResource.class, (owner, id) -> new AbstractParticipantResource() {
+            @Override
+            public String getParticipantContextId() {
+                return "owner-id";
+            }
+        });
+        var principal = new ParticipantPrincipal("a-different-principal", ParticipantPrincipal.ROLE_PARTICIPANT, "management-api:read management-api:write");
+        var securityContext = mock(SecurityContext.class);
+        when(securityContext.getUserPrincipal()).thenReturn(principal);
+
+        assertThat(authorizationService.authorize(securityContext, "owner-id", "test-resource-id", TestResource.class))
+                .isFailed()
+                .satisfies(f -> assertThat(f.getReason()).isEqualTo(ServiceFailure.Reason.UNAUTHORIZED));
     }
 
     @Test


### PR DESCRIPTION
Part of #5799 — closes #5801. **Step 2 of 4** toward [scope-based API authorization](https://github.com/eclipse-edc/Connector/tree/main/docs/developer/decision-records/2026-06-06-scope-based-api-authorization). Builds on #5804 (merged).

## What this does

Makes `management-api:admin` the cross-tenant elevation signal and uses the `ScopeMatcher` for the endpoint scope gate.

- **`ScopeBasedAccessFilter`** — evaluates the required scope via `ScopeMatcher.isSatisfiedBy(...)` (hierarchy- and wildcard-aware) instead of exact string `contains`. Coarse grants now satisfy fine requirements, and `admin ⊇ write ⊇ read` applies.
- **`AuthorizationServiceImpl`** — the ownership bypass now triggers on the `management-api:admin` scope (`scopeMatcher.isAdmin(...)`) instead of the `admin`/`provisioner` roles. The resource-ownership check itself is unchanged.
- **`OauthServer`** test fixture — `createAdminToken()` / `createProvisionerToken()` now issue `management-api:admin`, so elevated access keeps working across the e2e suites.

## Not in this PR (by design)

The role-based gate (`@RolesAllowed` / `RoleBasedAccessFilter`) is intentionally **left in place** — both gates still apply, so there's no behavioural regression. The role gate and the `@RolesAllowed` annotations are removed in step 3 (#5802).
