### PR TITLE
feat: identity is carried in `sub` claim

### DIFF
--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -14,7 +14,7 @@
   {
     "version": "5.0.0-beta",
     "urlPath": "/v5beta",
-    "lastUpdated": "2026-06-10T09:00:00Z",
+    "lastUpdated": "2026-06-10T16:00:00Z",
     "maturity": "beta"
   }
 ]

--- a/extensions/common/auth/auth-authentication-oauth2-lib/build.gradle.kts
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/build.gradle.kts
@@ -22,10 +22,10 @@ dependencies {
     api(project(":spi:common:core-spi"))
     api(project(":spi:common:token-spi"))
     api(project(":spi:common:auth-spi"))
-    api(project(":spi:common:jwt-spi"))
     api(project(":spi:common:connector-participant-context-spi"))
 
 
+    implementation(project(":spi:common:jwt-spi"))
     implementation(project(":spi:common:web-spi"))
     implementation(project(":core:common:lib:util-lib"))
 

--- a/extensions/common/auth/auth-authentication-oauth2-lib/build.gradle.kts
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     api(project(":spi:common:core-spi"))
     api(project(":spi:common:token-spi"))
     api(project(":spi:common:auth-spi"))
+    api(project(":spi:common:jwt-spi"))
     api(project(":spi:common:connector-participant-context-spi"))
 
 

--- a/extensions/common/auth/auth-authentication-oauth2-lib/src/main/java/org/eclipse/edc/api/authentication/filter/Constants.java
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/src/main/java/org/eclipse/edc/api/authentication/filter/Constants.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.api.authentication.filter;
 
 public interface Constants {
     String REQUEST_PROPERTY_CLAIMS = "claims";
-    String TOKEN_CLAIM_ROLE = "role";
     String TOKEN_CLAIM_SCOPE = "scope";
-    String TOKEN_CLAIM_PARTICIPANT_CONTEXT_ID = "participant_context_id";
+    String TOKEN_CLAIM_SUBJECT = "sub";
 }

--- a/extensions/common/auth/auth-authentication-oauth2-lib/src/main/java/org/eclipse/edc/api/authentication/filter/Constants.java
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/src/main/java/org/eclipse/edc/api/authentication/filter/Constants.java
@@ -16,6 +16,4 @@ package org.eclipse.edc.api.authentication.filter;
 
 public interface Constants {
     String REQUEST_PROPERTY_CLAIMS = "claims";
-    String TOKEN_CLAIM_SCOPE = "scope";
-    String TOKEN_CLAIM_SUBJECT = "sub";
 }

--- a/extensions/common/auth/auth-authentication-oauth2-lib/src/main/java/org/eclipse/edc/api/authentication/filter/ServicePrincipalAuthenticationFilter.java
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/src/main/java/org/eclipse/edc/api/authentication/filter/ServicePrincipalAuthenticationFilter.java
@@ -28,8 +28,8 @@ import org.eclipse.edc.spi.iam.ClaimToken;
 import java.security.Principal;
 
 import static org.eclipse.edc.api.authentication.filter.Constants.REQUEST_PROPERTY_CLAIMS;
-import static org.eclipse.edc.api.authentication.filter.Constants.TOKEN_CLAIM_SCOPE;
-import static org.eclipse.edc.api.authentication.filter.Constants.TOKEN_CLAIM_SUBJECT;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SCOPE;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SUBJECT;
 
 /**
  * A {@link ContainerRequestFilter} that extracts a {@link ParticipantPrincipal} from the Authorization Header, specifically,
@@ -51,8 +51,8 @@ public class ServicePrincipalAuthenticationFilter implements ContainerRequestFil
 
         var claims = containerRequestContext.getProperty(REQUEST_PROPERTY_CLAIMS);
         if (claims instanceof ClaimToken claimToken) {
-            var subject = claimToken.getStringClaim(TOKEN_CLAIM_SUBJECT);
-            var scope = claimToken.getStringClaim(TOKEN_CLAIM_SCOPE);
+            var subject = claimToken.getStringClaim(SUBJECT);
+            var scope = claimToken.getStringClaim(SCOPE);
 
             // a non-admin principal is identified by its participant context, which must exist; an admin principal is
             // elevated, so its subject need not correspond to a participant context (e.g. a service account)

--- a/extensions/common/auth/auth-authentication-oauth2-lib/src/main/java/org/eclipse/edc/api/authentication/filter/ServicePrincipalAuthenticationFilter.java
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/src/main/java/org/eclipse/edc/api/authentication/filter/ServicePrincipalAuthenticationFilter.java
@@ -21,24 +21,26 @@ import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
+import org.eclipse.edc.api.auth.spi.ScopeMatcher;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
 import org.eclipse.edc.spi.iam.ClaimToken;
 
 import java.security.Principal;
 
 import static org.eclipse.edc.api.authentication.filter.Constants.REQUEST_PROPERTY_CLAIMS;
-import static org.eclipse.edc.api.authentication.filter.Constants.TOKEN_CLAIM_PARTICIPANT_CONTEXT_ID;
-import static org.eclipse.edc.api.authentication.filter.Constants.TOKEN_CLAIM_ROLE;
 import static org.eclipse.edc.api.authentication.filter.Constants.TOKEN_CLAIM_SCOPE;
+import static org.eclipse.edc.api.authentication.filter.Constants.TOKEN_CLAIM_SUBJECT;
 
 /**
  * A {@link ContainerRequestFilter} that extracts a {@link ParticipantPrincipal} from the Authorization Header, specifically,
- * the JWT that is contained in the Authorization Header.
+ * the JWT that is contained in the Authorization Header. The principal's identity is taken from the standard {@code sub}
+ * claim and its permissions from the {@code scope} claim.
  */
 @Priority(Priorities.AUTHENTICATION)
 public class ServicePrincipalAuthenticationFilter implements ContainerRequestFilter {
 
     private final ParticipantContextService participantContextService;
+    private final ScopeMatcher scopeMatcher = new ScopeMatcher();
 
     public ServicePrincipalAuthenticationFilter(ParticipantContextService participantContextService) {
         this.participantContextService = participantContextService;
@@ -49,18 +51,18 @@ public class ServicePrincipalAuthenticationFilter implements ContainerRequestFil
 
         var claims = containerRequestContext.getProperty(REQUEST_PROPERTY_CLAIMS);
         if (claims instanceof ClaimToken claimToken) {
-            var participantContextId = claimToken.getStringClaim(TOKEN_CLAIM_PARTICIPANT_CONTEXT_ID);
-            var role = claimToken.getStringClaim(TOKEN_CLAIM_ROLE);
+            var subject = claimToken.getStringClaim(TOKEN_CLAIM_SUBJECT);
             var scope = claimToken.getStringClaim(TOKEN_CLAIM_SCOPE);
 
-            if (participantContextId != null) {
-                if (participantContextService.getParticipantContext(participantContextId).failed()) {
-                    containerRequestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED.getStatusCode(), "Authorization Header invalid: participant context not found").build());
-                    return;
-                }
+            // a non-admin principal is identified by its participant context, which must exist; an admin principal is
+            // elevated, so its subject need not correspond to a participant context (e.g. a service account)
+            if (!scopeMatcher.isAdmin(scope) && subject != null &&
+                    participantContextService.getParticipantContext(subject).failed()) {
+                containerRequestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED.getStatusCode(), "Authorization Header invalid: participant context not found").build());
+                return;
             }
 
-            var servicePrincipal = new ParticipantPrincipal(participantContextId, role, scope);
+            var servicePrincipal = new ParticipantPrincipal(subject, scope);
             containerRequestContext.setSecurityContext(new SecurityContext() {
                 @Override
                 public Principal getUserPrincipal() {
@@ -69,7 +71,7 @@ public class ServicePrincipalAuthenticationFilter implements ContainerRequestFil
 
                 @Override
                 public boolean isUserInRole(String s) {
-                    return servicePrincipal.getRoles().contains(s);
+                    return false;
                 }
 
                 @Override
@@ -85,7 +87,6 @@ public class ServicePrincipalAuthenticationFilter implements ContainerRequestFil
         } else {
             containerRequestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED.getStatusCode(), "Authorization failure: no '%s' found".formatted(REQUEST_PROPERTY_CLAIMS)).build());
         }
-
 
 
     }

--- a/extensions/common/auth/auth-authentication-oauth2-lib/src/main/java/org/eclipse/edc/api/authentication/filter/ServicePrincipalAuthenticationFilter.java
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/src/main/java/org/eclipse/edc/api/authentication/filter/ServicePrincipalAuthenticationFilter.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
 import org.eclipse.edc.api.auth.spi.ScopeMatcher;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
 import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.result.Result;
 
 import java.security.Principal;
 
@@ -54,11 +55,11 @@ public class ServicePrincipalAuthenticationFilter implements ContainerRequestFil
             var subject = claimToken.getStringClaim(SUBJECT);
             var scope = claimToken.getStringClaim(SCOPE);
 
-            // a non-admin principal is identified by its participant context, which must exist; an admin principal is
-            // elevated, so its subject need not correspond to a participant context (e.g. a service account)
-            if (!scopeMatcher.isAdmin(scope) && subject != null &&
-                    participantContextService.getParticipantContext(subject).failed()) {
-                containerRequestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED.getStatusCode(), "Authorization Header invalid: participant context not found").build());
+            // a non-admin principal is identified by its participant context (read from the 'sub' claim), which must exist;
+            // an admin principal is elevated, so its subject need not correspond to a participant context (e.g. a service account)
+            var authorized = isAuthorized(scope, subject);
+            if (authorized.failed()) {
+                containerRequestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED.getStatusCode()).entity("Not authorized: %s".formatted(authorized.getFailureDetail())).build());
                 return;
             }
 
@@ -88,6 +89,28 @@ public class ServicePrincipalAuthenticationFilter implements ContainerRequestFil
             containerRequestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED.getStatusCode(), "Authorization failure: no '%s' found".formatted(REQUEST_PROPERTY_CLAIMS)).build());
         }
 
+    }
 
+    /**
+     * Validates if a subject is authorized for a given scope. This is the case if the scope is an "admin" scope, in
+     * which case the subject claim is ignored, or if the scope is not admin, and the subject claim references an existing
+     * participant context
+     *
+     * @param scope   The scope for which authorization is being requested.
+     * @param subject The subject claim for which authorization is being verified.
+     * @return A {@link Result} indicating the authorization result.
+     */
+    private Result<Void> isAuthorized(String scope, String subject) {
+
+        if (scopeMatcher.isAdmin(scope)) {
+            return Result.success();
+        }
+        if (subject == null) {
+            return Result.failure("No 'sub' claim present");
+        }
+        if (participantContextService.getParticipantContext(subject).failed()) {
+            return Result.failure("No participant for 'sub = %s' found".formatted(subject));
+        }
+        return Result.success();
     }
 }

--- a/extensions/common/auth/auth-authentication-oauth2-lib/src/test/java/org/eclipse/edc/api/authentication/filter/ServicePrincipalAuthenticationFilterTest.java
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/src/test/java/org/eclipse/edc/api/authentication/filter/ServicePrincipalAuthenticationFilterTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.api.authentication.filter;
 
 import jakarta.ws.rs.container.ContainerRequestContext;
+import org.eclipse.edc.api.auth.spi.ManagementApiScopes;
 import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
@@ -24,9 +25,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.eclipse.edc.api.authentication.filter.Constants.REQUEST_PROPERTY_CLAIMS;
-import static org.eclipse.edc.api.authentication.filter.Constants.TOKEN_CLAIM_PARTICIPANT_CONTEXT_ID;
-import static org.eclipse.edc.api.authentication.filter.Constants.TOKEN_CLAIM_ROLE;
 import static org.eclipse.edc.api.authentication.filter.Constants.TOKEN_CLAIM_SCOPE;
+import static org.eclipse.edc.api.authentication.filter.Constants.TOKEN_CLAIM_SUBJECT;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -54,8 +54,24 @@ class ServicePrincipalAuthenticationFilterTest {
         var request = mock(ContainerRequestContext.class);
         when(request.getProperty(REQUEST_PROPERTY_CLAIMS)).thenReturn(ClaimToken.Builder.newInstance()
                 .claim(TOKEN_CLAIM_SCOPE, "management-api:read")
-                .claim(TOKEN_CLAIM_ROLE, ParticipantPrincipal.ROLE_PARTICIPANT)
-                .claim(TOKEN_CLAIM_PARTICIPANT_CONTEXT_ID, "test-context-id")
+                .claim(TOKEN_CLAIM_SUBJECT, "test-context-id")
+                .build());
+
+
+        filter.filter(request);
+
+        verify(request).getProperty(REQUEST_PROPERTY_CLAIMS);
+        verify(request).setSecurityContext(argThat(sc -> sc.getUserPrincipal() instanceof ParticipantPrincipal pp &&
+                "test-context-id".equals(pp.getName())));
+        verifyNoMoreInteractions(request);
+    }
+
+    @Test
+    void filter_success_noSubjectClaim() {
+        var request = mock(ContainerRequestContext.class);
+        when(request.getProperty(REQUEST_PROPERTY_CLAIMS)).thenReturn(ClaimToken.Builder.newInstance()
+                .claim(TOKEN_CLAIM_SCOPE, "management-api:read")
+                // missing: sub claim
                 .build());
 
 
@@ -67,20 +83,18 @@ class ServicePrincipalAuthenticationFilterTest {
     }
 
     @Test
-    void filter_success_noParticipantContextIdClaim() {
+    void filter_adminSubjectNotParticipantContext_isAllowed() {
+        // an admin token's subject need not be a participant context; the existence check must be skipped
+        when(participantContextService.getParticipantContext(anyString())).thenReturn(ServiceResult.notFound("not a participant context"));
         var request = mock(ContainerRequestContext.class);
         when(request.getProperty(REQUEST_PROPERTY_CLAIMS)).thenReturn(ClaimToken.Builder.newInstance()
-                .claim(TOKEN_CLAIM_SCOPE, "management-api:read")
-                .claim(TOKEN_CLAIM_ROLE, ParticipantPrincipal.ROLE_PARTICIPANT)
-                // missing: participant_context_id claim
+                .claim(TOKEN_CLAIM_SCOPE, ManagementApiScopes.ADMIN)
+                .claim(TOKEN_CLAIM_SUBJECT, "some-service-account")
                 .build());
-
 
         filter.filter(request);
 
-        verify(request).getProperty(REQUEST_PROPERTY_CLAIMS);
         verify(request).setSecurityContext(argThat(sc -> sc.getUserPrincipal() instanceof ParticipantPrincipal));
-        verifyNoMoreInteractions(request);
     }
 
     @Test
@@ -98,8 +112,7 @@ class ServicePrincipalAuthenticationFilterTest {
         var request = mock(ContainerRequestContext.class);
         when(request.getProperty(REQUEST_PROPERTY_CLAIMS)).thenReturn(ClaimToken.Builder.newInstance()
                 .claim(TOKEN_CLAIM_SCOPE, "management-api:read")
-                .claim(TOKEN_CLAIM_ROLE, ParticipantPrincipal.ROLE_PARTICIPANT)
-                .claim(TOKEN_CLAIM_PARTICIPANT_CONTEXT_ID, "test-context-id")
+                .claim(TOKEN_CLAIM_SUBJECT, "test-context-id")
                 .build());
         filter.filter(request);
 

--- a/extensions/common/auth/auth-authentication-oauth2-lib/src/test/java/org/eclipse/edc/api/authentication/filter/ServicePrincipalAuthenticationFilterTest.java
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/src/test/java/org/eclipse/edc/api/authentication/filter/ServicePrincipalAuthenticationFilterTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.api.authentication.filter;
 
 import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Response;
 import org.eclipse.edc.api.auth.spi.ManagementApiScopes;
 import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
@@ -30,6 +31,7 @@ import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SUBJECT;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -67,7 +69,7 @@ class ServicePrincipalAuthenticationFilterTest {
     }
 
     @Test
-    void filter_success_noSubjectClaim() {
+    void filter_noSubjectClaim_failure() {
         var request = mock(ContainerRequestContext.class);
         when(request.getProperty(REQUEST_PROPERTY_CLAIMS)).thenReturn(ClaimToken.Builder.newInstance()
                 .claim(SCOPE, "management-api:read")
@@ -78,7 +80,8 @@ class ServicePrincipalAuthenticationFilterTest {
         filter.filter(request);
 
         verify(request).getProperty(REQUEST_PROPERTY_CLAIMS);
-        verify(request).setSecurityContext(argThat(sc -> sc.getUserPrincipal() instanceof ParticipantPrincipal));
+        verify(request, never()).setSecurityContext(argThat(sc -> sc.getUserPrincipal() instanceof ParticipantPrincipal));
+        verify(request).abortWith(argThat(response -> response.getStatus() == Response.Status.UNAUTHORIZED.getStatusCode()));
         verifyNoMoreInteractions(request);
     }
 

--- a/extensions/common/auth/auth-authentication-oauth2-lib/src/test/java/org/eclipse/edc/api/authentication/filter/ServicePrincipalAuthenticationFilterTest.java
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/src/test/java/org/eclipse/edc/api/authentication/filter/ServicePrincipalAuthenticationFilterTest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.api.authentication.filter;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import org.eclipse.edc.api.auth.spi.ManagementApiScopes;
 import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
+import org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.iam.ClaimToken;
@@ -25,8 +26,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.eclipse.edc.api.authentication.filter.Constants.REQUEST_PROPERTY_CLAIMS;
-import static org.eclipse.edc.api.authentication.filter.Constants.TOKEN_CLAIM_SCOPE;
-import static org.eclipse.edc.api.authentication.filter.Constants.TOKEN_CLAIM_SUBJECT;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.*;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SCOPE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -53,8 +54,8 @@ class ServicePrincipalAuthenticationFilterTest {
     void filter_success() {
         var request = mock(ContainerRequestContext.class);
         when(request.getProperty(REQUEST_PROPERTY_CLAIMS)).thenReturn(ClaimToken.Builder.newInstance()
-                .claim(TOKEN_CLAIM_SCOPE, "management-api:read")
-                .claim(TOKEN_CLAIM_SUBJECT, "test-context-id")
+                .claim(SCOPE, "management-api:read")
+                .claim(SUBJECT, "test-context-id")
                 .build());
 
 
@@ -70,7 +71,7 @@ class ServicePrincipalAuthenticationFilterTest {
     void filter_success_noSubjectClaim() {
         var request = mock(ContainerRequestContext.class);
         when(request.getProperty(REQUEST_PROPERTY_CLAIMS)).thenReturn(ClaimToken.Builder.newInstance()
-                .claim(TOKEN_CLAIM_SCOPE, "management-api:read")
+                .claim(SCOPE, "management-api:read")
                 // missing: sub claim
                 .build());
 
@@ -88,8 +89,8 @@ class ServicePrincipalAuthenticationFilterTest {
         when(participantContextService.getParticipantContext(anyString())).thenReturn(ServiceResult.notFound("not a participant context"));
         var request = mock(ContainerRequestContext.class);
         when(request.getProperty(REQUEST_PROPERTY_CLAIMS)).thenReturn(ClaimToken.Builder.newInstance()
-                .claim(TOKEN_CLAIM_SCOPE, ManagementApiScopes.ADMIN)
-                .claim(TOKEN_CLAIM_SUBJECT, "some-service-account")
+                .claim(SCOPE, ManagementApiScopes.ADMIN)
+                .claim(SUBJECT, "some-service-account")
                 .build());
 
         filter.filter(request);
@@ -111,8 +112,8 @@ class ServicePrincipalAuthenticationFilterTest {
         when(participantContextService.getParticipantContext(anyString())).thenReturn(ServiceResult.notFound("test message"));
         var request = mock(ContainerRequestContext.class);
         when(request.getProperty(REQUEST_PROPERTY_CLAIMS)).thenReturn(ClaimToken.Builder.newInstance()
-                .claim(TOKEN_CLAIM_SCOPE, "management-api:read")
-                .claim(TOKEN_CLAIM_SUBJECT, "test-context-id")
+                .claim(SCOPE, "management-api:read")
+                .claim(SUBJECT, "test-context-id")
                 .build());
         filter.filter(request);
 

--- a/extensions/common/auth/auth-authentication-oauth2-lib/src/test/java/org/eclipse/edc/api/authentication/filter/ServicePrincipalAuthenticationFilterTest.java
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/src/test/java/org/eclipse/edc/api/authentication/filter/ServicePrincipalAuthenticationFilterTest.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.api.authentication.filter;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import org.eclipse.edc.api.auth.spi.ManagementApiScopes;
 import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
-import org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames;
 import org.eclipse.edc.participantcontext.spi.service.ParticipantContextService;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.iam.ClaimToken;
@@ -26,8 +25,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.eclipse.edc.api.authentication.filter.Constants.REQUEST_PROPERTY_CLAIMS;
-import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.*;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SCOPE;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SUBJECT;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;

--- a/extensions/common/auth/auth-authentication-oauth2-lib/src/testFixtures/java/org/eclipse/edc/api/authentication/OauthServer.java
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/src/testFixtures/java/org/eclipse/edc/api/authentication/OauthServer.java
@@ -20,7 +20,6 @@ import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.edc.api.auth.spi.ManagementApiScopes;
-import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
 
 import java.time.Instant;
 import java.util.HashMap;
@@ -30,6 +29,8 @@ import java.util.UUID;
 import static com.nimbusds.jose.JWSAlgorithm.ES256;
 
 public class OauthServer implements OauthTokenProvider {
+
+    private static final String ADMIN_SUBJECT = "admin-subject";
 
     private final ECKey oauthServerSigningKey;
     private final String issuer;
@@ -41,35 +42,28 @@ public class OauthServer implements OauthTokenProvider {
         this.scopes = scopes;
     }
 
+    @Override
     public String createToken(String participantContextId) {
         return createToken(participantContextId, Map.of());
     }
 
-    public String createToken(String participantContextId, String role) {
-        return createToken(participantContextId, Map.of(), scopes, role);
-    }
-
-    public String createToken(String participantContextId, String scopes, String role) {
-        return createToken(participantContextId, Map.of(), scopes, role);
+    public String createToken(String participantContextId, String scopes) {
+        return createToken(participantContextId, Map.of(), scopes);
     }
 
     public String createToken(String participantContextId, Map<String, String> additionalClaims) {
-        return createToken(participantContextId, additionalClaims, scopes, ParticipantPrincipal.ROLE_PARTICIPANT);
+        return createToken(participantContextId, additionalClaims, scopes);
     }
 
-    public String createToken(String participantContextId, Map<String, String> additionalClaims, String scopes, String role) {
+    public String createToken(String participantContextId, Map<String, String> additionalClaims, String scopes) {
         var defaultClaims = new HashMap<String, Object>(Map.of(
-                "sub", "test-subject",
+                "sub", participantContextId != null ? participantContextId : ADMIN_SUBJECT,
                 "iss", issuer,
                 "iat", Instant.now().getEpochSecond(),
                 "exp", Instant.now().plusSeconds(3600).getEpochSecond(),
                 "jti", UUID.randomUUID().toString(),
-                "scope", scopes,
-                "role", role
+                "scope", scopes
         ));
-        if (participantContextId != null) {
-            defaultClaims.put("participant_context_id", participantContextId);
-        }
         defaultClaims.putAll(additionalClaims);
         return createToken(defaultClaims);
     }
@@ -88,11 +82,12 @@ public class OauthServer implements OauthTokenProvider {
         }
     }
 
+    @Override
     public String createAdminToken() {
-        return createToken(null, ManagementApiScopes.ADMIN, ParticipantPrincipal.ROLE_ADMIN);
+        return createToken(null, ManagementApiScopes.ADMIN);
     }
 
     public String createProvisionerToken() {
-        return createToken(null, ManagementApiScopes.ADMIN, ParticipantPrincipal.ROLE_PROVISIONER);
+        return createToken(null, ManagementApiScopes.ADMIN);
     }
 }

--- a/extensions/common/auth/auth-authentication-oauth2-lib/src/testFixtures/java/org/eclipse/edc/api/authentication/OauthServer.java
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/src/testFixtures/java/org/eclipse/edc/api/authentication/OauthServer.java
@@ -86,8 +86,4 @@ public class OauthServer implements OauthTokenProvider {
     public String createAdminToken() {
         return createToken(null, ManagementApiScopes.ADMIN);
     }
-
-    public String createProvisionerToken() {
-        return createToken(null, ManagementApiScopes.ADMIN);
-    }
 }

--- a/extensions/common/auth/auth-authentication-oauth2-lib/src/testFixtures/java/org/eclipse/edc/api/authentication/OauthTokenProvider.java
+++ b/extensions/common/auth/auth-authentication-oauth2-lib/src/testFixtures/java/org/eclipse/edc/api/authentication/OauthTokenProvider.java
@@ -14,10 +14,15 @@
 
 package org.eclipse.edc.api.authentication;
 
-import java.util.Map;
-
 public interface OauthTokenProvider {
-    String createToken(String participantContextId, String role);
 
-    String createToken(String participantContextId, Map<String, String> additionalClaims);
+    /**
+     * Creates a token whose {@code sub} claim is the given participant context id (the principal identity).
+     */
+    String createToken(String participantContextId);
+
+    /**
+     * Creates an elevated, cross-tenant token carrying the {@code management-api:admin} scope.
+     */
+    String createAdminToken();
 }

--- a/extensions/common/auth/auth-authorization-oauth2-lib/src/test/java/org/eclipse/edc/api/authorization/filter/ScopeBasedAccessFilterTest.java
+++ b/extensions/common/auth/auth-authorization-oauth2-lib/src/test/java/org/eclipse/edc/api/authorization/filter/ScopeBasedAccessFilterTest.java
@@ -78,7 +78,7 @@ class ScopeBasedAccessFilterTest {
     void filter_allowsWhenRequiredScopePresent() throws Exception {
         var request = mock(ContainerRequestContext.class);
         var securityContext = mock(SecurityContext.class);
-        var participant = new ParticipantPrincipal("some-id", ParticipantPrincipal.ROLE_PARTICIPANT, "openid management-api:read profile");
+        var participant = new ParticipantPrincipal("some-id", "openid management-api:read profile");
         when(securityContext.getUserPrincipal()).thenReturn(participant);
         when(request.getSecurityContext()).thenReturn(securityContext);
 
@@ -94,7 +94,7 @@ class ScopeBasedAccessFilterTest {
         var request = mock(ContainerRequestContext.class);
         var securityContext = mock(SecurityContext.class);
         // required is management-api:read; a write (or admin) grant satisfies it via the action hierarchy
-        var participant = new ParticipantPrincipal("some-id", ParticipantPrincipal.ROLE_PARTICIPANT, "management-api:write");
+        var participant = new ParticipantPrincipal("some-id", "management-api:write");
         when(securityContext.getUserPrincipal()).thenReturn(participant);
         when(request.getSecurityContext()).thenReturn(securityContext);
 
@@ -109,7 +109,7 @@ class ScopeBasedAccessFilterTest {
     void filter_abortsWithForbidden_whenRequiredScopeMissingForParticipant() throws Exception {
         var request = mock(ContainerRequestContext.class);
         var securityContext = mock(SecurityContext.class);
-        var participant = new ParticipantPrincipal("some-id", ParticipantPrincipal.ROLE_PARTICIPANT, "openid profile");
+        var participant = new ParticipantPrincipal("some-id", "openid profile");
         when(securityContext.getUserPrincipal()).thenReturn(participant);
         when(request.getSecurityContext()).thenReturn(securityContext);
 
@@ -125,7 +125,7 @@ class ScopeBasedAccessFilterTest {
     void filter_abortsWithForbidden_whenParticipantScopeIsEmpty() throws Exception {
         var request = mock(ContainerRequestContext.class);
         var securityContext = mock(SecurityContext.class);
-        var participant = new ParticipantPrincipal("some-id", ParticipantPrincipal.ROLE_PARTICIPANT, " ");
+        var participant = new ParticipantPrincipal("some-id", " ");
         when(securityContext.getUserPrincipal()).thenReturn(participant);
         when(request.getSecurityContext()).thenReturn(securityContext);
 
@@ -142,7 +142,7 @@ class ScopeBasedAccessFilterTest {
         var request = mock(ContainerRequestContext.class);
         var securityContext = mock(SecurityContext.class);
         // a resource-specific grant does not satisfy the wildcard-resource requirement (management-api:read ≡ *:read)
-        var participant = new ParticipantPrincipal("some-id", ParticipantPrincipal.ROLE_PARTICIPANT, "management-api:assets:read");
+        var participant = new ParticipantPrincipal("some-id", "management-api:assets:read");
         when(securityContext.getUserPrincipal()).thenReturn(participant);
         when(request.getSecurityContext()).thenReturn(securityContext);
 

--- a/extensions/common/auth/auth-authorization-oauth2-lib/src/test/java/org/eclipse/edc/api/authorization/service/AuthorizationServiceImplTest.java
+++ b/extensions/common/auth/auth-authorization-oauth2-lib/src/test/java/org/eclipse/edc/api/authorization/service/AuthorizationServiceImplTest.java
@@ -98,7 +98,7 @@ class AuthorizationServiceImplTest {
             }
         });
         // principal name differs from the resource owner: only the admin scope grants access
-        var principal = new ParticipantPrincipal("a-different-principal", ParticipantPrincipal.ROLE_PARTICIPANT, scope);
+        var principal = new ParticipantPrincipal("a-different-principal", scope);
         var securityContext = mock(SecurityContext.class);
         when(securityContext.getUserPrincipal()).thenReturn(principal);
 
@@ -114,7 +114,7 @@ class AuthorizationServiceImplTest {
                 return "owner-id";
             }
         });
-        var principal = new ParticipantPrincipal("a-different-principal", ParticipantPrincipal.ROLE_PARTICIPANT, "management-api:read management-api:write");
+        var principal = new ParticipantPrincipal("a-different-principal", "management-api:read management-api:write");
         var securityContext = mock(SecurityContext.class);
         when(securityContext.getUserPrincipal()).thenReturn(principal);
 

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/ManagementApiClientV5.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/ManagementApiClientV5.java
@@ -260,10 +260,4 @@ public class ManagementApiClientV5 {
         return given().baseUri(managementEndpoint.get().toString())
                 .header("Authorization", "Bearer " + token);
     }
-
-    public RequestSpecification baseManagementRequest(String participantContextId, String scope, String role) {
-        var token = oauthServer.createToken(participantContextId, Map.of("scope", scope, "role", role));
-        return given().baseUri(managementEndpoint.get().toString())
-                .header("Authorization", "Bearer " + token);
-    }
 }

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/ManagementApiClientV5.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/ManagementApiClientV5.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.controlplane.test.system.utils.client;
 
 import io.restassured.specification.RequestSpecification;
-import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
 import org.eclipse.edc.api.authentication.OauthTokenProvider;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.AssetsApi;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.CatalogApi;
@@ -255,15 +254,9 @@ public class ManagementApiClientV5 {
     }
 
     public RequestSpecification baseManagementRequest(String participantContextId) {
-        if (participantContextId == null) {
-            return baseManagementRequest(null, ParticipantPrincipal.ROLE_ADMIN);
-        } else {
-            return baseManagementRequest(participantContextId, ParticipantPrincipal.ROLE_PARTICIPANT);
-        }
-    }
-
-    public RequestSpecification baseManagementRequest(String participantContextId, String role) {
-        var token = oauthServer.createToken(participantContextId, role);
+        var token = participantContextId == null
+                ? oauthServer.createAdminToken()
+                : oauthServer.createToken(participantContextId);
         return given().baseUri(managementEndpoint.get().toString())
                 .header("Authorization", "Bearer " + token);
     }

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/CelExpressionApi.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/CelExpressionApi.java
@@ -38,7 +38,7 @@ public class CelExpressionApi {
      * @return the ID of the created CEL expression
      */
     public String createExpression(CelExpressionDto expression) {
-        return connector.baseManagementRequest(null, "management-api:admin")
+        return connector.baseManagementRequest(null)
                 .contentType(JSON)
                 .body(new WithContext<>(expression))
                 .when()

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/CelExpressionApi.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/CelExpressionApi.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.controlplane.test.system.utils.client.api;
 
-import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.ManagementApiClientV5;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.CelExpressionDto;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.WithContext;
@@ -39,7 +38,7 @@ public class CelExpressionApi {
      * @return the ID of the created CEL expression
      */
     public String createExpression(CelExpressionDto expression) {
-        return connector.baseManagementRequest(null, "management-api:admin", ParticipantPrincipal.ROLE_PROVISIONER)
+        return connector.baseManagementRequest(null, "management-api:admin")
                 .contentType(JSON)
                 .body(new WithContext<>(expression))
                 .when()

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/ParticipantContextApi.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/ParticipantContextApi.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.controlplane.test.system.utils.client.api;
 
-import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.ManagementApiClientV5;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.ParticipantContextDto;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.WithContext;
@@ -34,7 +33,7 @@ public class ParticipantContextApi {
      * @param participantContextDto the participant context to create
      */
     public void createParticipant(ParticipantContextDto participantContextDto) {
-        connector.baseManagementRequest(null, "management-api:admin", ParticipantPrincipal.ROLE_PROVISIONER)
+        connector.baseManagementRequest(null)
                 .contentType(JSON)
                 .body(new WithContext<>(participantContextDto))
                 .when()

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/ParticipantContextConfigApi.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/api/ParticipantContextConfigApi.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.controlplane.test.system.utils.client.api;
 
-import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.ManagementApiClientV5;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.ParticipantContextConfigDto;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.WithContext;
@@ -38,7 +37,7 @@ public class ParticipantContextConfigApi {
      * @param participantContextDto the participant context configuration to save
      */
     public void saveConfig(String participantContextId, ParticipantContextConfigDto participantContextDto) {
-        connector.baseManagementRequest(null, "management-api:admin", ParticipantPrincipal.ROLE_PROVISIONER)
+        connector.baseManagementRequest(null)
                 .contentType(JSON)
                 .body(new WithContext<>(participantContextDto))
                 .when()

--- a/spi/common/auth-spi/src/main/java/org/eclipse/edc/api/auth/spi/ParticipantPrincipal.java
+++ b/spi/common/auth-spi/src/main/java/org/eclipse/edc/api/auth/spi/ParticipantPrincipal.java
@@ -15,21 +15,16 @@
 package org.eclipse.edc.api.auth.spi;
 
 import java.security.Principal;
-import java.util.Collection;
-import java.util.List;
 
-public record ParticipantPrincipal(String participantContextId, String role, String scope) implements Principal {
-
-    public static final String ROLE_ADMIN = "admin";
-    public static final String ROLE_PROVISIONER = "provisioner";
-    public static final String ROLE_PARTICIPANT = "participant";
+/**
+ * Represents the security principal of an authenticated Management API request. The {@code participantContextId} is the
+ * identity carried by the token's {@code sub} claim; {@code scope} is the (space-delimited) set of granted scopes that
+ * determine what the principal may do.
+ */
+public record ParticipantPrincipal(String participantContextId, String scope) implements Principal {
 
     @Override
     public String getName() {
         return participantContextId;
-    }
-
-    public Collection<String> getRoles() {
-        return List.of(role);
     }
 }

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CelExpressionApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CelExpressionApiV5EndToEndTest.java
@@ -55,8 +55,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesRegex;
-import static org.hamcrest.Matchers.matchesPattern;
-import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.Matchers.nullValue;
 
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CelExpressionApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CelExpressionApiV5EndToEndTest.java
@@ -55,6 +55,8 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesRegex;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.Matchers.nullValue;
 
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/DataPlaneRegistrationApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/DataPlaneRegistrationApiV5EndToEndTest.java
@@ -152,7 +152,7 @@ public class DataPlaneRegistrationApiV5EndToEndTest {
 
             var message = createDataPlaneRegistrationMessage("dataplane-1", null);
 
-            context.baseRequest(authServer.createProvisionerToken())
+            context.baseRequest(authServer.createAdminToken())
                     .contentType(ContentType.JSON)
                     .body(message)
                     .put("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/dataplanes")

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/DataspaceProfileContextApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/DataspaceProfileContextApiV5EndToEndTest.java
@@ -88,7 +88,7 @@ public class DataspaceProfileContextApiV5EndToEndTest {
 
             service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build());
 
-            var token = authServer.createProvisionerToken();
+            var token = authServer.createAdminToken();
 
             context.baseRequest(token)
                     .contentType(ContentType.JSON)
@@ -144,7 +144,7 @@ public class DataspaceProfileContextApiV5EndToEndTest {
 
             service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build());
 
-            var token = authServer.createProvisionerToken();
+            var token = authServer.createAdminToken();
 
             var profiles = associateProfileJson(List.of("http-dsp-profile-2025-1"));
 
@@ -163,7 +163,7 @@ public class DataspaceProfileContextApiV5EndToEndTest {
 
             service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build());
 
-            var token = authServer.createProvisionerToken();
+            var token = authServer.createAdminToken();
 
             var profiles = createObjectBuilder()
                     .add(CONTEXT, createArrayBuilder().add(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2))
@@ -186,7 +186,7 @@ public class DataspaceProfileContextApiV5EndToEndTest {
 
             service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build());
 
-            var token = authServer.createProvisionerToken();
+            var token = authServer.createAdminToken();
 
             var profiles = associateProfileJson(List.of("unknown-profile"));
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/ParticipantContextApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/ParticipantContextApiV5EndToEndTest.java
@@ -71,7 +71,7 @@ public class ParticipantContextApiV5EndToEndTest {
                     .build()
                     .toString();
 
-            var token = authServer.createProvisionerToken();
+            var token = authServer.createAdminToken();
 
             var su = context.baseRequest(token)
                     .contentType(JSON)
@@ -93,7 +93,7 @@ public class ParticipantContextApiV5EndToEndTest {
                     .build()
                     .toString();
 
-            var token = authServer.createProvisionerToken();
+            var token = authServer.createAdminToken();
 
             context.baseRequest(token)
                     .contentType(JSON)
@@ -176,7 +176,7 @@ public class ParticipantContextApiV5EndToEndTest {
                     .build()
                     .toString();
 
-            var token = authServer.createProvisionerToken();
+            var token = authServer.createAdminToken();
 
             context.baseRequest(token)
                     .contentType(JSON)
@@ -200,7 +200,7 @@ public class ParticipantContextApiV5EndToEndTest {
                     .build()
                     .toString();
 
-            var token = authServer.createProvisionerToken();
+            var token = authServer.createAdminToken();
 
             context.baseRequest(token)
                     .contentType(JSON)
@@ -244,7 +244,7 @@ public class ParticipantContextApiV5EndToEndTest {
                 service.createParticipantContext(participantContext(participantContextId));
             });
 
-            var token = authServer.createProvisionerToken();
+            var token = authServer.createAdminToken();
             context.baseRequest(token)
                     .contentType(JSON)
                     .get("/v5beta/participants")
@@ -261,7 +261,7 @@ public class ParticipantContextApiV5EndToEndTest {
                 service.createParticipantContext(participantContext(participantContextId));
             });
 
-            var token = authServer.createProvisionerToken();
+            var token = authServer.createAdminToken();
             context.baseRequest(token)
                     .contentType(JSON)
                     .get("/v5beta/participants?offset=2&limit=4")

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/ParticipantContextConfigApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/ParticipantContextConfigApiV5EndToEndTest.java
@@ -70,7 +70,7 @@ public class ParticipantContextConfigApiV5EndToEndTest {
                     .build()
                     .toString();
 
-            var token = authServer.createProvisionerToken();
+            var token = authServer.createAdminToken();
 
             context.baseRequest(token)
                     .contentType(ContentType.JSON)
@@ -97,7 +97,7 @@ public class ParticipantContextConfigApiV5EndToEndTest {
                     .build()
                     .toString();
 
-            var token = authServer.createProvisionerToken();
+            var token = authServer.createAdminToken();
 
             context.baseRequest(token)
                     .contentType(ContentType.JSON)


### PR DESCRIPTION
## What this PR changes/adds

- the principal identity is solely carried in the `sub` claim instead of the `participant_context_id` claim.
- all remnants of the `role` claim are dropped

## Why it does that

move to scope-based authz

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5803

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
