### PR TITLE
feat: support JSON merge patch

### DIFF
--- a/core/common/participant-context-config-core/src/main/java/org/eclipse/edc/participantcontext/config/service/ParticipantContextConfigServiceImpl.java
+++ b/core/common/participant-context-config-core/src/main/java/org/eclipse/edc/participantcontext/config/service/ParticipantContextConfigServiceImpl.java
@@ -24,9 +24,7 @@ import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import java.time.Clock;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class ParticipantContextConfigServiceImpl implements ParticipantContextConfigService {
 
@@ -46,28 +44,32 @@ public class ParticipantContextConfigServiceImpl implements ParticipantContextCo
 
     @Override
     public ServiceResult<Void> save(ParticipantContextConfiguration config) {
-        return transactionContext.execute(() -> encryptEntries(config)
-                .onSuccess(configStore::save)
-                .flatMap(ServiceResult::from)
-                .mapEmpty());
+        return transactionContext.execute(() -> {
+            if (hasNullValue(config.getEntries()) || hasNullValue(config.getPrivateEntries())) {
+                return ServiceResult.badRequest("Null values are not allowed when setting a configuration");
+            }
+            return encryptEntries(config)
+                    .onSuccess(configStore::save)
+                    .flatMap(ServiceResult::from)
+                    .mapEmpty();
+        });
     }
 
     @Override
     public ServiceResult<Void> merge(ParticipantContextConfiguration config) {
         return transactionContext.execute(() -> {
             var existing = configStore.get(config.getParticipantContextId());
-            if (existing == null) {
-                return ServiceResult.notFound("No configuration found for participant context with id " + config.getParticipantContextId());
-            }
             return ServiceResult.from(encryptEntries(config))
                     .map(encryptedPatch -> {
-                        var mergedEntries = new HashMap<>(existing.getEntries());
-                        mergedEntries.putAll(encryptedPatch.getEntries());
-                        var mergedPrivateEntries = new HashMap<>(existing.getPrivateEntries());
-                        mergedPrivateEntries.putAll(encryptedPatch.getPrivateEntries());
-                        return existing.toBuilder()
-                                .entries(mergedEntries)
-                                .privateEntries(mergedPrivateEntries)
+                        var base = existing != null
+                                ? existing
+                                : ParticipantContextConfiguration.Builder.newInstance()
+                                    .participantContextId(config.getParticipantContextId())
+                                    .createdAt(clock.millis())
+                                    .build();
+                        return base.toBuilder()
+                                .entries(mergePatch(base.getEntries(), encryptedPatch.getEntries()))
+                                .privateEntries(mergePatch(base.getPrivateEntries(), encryptedPatch.getPrivateEntries()))
                                 .lastModified(clock.millis())
                                 .build();
                     })
@@ -76,30 +78,41 @@ public class ParticipantContextConfigServiceImpl implements ParticipantContextCo
         });
     }
 
-
-    private Result<ParticipantContextConfiguration> encryptEntries(ParticipantContextConfiguration config) {
-
-        Result<List<Map.Entry<String, String>>> result = config.getPrivateEntries()
-                .entrySet()
-                .stream()
-                .map(this::encryptEntryMap)
-                .collect(Result.collector());
-
-        if (result.succeeded()) {
-            var encryptedConfig = config.toBuilder()
-                    .privateEntries(result.getContent().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)))
-                    .build();
-            return Result.success(encryptedConfig);
-        } else {
-            return Result.failure("Failed to encrypt entries: " + result.getFailureDetail());
-
-        }
-
+    private static boolean hasNullValue(Map<String, String> map) {
+        return map.values().stream().anyMatch(value -> value == null);
     }
 
-    private Result<Map.Entry<String, String>> encryptEntryMap(Map.Entry<String, String> entry) {
-        return encryptionRegistry.encrypt(encryptionAlgorithm, entry.getValue())
-                .map(encrypted -> Map.entry(entry.getKey(), encrypted));
+    /**
+     * Applies a JSON Merge Patch (RFC 7396) of {@code patch} onto {@code base}: a null value removes the key, any
+     * other value adds or overwrites it.
+     */
+    private static Map<String, String> mergePatch(Map<String, String> base, Map<String, String> patch) {
+        var merged = new HashMap<>(base);
+        patch.forEach((key, value) -> {
+            if (value == null) {
+                merged.remove(key);
+            } else {
+                merged.put(key, value);
+            }
+        });
+        return merged;
+    }
+
+    private Result<ParticipantContextConfiguration> encryptEntries(ParticipantContextConfiguration config) {
+        var encryptedPrivateEntries = new HashMap<String, String>();
+        for (var entry : config.getPrivateEntries().entrySet()) {
+            if (entry.getValue() == null) {
+                // a null value is a removal signal (RFC 7396), keep it as-is instead of encrypting
+                encryptedPrivateEntries.put(entry.getKey(), null);
+                continue;
+            }
+            var result = encryptionRegistry.encrypt(encryptionAlgorithm, entry.getValue());
+            if (result.failed()) {
+                return Result.failure("Failed to encrypt entries: " + result.getFailureDetail());
+            }
+            encryptedPrivateEntries.put(entry.getKey(), result.getContent());
+        }
+        return Result.success(config.toBuilder().privateEntries(encryptedPrivateEntries).build());
     }
 
     @Override

--- a/core/common/participant-context-config-core/src/test/java/org/eclipse/edc/participantcontext/config/service/ParticipantContextConfigServiceImplTest.java
+++ b/core/common/participant-context-config-core/src/test/java/org/eclipse/edc/participantcontext/config/service/ParticipantContextConfigServiceImplTest.java
@@ -102,15 +102,96 @@ public class ParticipantContextConfigServiceImplTest {
     }
 
     @Test
-    void merge_whenNotFound() {
+    void merge_whenNotFound_shouldCreate() {
+        when(registry.encrypt(anyString(), anyString())).then(a -> Result.success("enc(" + a.getArgument(1) + ")"));
+        when(store.get("participantContext")).thenReturn(null);
+
         var patch = ParticipantContextConfiguration.Builder.newInstance()
                 .participantContextId("participantContext")
                 .entries(Map.of("key", "value"))
+                .privateEntries(Map.of("secret", "plain"))
                 .build();
 
         var result = service.merge(patch);
+        assertThat(result).isSucceeded();
 
-        assertThat(result).isFailed().detail().contains("No configuration found for participant context");
+        verify(store).save(argThat(saved ->
+                saved.getParticipantContextId().equals("participantContext") &&
+                        saved.getCreatedAt() == 5000 &&
+                        saved.getLastModified() == 5000 &&
+                        saved.getEntries().equals(Map.of("key", "value")) &&
+                        saved.getPrivateEntries().equals(Map.of("secret", "enc(plain)"))));
+        verify(registry).encrypt(anyString(), anyString());
+    }
+
+    @Test
+    void merge_shouldRemoveEntry_whenValueIsNull() {
+        when(registry.encrypt(anyString(), anyString())).then(a -> Result.success("enc(" + a.getArgument(1) + ")"));
+
+        var existing = ParticipantContextConfiguration.Builder.newInstance()
+                .participantContextId("participantContext")
+                .createdAt(1000)
+                .lastModified(1000)
+                .entries(new HashMap<>(Map.of("key", "value", "keep", "kept")))
+                .privateEntries(new HashMap<>(Map.of("secret", "enc(existing)", "keepSecret", "enc(kept)")))
+                .build();
+        when(store.get("participantContext")).thenReturn(existing);
+
+        var entries = new HashMap<String, String>();
+        entries.put("key", null);
+        var privateEntries = new HashMap<String, String>();
+        privateEntries.put("secret", null);
+        var patch = ParticipantContextConfiguration.Builder.newInstance()
+                .participantContextId("participantContext")
+                .entries(entries)
+                .privateEntries(privateEntries)
+                .build();
+
+        var result = service.merge(patch);
+        assertThat(result).isSucceeded();
+
+        verify(store).save(argThat(saved ->
+                saved.getEntries().equals(Map.of("keep", "kept")) &&
+                        saved.getPrivateEntries().equals(Map.of("keepSecret", "enc(kept)"))));
+        // null values are removal signals and must never be encrypted
+        verify(registry, never()).encrypt(anyString(), any());
+    }
+
+    @Test
+    void merge_whenKeyAbsent_nullIsNoop() {
+        when(registry.encrypt(anyString(), anyString())).then(a -> Result.success("enc(" + a.getArgument(1) + ")"));
+
+        var existing = ParticipantContextConfiguration.Builder.newInstance()
+                .participantContextId("participantContext")
+                .entries(new HashMap<>(Map.of("keep", "kept")))
+                .build();
+        when(store.get("participantContext")).thenReturn(existing);
+
+        var entries = new HashMap<String, String>();
+        entries.put("missing", null);
+        var patch = ParticipantContextConfiguration.Builder.newInstance()
+                .participantContextId("participantContext")
+                .entries(entries)
+                .build();
+
+        var result = service.merge(patch);
+        assertThat(result).isSucceeded();
+
+        verify(store).save(argThat(saved -> saved.getEntries().equals(Map.of("keep", "kept"))));
+    }
+
+    @Test
+    void save_shouldReturnBadRequest_whenNullValue() {
+        var entries = new HashMap<String, String>();
+        entries.put("key", null);
+        var config = ParticipantContextConfiguration.Builder.newInstance()
+                .participantContextId("participantContext")
+                .entries(entries)
+                .build();
+
+        var result = service.save(config);
+
+        assertThat(result).isFailed().detail().contains("Null values are not allowed");
         verify(store, never()).save(any());
     }
 

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/config/to/JsonObjectToParticipantContextConfigurationTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/config/to/JsonObjectToParticipantContextConfigurationTransformer.java
@@ -49,7 +49,13 @@ public class JsonObjectToParticipantContextConfigurationTransformer extends Abst
         if (properties != null) {
             var jsonValue = nodeJsonValue(properties);
             if (jsonValue instanceof JsonObject json) {
-                visitProperties(json, (key, value) -> action.accept(key, transformString(value, context)));
+                visitProperties(json, (key, value) -> {
+                    if (value == null || value.getValueType() == JsonValue.ValueType.NULL) {
+                        action.accept(key, null);
+                    } else {
+                        action.accept(key, transformString(value, context));
+                    }
+                });
             } else {
                 context.reportProblem("Expected properties to be a JsonObject");
                 return true;

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/config/to/JsonObjectToParticipantContextConfigurationTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/config/to/JsonObjectToParticipantContextConfigurationTransformerTest.java
@@ -23,8 +23,10 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
 import static org.eclipse.edc.participantcontext.spi.config.model.ParticipantContextConfiguration.PARTICIPANT_CONTEXT_CONFIG_ENTRIES_IRI;
 import static org.eclipse.edc.participantcontext.spi.config.model.ParticipantContextConfiguration.PARTICIPANT_CONTEXT_CONFIG_PRIVATE_ENTRIES_IRI;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 class JsonObjectToParticipantContextConfigurationTransformerTest {
@@ -80,6 +82,27 @@ class JsonObjectToParticipantContextConfigurationTransformerTest {
         assertThat(result).isNotNull();
         assertThat(result.getEntries()).isEmpty();
 
+    }
+
+    @Test
+    void transform_withNullValues_shouldKeepNullAndNotReportProblem() {
+        var jsonObject = createObjectBuilder()
+                .add(PARTICIPANT_CONTEXT_CONFIG_ENTRIES_IRI, createObjectBuilder()
+                        .add(VALUE, createObjectBuilder()
+                                .add("key1", "value1")
+                                .addNull("key2")))
+                .add(PARTICIPANT_CONTEXT_CONFIG_PRIVATE_ENTRIES_IRI, createObjectBuilder()
+                        .add(VALUE, createObjectBuilder()
+                                .addNull("secret")))
+                .build();
+
+        var result = transformer.transform(jsonObject, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getEntries()).containsEntry("key1", "value1")
+                .containsEntry("key2", null);
+        assertThat(result.getPrivateEntries()).containsEntry("secret", null);
+        verify(context, never()).reportProblem(anyString());
     }
 
     @Test

--- a/extensions/control-plane/api/management-api-v5/participant-context-config-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/config/ParticipantContextConfigApiControllerTestBase.java
+++ b/extensions/control-plane/api/management-api-v5/participant-context-config-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/config/ParticipantContextConfigApiControllerTestBase.java
@@ -146,6 +146,26 @@ public abstract class ParticipantContextConfigApiControllerTestBase extends Rest
                     .statusCode(400);
             verifyNoInteractions(service);
         }
+
+        @Test
+        void set_shouldReturnBadRequest_whenServiceRejectsNullValues() {
+            var contextConfig = createParticipantContextConfig();
+            when(transformerRegistry.transform(any(), eq(ParticipantContextConfiguration.class))).thenReturn(Result.success(contextConfig));
+            when(service.save(any())).thenReturn(ServiceResult.badRequest("Null values are not allowed when setting a configuration"));
+            var requestBody = Json.createObjectBuilder()
+                    .add("policy", Json.createObjectBuilder()
+                            .add(CONTEXT, "context")
+                            .add(TYPE, "Set")
+                            .build())
+                    .build();
+
+            baseRequest()
+                    .body(requestBody)
+                    .contentType(JSON)
+                    .put("/participants/" + contextConfig.getParticipantContextId() + "/config")
+                    .then()
+                    .statusCode(400);
+        }
     }
 
     @Nested
@@ -191,26 +211,6 @@ public abstract class ParticipantContextConfigApiControllerTestBase extends Rest
                     .then()
                     .statusCode(400);
             verifyNoInteractions(service);
-        }
-
-        @Test
-        void patch_shouldReturnNotFound_whenConfigDoesNotExist() {
-            var contextConfig = createParticipantContextConfig();
-            when(transformerRegistry.transform(any(), eq(ParticipantContextConfiguration.class))).thenReturn(Result.success(contextConfig));
-            when(service.merge(any())).thenReturn(ServiceResult.notFound("not found"));
-            var requestBody = Json.createObjectBuilder()
-                    .add("policy", Json.createObjectBuilder()
-                            .add(CONTEXT, "context")
-                            .add(TYPE, "Set")
-                            .build())
-                    .build();
-
-            baseRequest()
-                    .body(requestBody)
-                    .contentType(JSON)
-                    .patch("/participants/" + contextConfig.getParticipantContextId() + "/config")
-                    .then()
-                    .statusCode(404);
         }
     }
 

--- a/spi/control-plane-spi/src/main/java/org/eclipse/edc/participantcontext/spi/config/service/ParticipantContextConfigService.java
+++ b/spi/control-plane-spi/src/main/java/org/eclipse/edc/participantcontext/spi/config/service/ParticipantContextConfigService.java
@@ -23,7 +23,8 @@ import org.eclipse.edc.spi.result.ServiceResult;
 public interface ParticipantContextConfigService {
 
     /**
-     * Saves the configuration for a given participant context.
+     * Saves the configuration for a given participant context. Null entry values are rejected with a bad-request
+     * result; removal semantics are only supported through {@link #merge(ParticipantContextConfiguration)}.
      *
      * @param config the configuration to save
      * @return a ServiceResult indicating success or failure
@@ -31,9 +32,10 @@ public interface ParticipantContextConfigService {
     ServiceResult<Void> save(ParticipantContextConfiguration config);
 
     /**
-     * Merges the given configuration into the existing one for the same participant context. Entries and private
-     * entries present in the patch are added or overwritten, while existing entries that are not part of the patch are
-     * preserved. Fails if no configuration currently exists for the participant context.
+     * Merges the given configuration into the existing one for the same participant context, following JSON Merge Patch
+     * (RFC 7396) semantics. Entries and private entries present in the patch with a non-null value are added or
+     * overwritten; entries present with a null value are removed; existing entries that are not part of the patch are
+     * preserved. If no configuration currently exists for the participant context, a new one is created from the patch.
      *
      * @param config the configuration containing the entries to merge
      * @return a ServiceResult indicating success or failure

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/ParticipantContextConfigApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/ParticipantContextConfigApiV5EndToEndTest.java
@@ -165,7 +165,63 @@ public class ParticipantContextConfigApiV5EndToEndTest {
         }
 
         @Test
-        void patch_shouldReturnNotFound_whenConfigDoesNotExist(ManagementEndToEndV5TestContext context, OauthServer authServer) {
+        void patch_shouldRemoveEntry_whenValueIsNull(ManagementEndToEndV5TestContext context, OauthServer authServer, ParticipantContextConfigService service) {
+            var participantContextId = "test-user";
+
+            service.save(ParticipantContextConfiguration.Builder.newInstance().participantContextId(participantContextId)
+                    .entries(Map.of("key1", "value1", "key2", "value2"))
+                    .build());
+
+            var body = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "ParticipantContextConfig")
+                    .add("entries", createObjectBuilder()
+                            .add("key1", "updated")
+                            .addNull("key2"))
+                    .build()
+                    .toString();
+
+            var token = authServer.createAdminToken();
+
+            context.baseRequest(token)
+                    .contentType(ContentType.JSON)
+                    .body(body)
+                    .patch("/v5beta/participants/" + participantContextId + "/config")
+                    .then()
+                    .log().all()
+                    .statusCode(204);
+
+            var cfg = service.get(participantContextId)
+                    .orElseThrow(f -> new AssertionError("Participant context config not found"));
+
+            assertThat(cfg.getEntries()).isEqualTo(Map.of("key1", "updated"));
+        }
+
+        @Test
+        void set_shouldReturnBadRequest_whenValueIsNull(ManagementEndToEndV5TestContext context, OauthServer authServer) {
+            var participantContextId = "test-user";
+
+            var body = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "ParticipantContextConfig")
+                    .add("entries", createObjectBuilder()
+                            .add("key1", "value1")
+                            .addNull("key2"))
+                    .build()
+                    .toString();
+
+            var token = authServer.createAdminToken();
+
+            context.baseRequest(token)
+                    .contentType(ContentType.JSON)
+                    .body(body)
+                    .put("/v5beta/participants/" + participantContextId + "/config")
+                    .then()
+                    .statusCode(400);
+        }
+
+        @Test
+        void patch_shouldCreateConfig_whenConfigDoesNotExist(ManagementEndToEndV5TestContext context, OauthServer authServer, ParticipantContextConfigService service) {
             var participantContextId = "user-without-config";
 
             var body = createObjectBuilder()
@@ -182,7 +238,12 @@ public class ParticipantContextConfigApiV5EndToEndTest {
                     .body(body)
                     .patch("/v5beta/participants/" + participantContextId + "/config")
                     .then()
-                    .statusCode(404);
+                    .statusCode(204);
+
+            var cfg = service.get(participantContextId)
+                    .orElseThrow(f -> new AssertionError("Participant context config not found"));
+
+            assertThat(cfg.getEntries()).isEqualTo(Map.of("key1", "value1"));
         }
 
         @Test


### PR DESCRIPTION
## What this PR changes/adds

Add support on the patch config method for JSON merge patch, for key with value null they will be removed.
Additionally the patch also create the config if not exists. 

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
