### PR TITLE
feat: register CallbackClient default service

### DIFF
--- a/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/controlplane/callback/dispatcher/CallbackEventDispatcherDefaultExtension.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/controlplane/callback/dispatcher/CallbackEventDispatcherDefaultExtension.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.controlplane.callback.dispatcher;
+
+import org.eclipse.edc.connector.controlplane.services.spi.callback.CallbackClient;
+import org.eclipse.edc.http.spi.EdcHttpClient;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.types.TypeManager;
+
+@Extension(value = CallbackEventDispatcherDefaultExtension.NAME)
+public class CallbackEventDispatcherDefaultExtension implements ServiceExtension {
+
+    public static final String NAME = "Callback event dispatcher default services";
+
+    @Inject
+    EdcHttpClient edcHttpClient;
+    @Inject
+    TypeManager typeManager;
+    @Inject
+    Vault vault;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider(isDefault = true)
+    public CallbackClient callbackClient() {
+        return new CallbackHttpClient(edcHttpClient, typeManager.getMapper(), vault);
+    }
+}

--- a/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/controlplane/callback/dispatcher/CallbackEventDispatcherExtension.java
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/main/java/org/eclipse/edc/connector/controlplane/callback/dispatcher/CallbackEventDispatcherExtension.java
@@ -14,22 +14,20 @@
 
 package org.eclipse.edc.connector.controlplane.callback.dispatcher;
 
+import org.eclipse.edc.connector.controlplane.services.spi.callback.CallbackClient;
 import org.eclipse.edc.connector.controlplane.services.spi.callback.CallbackRegistry;
-import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.types.TypeManager;
 
 @Extension(value = CallbackEventDispatcherExtension.NAME)
 public class CallbackEventDispatcherExtension implements ServiceExtension {
 
-    public static final String NAME = "Callback dispatcher extension";
+    public static final String NAME = "Callback event dispatcher";
 
     @Inject
     EventRouter router;
@@ -38,11 +36,7 @@ public class CallbackEventDispatcherExtension implements ServiceExtension {
     @Inject
     CallbackRegistry callbackRegistry;
     @Inject
-    EdcHttpClient edcHttpClient;
-    @Inject
-    TypeManager typeManager;
-    @Inject
-    Vault vault;
+    CallbackClient callbackClient;
 
     @Override
     public String name() {
@@ -51,7 +45,6 @@ public class CallbackEventDispatcherExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var callbackClient = new CallbackHttpClient(edcHttpClient, typeManager.getMapper(), vault);
         router.registerSync(Event.class, new CallbackEventDispatcher(callbackClient, callbackRegistry, true, monitor));
         router.register(Event.class, new CallbackEventDispatcher(callbackClient, callbackRegistry, false, monitor));
     }

--- a/extensions/control-plane/callback/callback-event-dispatcher/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/control-plane/callback/callback-event-dispatcher/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -12,5 +12,6 @@
 #
 #
 
+org.eclipse.edc.connector.controlplane.callback.dispatcher.CallbackEventDispatcherDefaultExtension
 org.eclipse.edc.connector.controlplane.callback.dispatcher.CallbackEventDispatcherExtension
 


### PR DESCRIPTION
## What this PR changes/adds

Missing piece from #5808
Register `CallbackClient` as default service, so it can be used in other implementations and also overridden, if necessary.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5658 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
