### PR TITLE
feat: propagate trace context to NATS event headers

### DIFF
--- a/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsEventPublisher.java
+++ b/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsEventPublisher.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.telemetry.Telemetry;
 
 import java.io.IOException;
 import java.net.URI;
@@ -41,13 +42,15 @@ public class NatsEventPublisher implements EventSubscriber {
     private final JetStream jetStream;
     private final ObjectMapper objectMapper;
     private final String hostname;
+    private final Telemetry telemetry;
     private final JsonFormat jsonFormat = new JsonFormat();
 
-    public NatsEventPublisher(Monitor monitor, JetStream jetStream, ObjectMapper objectMapper, String hostname) {
+    public NatsEventPublisher(Monitor monitor, JetStream jetStream, ObjectMapper objectMapper, String hostname, Telemetry telemetry) {
         this.monitor = monitor;
         this.jetStream = jetStream;
         this.objectMapper = objectMapper;
         this.hostname = hostname;
+        this.telemetry = telemetry;
     }
 
     @Override
@@ -82,6 +85,9 @@ public class NatsEventPublisher implements EventSubscriber {
     private Headers getHeaders() {
         var h = new Headers();
         h.add("Content-Type", "application/cloudevents+json");
+        // Propagate the current trace context (W3C traceparent/baggage) so consumers can
+        // continue the trace across the NATS boundary instead of starting a new root span.
+        telemetry.getCurrentTraceContext().forEach((key, value) -> h.add(key, value));
         return h;
     }
 }

--- a/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
+++ b/extensions/common/events/events-nats/src/main/java/org/eclipse/edc/event/nats/NatsPublishingExtension.java
@@ -33,6 +33,7 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.Hostname;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.telemetry.Telemetry;
 import org.eclipse.edc.spi.types.TypeManager;
 
 import java.io.IOException;
@@ -65,6 +66,9 @@ public class NatsPublishingExtension implements ServiceExtension {
     @Inject
     private Hostname hostname;
 
+    @Inject
+    private Telemetry telemetry;
+
     private Connection natsConnection;
 
     @Override
@@ -76,7 +80,7 @@ public class NatsPublishingExtension implements ServiceExtension {
     public void prepare() {
         try {
             var natsEventPublisher = new NatsEventPublisher(monitor.withPrefix("NATS events"),
-                    natsConnection.jetStream(), typeManager.getMapper(), hostname.get());
+                    natsConnection.jetStream(), typeManager.getMapper(), hostname.get(), telemetry);
             eventRouter.register(Event.class, natsEventPublisher);
         } catch (IOException e) {
             throw new EdcException("Error connecting to NATS", e);

--- a/extensions/common/events/events-nats/src/test/java/org/eclipse/edc/event/nats/NatsEventPublisherTest.java
+++ b/extensions/common/events/events-nats/src/test/java/org/eclipse/edc/event/nats/NatsEventPublisherTest.java
@@ -24,12 +24,16 @@ import io.nats.client.impl.Headers;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.telemetry.Telemetry;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Map;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -43,7 +47,7 @@ import static org.mockito.Mockito.when;
 class NatsEventPublisherTest {
     private final JetStream jetstream = mock();
     private final Monitor monitor = mock();
-    private final NatsEventPublisher natsEventPublisher = new NatsEventPublisher(monitor, jetstream, new ObjectMapper(), "localhost/test");
+    private final NatsEventPublisher natsEventPublisher = new NatsEventPublisher(monitor, jetstream, new ObjectMapper(), "localhost/test", new Telemetry());
 
     @Test
     void onEvent_shouldPublish() throws JetStreamApiException, IOException {
@@ -63,6 +67,20 @@ class NatsEventPublisherTest {
 
         verify(monitor).severe(anyString(), isA(JetStreamApiException.class));
         verify(jetstream).publish(eq("events.dummy.foobar"), any(Headers.class), notNull(), any(PublishOptions.class));
+    }
+
+    @Test
+    void onEvent_shouldInjectTraceContextIntoHeaders() throws JetStreamApiException, IOException {
+        var traceparent = "00-0102030405060708090a0b0c0d0e0f10-0102030405060708-01";
+        var telemetry = mock(Telemetry.class);
+        when(telemetry.getCurrentTraceContext()).thenReturn(Map.of("traceparent", traceparent));
+        var publisher = new NatsEventPublisher(monitor, jetstream, new ObjectMapper(), "localhost/test", telemetry);
+        var headers = ArgumentCaptor.forClass(Headers.class);
+
+        publisher.on(payload(new DummyEvent("foobar")));
+
+        verify(jetstream).publish(eq("events.dummy.foobar"), headers.capture(), notNull(), any(PublishOptions.class));
+        assertThat(headers.getValue().get("traceparent")).containsExactly(traceparent);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## What this does

Propagates the current W3C trace context (`traceparent`/`baggage`) onto NATS messages published by `NatsEventPublisher`, so a trace started in the connector continues across the NATS boundary instead of being dropped.

## Why

`NatsEventPublisher.getHeaders()` previously set only `Content-Type: application/cloudevents+json`. With no `traceparent` on the message, any consumer extracting trace context from the NATS headers starts a brand-new root span, and the trace shows up **disconnected** in tools like Jaeger (spans are exported fine, but the parent/child link is lost at the event-bus hop).

## How

- `NatsEventPublisher` now injects `telemetry.getCurrentTraceContext()` into the NATS `Headers` on publish, using the existing `Telemetry` SPI (which uses the configured propagator — W3C by default — so the keys stay consistent with the rest of the system).
- `NatsPublishingExtension` `@Inject`s `Telemetry` and passes it to the publisher.

When no OpenTelemetry agent/propagator is active, `getCurrentTraceContext()` returns an empty map, so this is a no-op in untraced deployments.
