### PR TITLE
refactor: remove control-plane address parse/validation

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/ControlPlaneServicesExtension.java
@@ -63,7 +63,6 @@ import org.eclipse.edc.connector.controlplane.services.transferprocess.TransferP
 import org.eclipse.edc.connector.controlplane.services.transferprocess.TransferProcessProviderFactory;
 import org.eclipse.edc.connector.controlplane.services.transferprocess.TransferProcessServiceImpl;
 import org.eclipse.edc.connector.controlplane.transfer.spi.flow.DataFlowController;
-import org.eclipse.edc.connector.controlplane.transfer.spi.flow.TransferTypeParser;
 import org.eclipse.edc.connector.controlplane.transfer.spi.observe.TransferProcessObservable;
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.DataAddressStore;
@@ -89,7 +88,6 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.telemetry.Telemetry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
-import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
 
 import java.time.Clock;
 
@@ -146,8 +144,6 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Inject
     private CommandHandlerRegistry commandHandlerRegistry;
     @Inject
-    private DataAddressValidatorRegistry dataAddressValidator;
-    @Inject
     private IdentityService identityService;
     @Inject
     private PolicyEngine policyEngine;
@@ -155,8 +151,6 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     private ProtocolTokenValidator protocolTokenValidator;
     @Inject
     private DataspaceProfileContextRegistry dataspaceProfileContextRegistry;
-    @Inject
-    private TransferTypeParser transferTypeParser;
     @Inject
     private ParticipantIdentityResolver identityResolver;
     @Inject
@@ -238,7 +232,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     @Provider
     public TransferProcessService transferProcessService() {
         return new TransferProcessServiceImpl(transferProcessStore, transactionContext,
-                dataAddressValidator, commandHandlerRegistry, transferTypeParser, contractNegotiationStore,
+                commandHandlerRegistry, contractNegotiationStore,
                 QueryValidators.transferProcess());
     }
 
@@ -246,7 +240,7 @@ public class ControlPlaneServicesExtension implements ServiceExtension {
     public TransferProcessProtocolService transferProcessProtocolService() {
         var factory = new TransferProcessProviderFactory(clock, telemetry, assetIndex);
         return new TransferProcessProtocolServiceImpl(transferProcessStore, transactionContext, contractNegotiationStore,
-                contractValidationService, protocolTokenValidator(), dataAddressValidator, transferProcessObservable,
+                contractValidationService, protocolTokenValidator(), transferProcessObservable,
                 monitor, dataFlowController, dataAddressStore, factory);
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -46,7 +46,6 @@ import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 import org.eclipse.edc.transaction.spi.TransactionContext;
-import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
@@ -65,7 +64,6 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     private final TransactionContext transactionContext;
     private final ContractNegotiationStore negotiationStore;
     private final ContractValidationService contractValidationService;
-    private final DataAddressValidatorRegistry dataAddressValidator;
     private final TransferProcessObservable observable;
     private final ProtocolTokenValidator protocolTokenValidator;
     private final Monitor monitor;
@@ -78,7 +76,6 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
                                               ContractNegotiationStore negotiationStore,
                                               ContractValidationService contractValidationService,
                                               ProtocolTokenValidator protocolTokenValidator,
-                                              DataAddressValidatorRegistry dataAddressValidator,
                                               TransferProcessObservable observable,
                                               Monitor monitor,
                                               DataFlowController dataFlowController, DataAddressStore dataAddressStore,
@@ -88,7 +85,6 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
         this.negotiationStore = negotiationStore;
         this.contractValidationService = contractValidationService;
         this.protocolTokenValidator = protocolTokenValidator;
-        this.dataAddressValidator = dataAddressValidator;
         this.observable = observable;
         this.monitor = monitor;
         this.dataFlowController = dataFlowController;
@@ -158,14 +154,6 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
 
     @NotNull
     private ServiceResult<TransferProcess> requestedAction(ParticipantContext participantContext, TransferRequestMessage message, ClaimTokenContext context) {
-        var destination = message.getDataAddress();
-        if (destination != null) {
-            var validDestination = dataAddressValidator.validateDestination(destination);
-            if (validDestination.failed()) {
-                return ServiceResult.badRequest(validDestination.getFailureMessages());
-            }
-        }
-
         var transferType = message.getTransferType();
         var supportedTransferTypes = dataFlowController.transferTypesFor(context.agreement().getAssetId());
         if (!supportedTransferTypes.contains(transferType)) {

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImpl.java
@@ -18,7 +18,6 @@ package org.eclipse.edc.connector.controlplane.services.transferprocess;
 import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.ContractNegotiationStore;
 import org.eclipse.edc.connector.controlplane.services.query.QueryValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
-import org.eclipse.edc.connector.controlplane.transfer.spi.flow.TransferTypeParser;
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
@@ -35,9 +34,7 @@ import org.eclipse.edc.spi.command.CommandHandlerRegistry;
 import org.eclipse.edc.spi.command.EntityCommand;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
-import org.eclipse.edc.spi.types.domain.transfer.FlowType;
 import org.eclipse.edc.transaction.spi.TransactionContext;
-import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -50,20 +47,16 @@ public class TransferProcessServiceImpl implements TransferProcessService {
     private final TransferProcessStore transferProcessStore;
     private final TransactionContext transactionContext;
     private final QueryValidator queryValidator;
-    private final DataAddressValidatorRegistry dataAddressValidator;
     private final CommandHandlerRegistry commandHandlerRegistry;
-    private final TransferTypeParser transferTypeParser;
     private final ContractNegotiationStore contractNegotiationStore;
 
     public TransferProcessServiceImpl(TransferProcessStore transferProcessStore,
-                                      TransactionContext transactionContext, DataAddressValidatorRegistry dataAddressValidator,
-                                      CommandHandlerRegistry commandHandlerRegistry, TransferTypeParser transferTypeParser,
+                                      TransactionContext transactionContext,
+                                      CommandHandlerRegistry commandHandlerRegistry,
                                       ContractNegotiationStore contractNegotiationStore, QueryValidator queryValidator) {
         this.transferProcessStore = transferProcessStore;
         this.transactionContext = transactionContext;
-        this.dataAddressValidator = dataAddressValidator;
         this.commandHandlerRegistry = commandHandlerRegistry;
-        this.transferTypeParser = transferTypeParser;
         this.contractNegotiationStore = contractNegotiationStore;
         this.queryValidator = queryValidator;
     }
@@ -112,23 +105,9 @@ public class TransferProcessServiceImpl implements TransferProcessService {
 
     @Override
     public @NotNull ServiceResult<TransferProcess> initiateTransfer(ParticipantContext participantContext, TransferRequest request) {
-        var transferTypeParse = transferTypeParser.parse(request.getTransferType());
-        if (transferTypeParse.failed()) {
-            return ServiceResult.badRequest("Property transferType not valid: " + transferTypeParse.getFailureDetail());
-        }
-
         var agreement = contractNegotiationStore.findContractAgreement(request.getContractId());
         if (agreement == null) {
             return ServiceResult.badRequest("Contract agreement with id %s not found".formatted(request.getContractId()));
-        }
-
-        var flowType = transferTypeParse.getContent().flowType();
-
-        if (flowType == FlowType.PUSH && request.getDataDestination() != null) {
-            var validDestination = dataAddressValidator.validateDestination(request.getDataDestination());
-            if (validDestination.failed()) {
-                return ServiceResult.badRequest(validDestination.getFailureMessages());
-            }
         }
 
         return transactionContext.execute(() -> commandHandlerRegistry

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -48,8 +48,6 @@ import org.eclipse.edc.spi.types.domain.message.ProcessRemoteMessage;
 import org.eclipse.edc.spi.types.domain.message.RemoteMessage;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
-import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
-import org.eclipse.edc.validator.spi.ValidationResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -86,7 +84,6 @@ import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.BAD_REQUEST;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.CONFLICT;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
-import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -107,7 +104,6 @@ class TransferProcessProtocolServiceImplTest {
     private final TransactionContext transactionContext = spy(new NoopTransactionContext());
     private final ContractNegotiationStore negotiationStore = mock();
     private final ContractValidationService validationService = mock();
-    private final DataAddressValidatorRegistry dataAddressValidator = mock();
     private final TransferProcessListener listener = mock();
     private final ProtocolTokenValidator protocolTokenValidator = mock();
     private final DataAddressStore dataAddressStore = mock();
@@ -124,7 +120,7 @@ class TransferProcessProtocolServiceImplTest {
         var observable = new TransferProcessObservableImpl();
         observable.registerListener(listener);
         service = new TransferProcessProtocolServiceImpl(store, transactionContext, negotiationStore, validationService,
-                protocolTokenValidator, dataAddressValidator, observable, mock(), dataFlowController,
+                protocolTokenValidator, observable, mock(), dataFlowController,
                 dataAddressStore, transferProcessProviderFactory);
         when(store.save(any())).thenReturn(StoreResult.success());
     }
@@ -340,7 +336,6 @@ class TransferProcessProtocolServiceImplTest {
             when(validationService.validateRequest(any(), isA(ContractAgreement.class))).thenReturn(Result.success());
             when(negotiationStore.queryAgreements(any())).thenReturn(Stream.of(contractAgreement()));
             when(validationService.validateAgreement(any(ParticipantAgent.class), any())).thenReturn(Result.success(null));
-            when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
             when(dataFlowController.transferTypesFor(anyString())).thenReturn(Set.of("transferType"));
             when(dataAddressStore.store(any(), any())).thenReturn(StoreResult.success());
             var transferProcess = transferProcess(INITIAL, "transferProcessId");
@@ -374,7 +369,6 @@ class TransferProcessProtocolServiceImplTest {
             when(validationService.validateRequest(any(), isA(ContractAgreement.class))).thenReturn(Result.failure("invalid credentials"));
             when(negotiationStore.queryAgreements(any())).thenReturn(Stream.of(contractAgreement()));
             when(validationService.validateAgreement(any(ParticipantAgent.class), any())).thenReturn(Result.success(null));
-            when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
             var transferProcess = transferProcess(INITIAL, "transferProcessId");
             when(transferProcessProviderFactory.create(any(), any(), any(), any())).thenReturn(ServiceResult.success(transferProcess));
 
@@ -404,7 +398,6 @@ class TransferProcessProtocolServiceImplTest {
             when(validationService.validateRequest(any(), isA(ContractAgreement.class))).thenReturn(Result.success());
             when(negotiationStore.queryAgreements(any())).thenReturn(Stream.of(contractAgreement()));
             when(validationService.validateAgreement(any(ParticipantAgent.class), any())).thenReturn(Result.success(null));
-            when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
             when(dataFlowController.transferTypesFor(anyString())).thenReturn(Set.of("transferType"));
             when(dataAddressStore.store(any(), any())).thenReturn(StoreResult.generalError("error"));
             when(transferProcessProviderFactory.create(any(), any(), any(), any())).thenReturn(ServiceResult.success(transferProcess(INITIAL, "transferProcessId")));
@@ -433,7 +426,6 @@ class TransferProcessProtocolServiceImplTest {
             when(validationService.validateRequest(any(), isA(ContractAgreement.class))).thenReturn(Result.success());
             when(negotiationStore.queryAgreements(any())).thenReturn(Stream.of(contractAgreement()));
             when(validationService.validateAgreement(any(ParticipantAgent.class), any())).thenReturn(Result.success(null));
-            when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
             when(dataFlowController.transferTypesFor(anyString())).thenReturn(Set.of("transferType"));
             when(transferProcessProviderFactory.create(any(), any(), any(), any())).thenReturn(ServiceResult.badRequest("cannot create transfer process"));
 
@@ -464,7 +456,6 @@ class TransferProcessProtocolServiceImplTest {
             when(validationService.validateRequest(any(), isA(ContractAgreement.class))).thenReturn(Result.success());
             when(negotiationStore.queryAgreements(any())).thenReturn(Stream.of(contractAgreement()));
             when(validationService.validateAgreement(any(ParticipantAgent.class), any())).thenReturn(Result.success(null));
-            when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
             when(store.findForCorrelationId(any())).thenReturn(transferProcess(REQUESTED, "transferProcessId"));
             when(dataFlowController.transferTypesFor(anyString())).thenReturn(Set.of("transferType"));
 
@@ -492,7 +483,6 @@ class TransferProcessProtocolServiceImplTest {
             when(validationService.validateRequest(any(), isA(ContractAgreement.class))).thenReturn(Result.success());
             when(negotiationStore.queryAgreements(any())).thenReturn(Stream.of(contractAgreement()));
             when(validationService.validateAgreement(any(ParticipantAgent.class), any())).thenReturn(Result.failure("error"));
-            when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
             when(dataFlowController.transferTypesFor(anyString())).thenReturn(Set.of("transferType"));
 
             var result = service.notifyRequested(participantContext, message, tokenRepresentation);
@@ -517,7 +507,6 @@ class TransferProcessProtocolServiceImplTest {
             when(negotiationStore.queryAgreements(any())).thenReturn(Stream.of(contractAgreement()));
             when(protocolTokenValidator.verify(eq(participantContext), eq(tokenRepresentation), any(), any(), eq(message))).thenReturn(ServiceResult.success(participantAgent));
             when(validationService.validateRequest(any(), isA(ContractAgreement.class))).thenReturn(Result.success());
-            when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.failure(violation("invalid data address", "path")));
 
             var result = service.notifyRequested(participantContext, message, tokenRepresentation);
 
@@ -544,7 +533,6 @@ class TransferProcessProtocolServiceImplTest {
             when(validationService.validateRequest(any(), isA(ContractAgreement.class))).thenReturn(Result.success());
             when(negotiationStore.queryAgreements(any())).thenReturn(Stream.of(contractAgreement));
             when(validationService.validateAgreement(any(ParticipantAgent.class), any())).thenReturn(Result.success(contractAgreement));
-            when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
             when(dataFlowController.transferTypesFor(anyString())).thenReturn(Set.of("supported-transfer-type"));
 
             var result = service.notifyRequested(participantContext, message, tokenRepresentation);

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImplTest.java
@@ -19,7 +19,6 @@ import org.eclipse.edc.connector.controlplane.contract.spi.negotiation.store.Con
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.controlplane.services.query.QueryValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
-import org.eclipse.edc.connector.controlplane.transfer.spi.flow.TransferTypeParser;
 import org.eclipse.edc.connector.controlplane.transfer.spi.store.TransferProcessStore;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
@@ -36,12 +35,8 @@ import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceFailure;
 import org.eclipse.edc.spi.types.domain.DataAddress;
-import org.eclipse.edc.spi.types.domain.transfer.FlowType;
-import org.eclipse.edc.spi.types.domain.transfer.TransferType;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
-import org.eclipse.edc.validator.spi.DataAddressValidatorRegistry;
-import org.eclipse.edc.validator.spi.ValidationResult;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -55,7 +50,6 @@ import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.BAD_REQUEST;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
-import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -72,14 +66,12 @@ class TransferProcessServiceImplTest {
     private final QuerySpec query = QuerySpec.Builder.newInstance().limit(5).offset(2).build();
     private final TransferProcessStore store = mock();
     private final TransactionContext transactionContext = spy(new NoopTransactionContext());
-    private final DataAddressValidatorRegistry dataAddressValidator = mock();
     private final CommandHandlerRegistry commandHandlerRegistry = mock();
-    private final TransferTypeParser transferTypeParser = mock();
     private final ContractNegotiationStore contractNegotiationStore = mock();
     private final QueryValidator queryValidator = mock();
 
     private final TransferProcessService service = new TransferProcessServiceImpl(store, transactionContext,
-            dataAddressValidator, commandHandlerRegistry, transferTypeParser, contractNegotiationStore, queryValidator);
+            commandHandlerRegistry, contractNegotiationStore, queryValidator);
 
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
             .participantContextId("participantContextId")
@@ -195,8 +187,6 @@ class TransferProcessServiceImplTest {
             var transferProcess = transferProcess();
             when(contractNegotiationStore.findContractAgreement(transferRequest.getContractId()))
                     .thenReturn(createContractAgreement(transferProcess.getContractId(), "assetId"));
-            when(transferTypeParser.parse(any())).thenReturn(Result.success(new TransferType("DestinationType", FlowType.PUSH)));
-            when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
             when(commandHandlerRegistry.execute(any())).thenReturn(CommandResult.success(transferProcess));
 
             var result = service.initiateTransfer(participantContext, transferRequest);
@@ -207,22 +197,7 @@ class TransferProcessServiceImplTest {
         }
 
         @Test
-        void shouldFail_whenTransferTypeIsNotValid() {
-            when(transferTypeParser.parse(any())).thenReturn(Result.failure("cannot parse"));
-
-            var result = service.initiateTransfer(participantContext, transferRequest());
-
-            assertThat(result).isFailed()
-                    .extracting(ServiceFailure::getReason)
-                    .isEqualTo(BAD_REQUEST);
-            assertThat(result.getFailureDetail()).contains("cannot parse");
-        }
-
-        @Test
         void shouldFail_whenContractAgreementNotFound() {
-            when(transferTypeParser.parse(any())).thenReturn(Result.success(new TransferType("DestinationType", FlowType.PUSH)));
-            when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.failure(violation("invalid data address", "path")));
-
             var result = service.initiateTransfer(participantContext, transferRequest());
 
             assertThat(result).isFailed()
@@ -232,29 +207,11 @@ class TransferProcessServiceImplTest {
         }
 
         @Test
-        void shouldFail_whenDestinationIsNotValid() {
-            var transferRequest = transferRequest();
-            when(contractNegotiationStore.findContractAgreement(transferRequest.getContractId()))
-                    .thenReturn(createContractAgreement(transferRequest.getContractId(), "assetId"));
-            when(transferTypeParser.parse(any())).thenReturn(Result.success(new TransferType("DestinationType", FlowType.PUSH)));
-            when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.failure(violation("invalid data address", "path")));
-
-            var result = service.initiateTransfer(participantContext, transferRequest);
-
-            assertThat(result).isFailed()
-                    .extracting(ServiceFailure::getReason)
-                    .isEqualTo(BAD_REQUEST);
-            assertThat(result.getFailureMessages()).containsExactly("invalid data address");
-        }
-
-        @Test
         void shouldFail_whenCommandFails() {
             var transferRequest = transferRequest();
             var transferProcess = transferProcess();
             when(contractNegotiationStore.findContractAgreement(transferRequest.getContractId()))
                     .thenReturn(createContractAgreement(transferProcess.getContractId(), "assetId"));
-            when(transferTypeParser.parse(any())).thenReturn(Result.success(new TransferType("DestinationType", FlowType.PUSH)));
-            when(dataAddressValidator.validateDestination(any())).thenReturn(ValidationResult.success());
             when(commandHandlerRegistry.execute(any())).thenReturn(CommandResult.notExecutable("error"));
 
             var result = service.initiateTransfer(participantContext, transferRequest);
@@ -268,14 +225,12 @@ class TransferProcessServiceImplTest {
             var transferProcess = transferProcess();
             when(contractNegotiationStore.findContractAgreement(transferRequest.getContractId()))
                     .thenReturn(createContractAgreement(transferProcess.getContractId(), "assetId"));
-            when(transferTypeParser.parse(any())).thenReturn(Result.success(new TransferType("DestinationType", FlowType.PUSH)));
             when(commandHandlerRegistry.execute(any())).thenReturn(CommandResult.success(transferProcess));
 
             var result = service.initiateTransfer(participantContext, transferRequest);
 
             assertThat(result).isSucceeded().isEqualTo(transferProcess);
             verify(transactionContext).execute(any(TransactionContext.ResultTransactionBlock.class));
-            verifyNoInteractions(dataAddressValidator);
         }
     }
 

--- a/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/TransferTypeParser.java
+++ b/spi/control-plane/transfer-spi/src/main/java/org/eclipse/edc/connector/controlplane/transfer/spi/flow/TransferTypeParser.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.connector.controlplane.transfer.spi.flow;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.domain.transfer.TransferType;
 
+@Deprecated(since = "0.18.0")
 public interface TransferTypeParser {
 
     /**


### PR DESCRIPTION
## What this PR changes/adds

The control-plane should not parse the transfer-type as it really has (or should have) no knowledge about.
Also the data-address validation is something that should be demanded to the data-plane

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5829 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
