### PR TITLE
feat: support java 25 compilation

### DIFF
--- a/core/common/lib/core-lib/src/main/java/org/eclipse/edc/keys/keyparsers/PemParser.java
+++ b/core/common/lib/core-lib/src/main/java/org/eclipse/edc/keys/keyparsers/PemParser.java
@@ -76,7 +76,8 @@ public class PemParser implements KeyParser {
                     .map(keyPair -> keyPair.getPrivate() != null ? keyPair.getPrivate() : keyPair.getPublic())
                     .findFirst()
                     .map(Result::success)
-                    .orElseGet(() -> Result.failure("PEM-encoded structure did not contain a private key."));
+                    .orElseGet(() -> Result.failure("PEM-encoded structure did not contain a private key."))
+                    .map(Key.class::cast);
         }
 
         return keypair.mapEmpty();


### PR DESCRIPTION
## What this PR changes/adds

Supports java 25 compilation

## Why it does that

the `map` at line 76 will return an `AsymmetricKey` in java 25 as it's the highest common super interface for `PublicKey` and `PrivateKey`, but this need to be cast to `Key` to satisfy the signature boundary.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5880

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
