### PR TITLE
fix: add conversion edc endpoint to dspace data address if present

### DIFF
--- a/core/common/lib/jsonld-lib/src/main/java/org/eclipse/edc/transform/transformer/dspace/from/JsonObjectFromDataAddressDspaceTransformer.java
+++ b/core/common/lib/jsonld-lib/src/main/java/org/eclipse/edc/transform/transformer/dspace/from/JsonObjectFromDataAddressDspaceTransformer.java
@@ -28,11 +28,13 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Set;
 
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.types.domain.DataAddress.EDC_DATA_ADDRESS_TYPE_PROPERTY;
 import static org.eclipse.edc.transform.transformer.dspace.DataAddressDspaceSerialization.DSPACE_DATAADDRESS_TYPE_TERM;
 import static org.eclipse.edc.transform.transformer.dspace.DataAddressDspaceSerialization.ENDPOINT_PROPERTIES_PROPERTY_TERM;
 import static org.eclipse.edc.transform.transformer.dspace.DataAddressDspaceSerialization.ENDPOINT_PROPERTY_NAME_PROPERTY_TERM;
 import static org.eclipse.edc.transform.transformer.dspace.DataAddressDspaceSerialization.ENDPOINT_PROPERTY_PROPERTY_TYPE_TERM;
+import static org.eclipse.edc.transform.transformer.dspace.DataAddressDspaceSerialization.ENDPOINT_PROPERTY_TERM;
 import static org.eclipse.edc.transform.transformer.dspace.DataAddressDspaceSerialization.ENDPOINT_PROPERTY_VALUE_PROPERTY_TERM;
 import static org.eclipse.edc.transform.transformer.dspace.DataAddressDspaceSerialization.ENDPOINT_TYPE_PROPERTY_TERM;
 
@@ -57,11 +59,16 @@ public class JsonObjectFromDataAddressDspaceTransformer extends AbstractNamespac
                 .map(it -> endpointProperty(it.getKey(), it.getValue(), context))
                 .collect(JsonCollectors.toJsonArray());
 
-        return jsonFactory.createObjectBuilder()
+        var builder = jsonFactory.createObjectBuilder()
                 .add(TYPE, forNamespace(DSPACE_DATAADDRESS_TYPE_TERM))
                 .add(forNamespace(ENDPOINT_TYPE_PROPERTY_TERM), createId(jsonFactory, dataAddress.getType()))
-                .add(forNamespace(ENDPOINT_PROPERTIES_PROPERTY_TERM), endpointProperties)
-                .build();
+                .add(forNamespace(ENDPOINT_PROPERTIES_PROPERTY_TERM), endpointProperties);
+
+        var endpoint = dataAddress.getStringProperty(EDC_NAMESPACE + "endpoint");
+        if (endpoint != null) {
+            builder.add(forNamespace(ENDPOINT_PROPERTY_TERM), endpoint);
+        }
+        return builder.build();
     }
 
     private JsonObject endpointProperty(String key, Object value, TransformerContext context) {

--- a/core/common/lib/jsonld-lib/src/test/java/org/eclipse/edc/transform/transformer/dspace/from/JsonObjectFromDataAddressDspaceTransformerTest.java
+++ b/core/common/lib/jsonld-lib/src/test/java/org/eclipse/edc/transform/transformer/dspace/from/JsonObjectFromDataAddressDspaceTransformerTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.transform.transformer.dspace.DataAddressDspaceSerialization.ENDPOINT_PROPERTIES_PROPERTY_TERM;
 import static org.eclipse.edc.transform.transformer.dspace.DataAddressDspaceSerialization.ENDPOINT_PROPERTY_NAME_PROPERTY_TERM;
 import static org.eclipse.edc.transform.transformer.dspace.DataAddressDspaceSerialization.ENDPOINT_PROPERTY_TERM;
@@ -53,6 +54,7 @@ class JsonObjectFromDataAddressDspaceTransformerTest {
         var dataAddress = DataAddress.Builder.newInstance()
                 .type("https://w3id.org/idsa/v4.1/HTTP")
                 .property("endpoint", "https://example.com")
+                .property(EDC_NAMESPACE + "endpoint", "https://example.com")
                 .property("authorization", "secret-token")
                 .property("foo", "bar")
                 .build();
@@ -61,8 +63,8 @@ class JsonObjectFromDataAddressDspaceTransformerTest {
 
         assertThat(jsonObject).isNotNull();
         assertThat(jsonObject.getJsonObject(DSP_NAMESPACE.toIri(ENDPOINT_TYPE_PROPERTY_TERM)).getString(ID)).isEqualTo("https://w3id.org/idsa/v4.1/HTTP");
-        assertThat(jsonObject.get(DSP_NAMESPACE.toIri(ENDPOINT_PROPERTY_TERM))).isEqualTo(null);
-        assertThat(jsonObject.getJsonArray(DSP_NAMESPACE.toIri(ENDPOINT_PROPERTIES_PROPERTY_TERM))).hasSize(3)
+        assertThat(jsonObject.getString(DSP_NAMESPACE.toIri(ENDPOINT_PROPERTY_TERM))).isEqualTo("https://example.com");
+        assertThat(jsonObject.getJsonArray(DSP_NAMESPACE.toIri(ENDPOINT_PROPERTIES_PROPERTY_TERM))).hasSize(4)
                 .anySatisfy(jv -> {
                     assertThat(jv.asJsonObject().getString(DSP_NAMESPACE.toIri(ENDPOINT_PROPERTY_NAME_PROPERTY_TERM))).isEqualTo("authorization");
                     assertThat(jv.asJsonObject().getString(DSP_NAMESPACE.toIri(ENDPOINT_PROPERTY_VALUE_PROPERTY_TERM))).isEqualTo("secret-token");
@@ -72,6 +74,10 @@ class JsonObjectFromDataAddressDspaceTransformerTest {
                 })
                 .anySatisfy(jv -> {
                     assertThat(jv.asJsonObject().getString(DSP_NAMESPACE.toIri(ENDPOINT_PROPERTY_NAME_PROPERTY_TERM))).isEqualTo("endpoint");
+                    assertThat(jv.asJsonObject().getString(DSP_NAMESPACE.toIri(ENDPOINT_PROPERTY_VALUE_PROPERTY_TERM))).isEqualTo("https://example.com");
+                })
+                .anySatisfy(jv -> {
+                    assertThat(jv.asJsonObject().getString(DSP_NAMESPACE.toIri(ENDPOINT_PROPERTY_NAME_PROPERTY_TERM))).isEqualTo(EDC_NAMESPACE + "endpoint");
                     assertThat(jv.asJsonObject().getString(DSP_NAMESPACE.toIri(ENDPOINT_PROPERTY_VALUE_PROPERTY_TERM))).isEqualTo("https://example.com");
                 });
     }


### PR DESCRIPTION
## What this PR changes/adds

 add conversion edc endpoint to dspace data address if present

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5890 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
