### PR TITLE
build: bump dps-tck to 1.2.0

### DIFF
--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingFlowControllerExtension.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/DataPlaneSignalingFlowControllerExtension.java
@@ -63,7 +63,7 @@ public class DataPlaneSignalingFlowControllerExtension implements ServiceExtensi
         typeTransformerRegistry.register(new DataAddressToDspDataAddressTransformer());
         typeTransformerRegistry.register(new DataFlowStatusMessageToDataFlowResponseTransformer());
         typeTransformerRegistry.register(new DspDataAddressToDataAddressTransformer());
-        return new DataPlaneSignalingFlowController(apiConfiguration.createPublicUri(), dataPlaneSelectorService,
+        return new DataPlaneSignalingFlowController(dataPlaneSelectorService,
                 typeTransformerRegistry, clientFactory, dataAddressStore, assetIndex);
     }
 }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/SignalingApiConfiguration.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/SignalingApiConfiguration.java
@@ -16,13 +16,7 @@ package org.eclipse.edc.signaling;
 
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.runtime.metamodel.annotation.Settings;
-import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
-
-import java.net.URI;
-
-import static java.lang.String.format;
-import static java.util.Optional.ofNullable;
 
 @Settings
 record SignalingApiConfiguration(
@@ -46,13 +40,4 @@ record SignalingApiConfiguration(
     private static final String DEFAULT_SIGNALING_PATH = "/api/signaling";
     private static final int DEFAULT_SIGNALING_PORT = 8182;
 
-    public URI createPublicUri() {
-        var callbackAddress = ofNullable(publicUri).orElseGet(() -> format("http://localhost:%s%s", port(), path()));
-
-        try {
-            return URI.create(callbackAddress);
-        } catch (IllegalArgumentException e) {
-            throw new EdcException("Error creating signaling endpoint url", e);
-        }
-    }
 }

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/domain/DataFlowPrepareMessage.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/domain/DataFlowPrepareMessage.java
@@ -27,7 +27,7 @@ public final class DataFlowPrepareMessage {
     private String agreementId;
     private String datasetId;
     private URI callbackAddress;
-    private String transferType;
+    private String profile;
     private List<String> labels;
     private Map<String, Object> metadata;
     private Map<String, Object> claims;
@@ -67,8 +67,8 @@ public final class DataFlowPrepareMessage {
         return callbackAddress;
     }
 
-    public String getTransferType() {
-        return transferType;
+    public String getProfile() {
+        return profile;
     }
 
     public List<String> getLabels() {
@@ -134,13 +134,8 @@ public final class DataFlowPrepareMessage {
             return this;
         }
 
-        public Builder callbackAddress(URI callbackAddress) {
-            instance.callbackAddress = callbackAddress;
-            return this;
-        }
-
-        public Builder transferType(String transferType) {
-            instance.transferType = transferType;
+        public Builder profile(String profile) {
+            instance.profile = profile;
             return this;
         }
 

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/domain/DataFlowStartMessage.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/domain/DataFlowStartMessage.java
@@ -30,7 +30,7 @@ public final class DataFlowStartMessage {
     private String agreementId;
     private String datasetId;
     private URI callbackAddress;
-    private String transferType;
+    private String profile;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private DspDataAddress dataAddress;
     private List<String> labels;
@@ -72,8 +72,8 @@ public final class DataFlowStartMessage {
         return callbackAddress;
     }
 
-    public String getTransferType() {
-        return transferType;
+    public String getProfile() {
+        return profile;
     }
 
     public DspDataAddress getDataAddress() {
@@ -143,13 +143,8 @@ public final class DataFlowStartMessage {
             return this;
         }
 
-        public Builder callbackAddress(URI callbackAddress) {
-            instance.callbackAddress = callbackAddress;
-            return this;
-        }
-
-        public Builder transferType(String transferType) {
-            instance.transferType = transferType;
+        public Builder profile(String profile) {
+            instance.profile = profile;
             return this;
         }
 

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowController.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowController.java
@@ -38,7 +38,6 @@ import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.jetbrains.annotations.NotNull;
 
-import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -56,17 +55,15 @@ import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
  */
 public class DataPlaneSignalingFlowController implements DataFlowController {
 
-    private final URI callbackUri;
     private final DataPlaneSelectorService selectorClient;
     private final TypeTransformerRegistry typeTransformerRegistry;
     private final ClientFactory clientFactory;
     private final DataAddressStore dataAddressStore;
     private final AssetIndex assetIndex;
 
-    public DataPlaneSignalingFlowController(URI callbackUri, DataPlaneSelectorService selectorClient,
+    public DataPlaneSignalingFlowController(DataPlaneSelectorService selectorClient,
                                             TypeTransformerRegistry typeTransformerRegistry, ClientFactory clientFactory,
                                             DataAddressStore dataAddressStore, AssetIndex assetIndex) {
-        this.callbackUri = callbackUri;
         this.selectorClient = selectorClient;
         this.typeTransformerRegistry = typeTransformerRegistry;
         this.clientFactory = clientFactory;
@@ -94,8 +91,7 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
                 .processId(transferProcess.getId())
                 .agreementId(transferProcess.getContractId())
                 .datasetId(transferProcess.getAssetId())
-                .callbackAddress(callbackUri)
-                .transferType(transferProcess.getTransferType())
+                .profile(transferProcess.getTransferType())
                 .claims(transferProcess.getClaims());
 
         var dataplaneMetadata = transferProcess.getDataplaneMetadata();
@@ -129,8 +125,7 @@ public class DataPlaneSignalingFlowController implements DataFlowController {
                 .processId(transferProcess.getId())
                 .agreementId(transferProcess.getContractId())
                 .datasetId(transferProcess.getAssetId())
-                .callbackAddress(callbackUri)
-                .transferType(transferProcess.getTransferType())
+                .profile(transferProcess.getTransferType())
                 .claims(transferProcess.getClaims());
 
         var dataAddress = dataAddressStore.resolve(transferProcess).orElse(f -> null);

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowControllerTest.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/logic/DataPlaneSignalingFlowControllerTest.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -70,8 +69,7 @@ public class DataPlaneSignalingFlowControllerTest {
     private final DataAddressStore dataAddressStore = mock();
     private final AssetIndex assetIndex = mock();
 
-    private final DataPlaneSignalingFlowController flowController = new DataPlaneSignalingFlowController(
-            URI.create("http://localhost"), selectorService,
+    private final DataPlaneSignalingFlowController flowController = new DataPlaneSignalingFlowController(selectorService,
             typeTransformerRegistry, clientFactory, dataAddressStore, assetIndex);
 
     @NotNull

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ atomikos = "6.0.1"
 awaitility = "4.2.2"
 bouncyCastle-jdk18on = "1.84"
 cloudEvents = "4.1.1"
-dataplane-sdk = "0.0.10-SNAPSHOT"
+dataplane-sdk = "1.0.0"
 edc = "0.19.0-SNAPSHOT"
 failsafe = "3.3.2"
 h2 = "2.4.240"
@@ -51,7 +51,8 @@ assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
 bouncyCastle-bcpkixJdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncyCastle-jdk18on" }
 bouncyCastle-bcprovJdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncyCastle-jdk18on" }
-dataplane-sdk = { module = "org.eclipse.dataplane-core:dataplane-sdk", version.ref = "dataplane-sdk" }
+dataplane-sdk-core = { module = "org.eclipse.dataplane-core:dataplane-sdk-core", version.ref = "dataplane-sdk" }
+dataplane-sdk-jakarta-ee = { module = "org.eclipse.dataplane-core:dataplane-sdk-jakarta-ee", version.ref = "dataplane-sdk" }
 dnsOverHttps = { module = "com.squareup.okhttp3:okhttp-dnsoverhttps", version.ref = "okhttp" }
 edc-runtime-metamodel = { module = "org.eclipse.edc:runtime-metamodel", version.ref = "edc" }
 failsafe-core = { module = "dev.failsafe:failsafe", version.ref = "failsafe" }
@@ -112,7 +113,7 @@ nats = { module = "io.nats:jnats", version = "2.25.3" }
 
 dcp-tck = { module = "org.eclipse.dataspacetck.dcp:dcp-tck", version = "1.0.2" }
 dsp-tck = { module = "org.eclipse.dataspacetck.dsp:dsp-tck", version = "1.0.1" }
-dps-tck = { module = "org.eclipse.dataspacetck.dps:dps-tck", version = "1.1.2" }
+dps-tck = { module = "org.eclipse.dataspacetck.dps:dps-tck", version = "1.2.0" }
 
 [bundles]
 jackson = ["jackson-annotations", "jackson-databind"]

--- a/system-tests/e2e-transfer-test/signaling-data-plane/build.gradle.kts
+++ b/system-tests/e2e-transfer-test/signaling-data-plane/build.gradle.kts
@@ -18,7 +18,8 @@ plugins {
 dependencies {
     implementation(project(":core:common:runtime-core"))
     implementation(project(":extensions:common:http"))
-    implementation(libs.dataplane.sdk)
+    implementation(libs.dataplane.sdk.core)
+    implementation(libs.dataplane.sdk.jakarta.ee)
 }
 
 edcBuild {

--- a/system-tests/e2e-transfer-test/signaling-data-plane/src/main/java/org/eclipse/edc/test/runtime/signaling/SignalingDataPlaneRuntimeExtension.java
+++ b/system-tests/e2e-transfer-test/signaling-data-plane/src/main/java/org/eclipse/edc/test/runtime/signaling/SignalingDataPlaneRuntimeExtension.java
@@ -22,6 +22,8 @@ import org.eclipse.dataplane.domain.Result;
 import org.eclipse.dataplane.domain.dataflow.DataFlow;
 import org.eclipse.dataplane.domain.registration.Oauth2ClientCredentialsAuthorization;
 import org.eclipse.dataplane.logic.OnPrepare;
+import org.eclipse.dataplane.port.DataPlaneRegistrationApiController;
+import org.eclipse.dataplane.port.DataPlaneSignalingApiController;
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
@@ -69,12 +71,12 @@ public class SignalingDataPlaneRuntimeExtension implements ServiceExtension {
                 .id(dataplaneId)
                 .registerAuthorization(new Oauth2ClientCredentialsAuthorization())
                 .endpoint(apiConfiguration.dataFlowEndpoint())
-                .transferType("Finite-PUSH")
-                .transferType("Finite-PULL")
-                .transferType("NonFinite-PUSH")
-                .transferType("NonFinite-PULL")
-                .transferType("AsyncPrepare-PUSH")
-                .transferType("AsyncStart-PULL")
+                .profile("Finite-PUSH")
+                .profile("Finite-PULL")
+                .profile("NonFinite-PUSH")
+                .profile("NonFinite-PULL")
+                .profile("AsyncPrepare-PUSH")
+                .profile("AsyncStart-PULL")
                 .onPrepare(new DataplaneOnPrepare())
                 .onStart(this::startDataFlow)
                 .onStarted(this::receiveDataFlow)
@@ -87,8 +89,8 @@ public class SignalingDataPlaneRuntimeExtension implements ServiceExtension {
 
         dataplane = builder.build();
 
-        webService.registerResource(dataplane.controller());
-        webService.registerResource(dataplane.registrationController());
+        webService.registerResource(new DataPlaneSignalingApiController(dataplane));
+        webService.registerResource(new DataPlaneRegistrationApiController(dataplane));
         webService.registerResource(new DataController(monitor));
         webService.registerResource(new ControlController(monitor, dataplane, apiConfiguration));
     }
@@ -99,7 +101,7 @@ public class SignalingDataPlaneRuntimeExtension implements ServiceExtension {
     }
 
     private @NotNull Result<DataFlow> startDataFlow(DataFlow dataFlow) {
-        switch (dataFlow.getTransferType()) {
+        switch (dataFlow.getProfile()) {
             case "NonFinite-PUSH" -> {
                 if (dataFlow.getDataAddress() == null) {
                     return Result.failure(new InvalidRequestException("DataAddress should not be null for PUSH transfers"));
@@ -129,7 +131,7 @@ public class SignalingDataPlaneRuntimeExtension implements ServiceExtension {
                 return Result.success(dataFlow);
             }
             case "NonFinite-PULL", "Finite-PULL" -> {
-                var dataAddress = new DataAddress(dataFlow.getTransferType(), "http", apiConfiguration.dataSourceEndpoint(), emptyList());
+                var dataAddress = new DataAddress("http", apiConfiguration.dataSourceEndpoint(), emptyList());
                 dataFlow.setDataAddress(dataAddress);
                 return Result.success(dataFlow);
             }
@@ -138,7 +140,7 @@ public class SignalingDataPlaneRuntimeExtension implements ServiceExtension {
                 return Result.success(dataFlow);
             }
             default -> {
-                return Result.failure(new RuntimeException("TransferType %s not supported".formatted(dataFlow.getTransferType())));
+                return Result.failure(new RuntimeException("TransferType %s not supported".formatted(dataFlow.getProfile())));
             }
         }
     }
@@ -150,7 +152,7 @@ public class SignalingDataPlaneRuntimeExtension implements ServiceExtension {
     }
 
     private Result<DataFlow> receiveDataFlow(DataFlow dataFlow) {
-        switch (dataFlow.getTransferType()) {
+        switch (dataFlow.getProfile()) {
             case "NonFinite-PULL" -> {
                 var sourceUri = URI.create(dataFlow.getDataAddress().endpoint());
                 var future = executor.scheduleAtFixedRate(() -> requestData(dataFlow, sourceUri), 0, 200, TimeUnit.MILLISECONDS);
@@ -240,11 +242,11 @@ public class SignalingDataPlaneRuntimeExtension implements ServiceExtension {
     private class DataplaneOnPrepare implements OnPrepare {
         @Override
         public Result<DataFlow> action(DataFlow dataFlow) {
-            if (dataFlow.getTransferType().startsWith("AsyncPrepare-")) {
+            if (dataFlow.getProfile().startsWith("AsyncPrepare-")) {
                 dataFlow.transitionToPreparing();
                 return Result.success(dataFlow);
             }
-            var destination = new DataAddress("Finite-PUSH", "http", apiConfiguration.receiveDataEndpoint(), emptyList());
+            var destination = new DataAddress("http", apiConfiguration.receiveDataEndpoint(), emptyList());
             dataFlow.setDataAddress(destination);
             return Result.success(dataFlow);
         }

--- a/system-tests/tck/dps-tck-tests/src/test/java/org/eclipse/edc/tck/dps/DpsTckTest.java
+++ b/system-tests/tck/dps-tck-tests/src/test/java/org/eclipse/edc/tck/dps/DpsTckTest.java
@@ -43,6 +43,7 @@ public class DpsTckTest {
     private static final int TCK_PORT = getFreePort();
     private static final URI TCK_WEBHOOK_URL = URI.create("http://localhost:" + getFreePort() + "/tck");
     private static final URI PROTOCOL_URL = URI.create("http://localhost:" + getFreePort() + "/protocol");
+    private static final URI SIGNALING_URL = URI.create("http://localhost:%d/api/signaling".formatted(getFreePort()));
 
     @RegisterExtension
     static RuntimeExtension runtime = ComponentRuntimeExtension.Builder.newInstance()
@@ -52,7 +53,7 @@ public class DpsTckTest {
                     .endpoint("default", () -> URI.create("http://localhost:%d/api".formatted(getFreePort())))
                     .endpoint("management", () -> URI.create("http://localhost:%d/api/management".formatted(getFreePort())))
                     .endpoint("protocol", () -> PROTOCOL_URL)
-                    .endpoint("signaling", () -> URI.create("http://localhost:%d/api/signaling".formatted(getFreePort())))
+                    .endpoint("signaling", () -> SIGNALING_URL)
                     .endpoint("tck", () -> TCK_WEBHOOK_URL)
                     .build())
             .configurationProvider(() -> ConfigFactory.fromMap(Map.of(
@@ -74,6 +75,7 @@ public class DpsTckTest {
         properties.put("dataspacetck.port", String.valueOf(TCK_PORT));
         properties.put("dataspacetck.dps.controlplane.webhook.url", TCK_WEBHOOK_URL.toString());
         properties.put("dataspacetck.dps.controlplane.protocol.url", PROTOCOL_URL + "/2025-1");
+        properties.put("dataspacetck.dps.controlplane.signaling.url", SIGNALING_URL.toString());
 
         var result = TckRuntime.Builder.newInstance()
                 .properties(properties)


### PR DESCRIPTION
## What this PR changes/adds

Bumps DPS-TCK to 1.2.0, that aligns with dataplane-signaling 1.0-RC3.

**Breaking change** as there have been breaking changes between dataplane-signaling 1.0-RC2 and RC3.
Update your dataplanes accordingly

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
