### PR TITLE
fix: update PostgreSQL type casts in JsonFieldTranslator and add tests

### DIFF
--- a/core/common/lib/core-lib/src/main/java/org/eclipse/edc/sql/translation/JsonFieldTranslator.java
+++ b/core/common/lib/core-lib/src/main/java/org/eclipse/edc/sql/translation/JsonFieldTranslator.java
@@ -72,19 +72,19 @@ public class JsonFieldTranslator implements FieldTranslator {
         }
 
         if (type.equals(Double.class)) {
-            return format("(%s)::double", statement);
+            return format("(%s)::double precision", statement);
         }
 
         if (type.equals(Float.class)) {
-            return format("(%s)::float", statement);
+            return format("(%s)::real", statement);
         }
 
         if (type.equals(Long.class)) {
-            return format("(%s)::long", statement);
+            return format("(%s)::bigint", statement);
         }
 
         if (type.equals(Short.class)) {
-            return format("(%s)::short", statement);
+            return format("(%s)::smallint", statement);
         }
 
         return statement;

--- a/core/common/lib/core-lib/src/test/java/org/eclipse/edc/sql/translation/JsonFieldTranslatorTest.java
+++ b/core/common/lib/core-lib/src/test/java/org/eclipse/edc/sql/translation/JsonFieldTranslatorTest.java
@@ -104,7 +104,7 @@ class JsonFieldTranslatorTest {
 
             var result = translator.toWhereClause(PathItem.parse("field"), criterion, operator);
 
-            assertThat(result.sql()).isEqualTo("(column_name ->> 'field')::double = ?");
+            assertThat(result.sql()).isEqualTo("(column_name ->> 'field')::double precision = ?");
             assertThat(result.parameters()).containsExactly(100.0);
         }
 
@@ -115,7 +115,7 @@ class JsonFieldTranslatorTest {
 
             var result = translator.toWhereClause(PathItem.parse("field"), criterion, operator);
 
-            assertThat(result.sql()).isEqualTo("(column_name ->> 'field')::float = ?");
+            assertThat(result.sql()).isEqualTo("(column_name ->> 'field')::real = ?");
             assertThat(result.parameters()).containsExactly(100.0F);
         }
 
@@ -126,7 +126,7 @@ class JsonFieldTranslatorTest {
 
             var result = translator.toWhereClause(PathItem.parse("field"), criterion, operator);
 
-            assertThat(result.sql()).isEqualTo("(column_name ->> 'field')::long = ?");
+            assertThat(result.sql()).isEqualTo("(column_name ->> 'field')::bigint = ?");
             assertThat(result.parameters()).containsExactly(100L);
         }
 
@@ -137,7 +137,7 @@ class JsonFieldTranslatorTest {
 
             var result = translator.toWhereClause(PathItem.parse("field"), criterion, operator);
 
-            assertThat(result.sql()).isEqualTo("(column_name ->> 'field')::short = ?");
+            assertThat(result.sql()).isEqualTo("(column_name ->> 'field')::smallint = ?");
             assertThat(result.parameters()).containsExactly((short) 1);
         }
 

--- a/spi/control-plane-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/asset/spi/testfixtures/AssetIndexTestBase.java
+++ b/spi/control-plane-spi/src/testFixtures/java/org/eclipse/edc/connector/controlplane/asset/spi/testfixtures/AssetIndexTestBase.java
@@ -289,6 +289,66 @@ public abstract class AssetIndexTestBase {
         }
 
         @Test
+        void shouldFilterByDoubleProperty() {
+            var expected = createAssetBuilder("id1").property("score", 10.0).build();
+            var different = createAssetBuilder("id2").property("score", 20.0).build();
+            getAssetIndex().create(expected);
+            getAssetIndex().create(different);
+
+            var assets = getAssetIndex().queryAssets(filter(criterion("score", "=", 10.0)));
+
+            assertThat(assets).hasSize(1).map(Asset::getId).containsExactly(expected.getId());
+        }
+
+        @Test
+        void shouldFilterByIntegerProperty() {
+            var expected = createAssetBuilder("id1").property("count", 42).build();
+            var different = createAssetBuilder("id2").property("count", 99).build();
+            getAssetIndex().create(expected);
+            getAssetIndex().create(different);
+
+            var assets = getAssetIndex().queryAssets(filter(criterion("count", "=", 42)));
+
+            assertThat(assets).hasSize(1).map(Asset::getId).containsExactly(expected.getId());
+        }
+
+        @Test
+        void shouldFilterByLongProperty() {
+            var expected = createAssetBuilder("id1").property("timestamp", 123456789L).build();
+            var different = createAssetBuilder("id2").property("timestamp", 987654321L).build();
+            getAssetIndex().create(expected);
+            getAssetIndex().create(different);
+
+            var assets = getAssetIndex().queryAssets(filter(criterion("timestamp", "=", 123456789L)));
+
+            assertThat(assets).hasSize(1).map(Asset::getId).containsExactly(expected.getId());
+        }
+
+        @Test
+        void shouldFilterByFloatProperty() {
+            var expected = createAssetBuilder("id1").property("rating", 4.5F).build();
+            var different = createAssetBuilder("id2").property("rating", 3.5F).build();
+            getAssetIndex().create(expected);
+            getAssetIndex().create(different);
+
+            var assets = getAssetIndex().queryAssets(filter(criterion("rating", "=", 4.5F)));
+
+            assertThat(assets).hasSize(1).map(Asset::getId).containsExactly(expected.getId());
+        }
+
+        @Test
+        void shouldFilterByShortProperty() {
+            var expected = createAssetBuilder("id1").property("priority", (short) 1).build();
+            var different = createAssetBuilder("id2").property("priority", (short) 2).build();
+            getAssetIndex().create(expected);
+            getAssetIndex().create(different);
+
+            var assets = getAssetIndex().queryAssets(filter(criterion("priority", "=", (short) 1)));
+
+            assertThat(assets).hasSize(1).map(Asset::getId).containsExactly(expected.getId());
+        }
+
+        @Test
         void shouldFilterByNestedProperty() {
             var nested = EDC_NAMESPACE + "nested";
             var version = EDC_NAMESPACE + "version";


### PR DESCRIPTION
## What this PR changes/adds

This PR fixes the Postgres cast type error in [JsonFieldTranslator.java](https://github.com/eclipse-edc/Connector/compare/main...mokhairymahmoud:Connector:fix/PostgreSQL-type-casts?expand=1#diff-569a6a3fe3110fe6a92d41b9009b7e760bea4a243a848476124bd233b5c69183), as Postgres doesn't have "double" syntax but rather "double percision" similarly for the float, short and long.  

## Why it does that

To allow using numeric filter expression in the catalog and everywhere.

## Linked Issue(s)

Closes #5843 
_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
