### PR TITLE
build: bump opentelemetry version

### DIFF
--- a/extensions/common/otel-monitor/src/test/java/org/eclipse/edc/monitor/opentelemetry/OtelMonitorTest.java
+++ b/extensions/common/otel-monitor/src/test/java/org/eclipse/edc/monitor/opentelemetry/OtelMonitorTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.monitor.opentelemetry;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.logs.LogRecordBuilder;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.logs.LoggerBuilder;
@@ -50,7 +51,7 @@ class OtelMonitorTest {
         when(logger.logRecordBuilder()).thenReturn(builder);
         when(builder.setSeverity(any())).thenReturn(builder);
         when(builder.setBody(anyString())).thenReturn(builder);
-        when(builder.setAttribute(any(), anyString())).thenReturn(builder);
+        when(builder.setAttribute(any(AttributeKey.class), any())).thenReturn(builder);
 
         return new OtelMonitor(level, () -> openTelemetry);
     }
@@ -185,7 +186,7 @@ class OtelMonitorTest {
             monitor.severe(() -> "test");
             monitor.severe(() -> "test", new Exception("test"));
             verify(builder, times(2)).emit();
-            verify(builder, times(3)).setAttribute(any(), any());
+            verify(builder, times(3)).setAttribute(any(AttributeKey.class), anyString());
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,8 +28,9 @@ micrometer = "1.17.0"
 mockito = "5.2.0"
 nimbus = "10.9.1"
 okhttp = "5.3.2"
-opentelemetry = "1.32.0"
-opentelemetry-proto = "1.10.0-alpha"
+opentelemetry = "1.63.0"
+opentelemetry-instrumentation = "1.33.2"
+opentelemetry-proto = "1.3.2-alpha"
 parsson = "1.1.7"
 postgres = "42.7.11"
 restAssured = "6.0.0"
@@ -86,7 +87,7 @@ wiremock = { module = "org.wiremock:wiremock-jetty12", version.ref = "wiremock" 
 nimbus-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbus" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version.ref = "opentelemetry" }
-opentelemetry-instrumentation-annotations = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations", version.ref = "opentelemetry" }
+opentelemetry-instrumentation-annotations = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations", version.ref = "opentelemetry-instrumentation" }
 opentelemetry-proto = { module = "io.opentelemetry.proto:opentelemetry-proto", version.ref = "opentelemetry-proto" }
 parsson = { module = "org.eclipse.parsson:parsson", version.ref = "parsson" }
 restAssured = { module = "io.rest-assured:rest-assured", version.ref = "restAssured" }

--- a/system-tests/telemetry/telemetry-test-runner/build.gradle.kts
+++ b/system-tests/telemetry/telemetry-test-runner/build.gradle.kts
@@ -35,7 +35,7 @@ edcBuild {
     publish.set(false)
 }
 
-val opentelemetryVersion = libs.versions.opentelemetry.asProvider().get()!!
+val opentelemetryVersion = libs.versions.opentelemetry.instrumentation.get()
 tasks.withType<Test> {
     afterEvaluate {
         val download = { url: String, destFile: File -> ant.invokeMethod("get", mapOf("src" to url, "dest" to destFile)) }

--- a/system-tests/telemetry/telemetry-test-runner/src/test/java/org/eclipse/edc/test/e2e/tracing/MicrometerEndToEndTest.java
+++ b/system-tests/telemetry/telemetry-test-runner/src/test/java/org/eclipse/edc/test/e2e/tracing/MicrometerEndToEndTest.java
@@ -18,6 +18,9 @@ import jakarta.json.Json;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.stream.Stream;
+
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,13 +60,20 @@ public class MicrometerEndToEndTest extends BaseTelemetryEndToEndTest {
 
         var metrics = metricsResponseBody.split("\n");
 
-        assertThat(metrics)
-                .anyMatch(it -> it.startsWith("executor_")) // ExecutorMetrics added by MicrometerExtension
-                .anyMatch(it -> it.startsWith("jvm_memory_")) // JvmMemoryMetrics added by MicrometerExtension
-                .anyMatch(it -> it.startsWith("jvm_gc")) // JvmGcMetrics added by MicrometerExtension
-                .anyMatch(it -> it.startsWith("system_cpu_")) // ProcessorMetrics added by MicrometerExtension
-                .anyMatch(it -> it.startsWith("jvm_threads_")) // JvmThreadMetrics added by MicrometerExtension
-                .anyMatch(it -> it.startsWith("jetty_")) // Added by JettyMicrometerExtension
-                .anyMatch(it -> it.startsWith("http_client_")); // OkHttp metrics
+        Stream.of(
+                        "executor_", // ExecutorMetrics added by MicrometerExtension
+                        "jvm_memory_", // JvmMemoryMetrics added by MicrometerExtension
+                        "jvm_gc", // JvmGcMetrics added by MicrometerExtension
+                        "system_cpu_", // ProcessorMetrics added by MicrometerExtension
+                        "jvm_threads_", // JvmThreadMetrics added by MicrometerExtension
+                        "jetty_", // Added by JettyMicrometerExtension
+                        "http_client_" // OkHttp metrics
+                )
+                .forEach(metricPrefix -> {
+                    assertThat(metrics)
+                            .overridingErrorMessage(() -> "expecting at least one metric starting with '%s', but got %s"
+                                    .formatted(metricPrefix, Arrays.toString(metrics)))
+                            .anyMatch(it -> it.startsWith(metricPrefix));
+                });
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Clearly split opentelemetry versions (as explained here: https://opentelemetry.io/docs/languages/java/intro/#repositories) and bump the main one to 1.63.0

## Why it does that

Solve CVE

## Further notes

I bumped the instrumentation to the latest 1.x, as with 2.x was breaking e2e tests, leaving this update for the future


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
