### PR TITLE
fix: avoid exceptions during shutdown by guarding the iteration scheduling

### DIFF
--- a/core/control-plane/lib/control-plane-lib/src/main/java/org/eclipse/edc/statemachine/StateMachineManager.java
+++ b/core/control-plane/lib/control-plane-lib/src/main/java/org/eclipse/edc/statemachine/StateMachineManager.java
@@ -100,13 +100,11 @@ public class StateMachineManager {
     }
 
     private void logic() {
-        if (active.get()) {
-            try {
-                performLogic();
-            } catch (Throwable e) {
-                active.set(false);
-                monitor.severe(format("StateMachineManager [%s] unrecoverable error", name), e);
-            }
+        try {
+            performLogic();
+        } catch (Throwable e) {
+            active.set(false);
+            monitor.severe(format("StateMachineManager [%s] unrecoverable error", name), e);
         }
     }
 
@@ -126,7 +124,9 @@ public class StateMachineManager {
 
         var delay = processed == 0 ? waitStrategy.waitForMillis() : 0;
 
-        scheduleNextIterationIn(delay);
+        if (isActive()) {
+            scheduleNextIterationIn(delay);
+        }
 
     }
 

--- a/core/control-plane/lib/control-plane-lib/src/test/java/org/eclipse/edc/statemachine/StateMachineManagerTest.java
+++ b/core/control-plane/lib/control-plane-lib/src/test/java/org/eclipse/edc/statemachine/StateMachineManagerTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -150,5 +152,24 @@ class StateMachineManagerTest {
             assertThat(stateMachine.isActive()).isTrue();
             verify(successful, atLeastOnce()).process();
         });
+    }
+
+    @Test
+    void shouldNotThrowException_whenStoppedDuringProcessorRunning() {
+        var slowProcessor = mock(Processor.class);
+        when(slowProcessor.process()).thenAnswer(i -> {
+            Thread.sleep(200L);
+            return 1L;
+        });
+        var stateMachine = StateMachineManager.Builder.newInstance("test", monitor, instrumentation, waitStrategy)
+                .processor(slowProcessor)
+                .build();
+
+        stateMachine.start();
+
+        await().untilAsserted(() -> verify(slowProcessor).process()); // wait processor to be called
+        stateMachine.stop(); // stop right away
+
+        verify(monitor, never()).severe(anyString(), any());
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Check state machine active state before scheduling the next iteration instead of at the start of the iteration

## Why it does that

Avoid `RejectedExecutionException`s

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5868 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
