### PR TITLE
fix: wrong type when reason validation fails

### DIFF
--- a/data-protocols/dsp/dsp-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/to/JsonObjectToTransferSuspensionMessageTransformer.java
+++ b/data-protocols/dsp/dsp-lib/src/main/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/type/to/JsonObjectToTransferSuspensionMessageTransformer.java
@@ -35,7 +35,6 @@ import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPA
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_PROVIDER_PID_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspPropertyAndTypeNames.DSPACE_PROPERTY_REASON_TERM;
 import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_SUSPENSION_MESSAGE_TERM;
-import static org.eclipse.edc.protocol.dsp.spi.type.DspTransferProcessPropertyAndTypeNames.DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM;
 
 public class JsonObjectToTransferSuspensionMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, TransferSuspensionMessage> {
 
@@ -82,7 +81,7 @@ public class JsonObjectToTransferSuspensionMessageTransformer extends AbstractNa
             } else {
                 context.problem()
                         .unexpectedType()
-                        .type(forNamespace(DSPACE_TYPE_TRANSFER_TERMINATION_MESSAGE_TERM))
+                        .type(forNamespace(DSPACE_TYPE_TRANSFER_SUSPENSION_MESSAGE_TERM))
                         .property(forNamespace(DSPACE_PROPERTY_REASON_TERM))
                         .actual(reasons.getValueType())
                         .expected(ARRAY)

--- a/data-protocols/dsp/dsp-lib/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/to/JsonObjectToTransferSuspensionMessageTransformerTest.java
+++ b/data-protocols/dsp/dsp-lib/src/test/java/org/eclipse/edc/protocol/dsp/transferprocess/transform/to/JsonObjectToTransferSuspensionMessageTransformerTest.java
@@ -104,4 +104,21 @@ class JsonObjectToTransferSuspensionMessageTransformerTest {
         verify(context).reportProblem(anyString());
     }
 
+    @Test
+    void shouldReportError_whenEmptyReason() {
+        when(context.problem()).thenReturn(new ProblemBuilder(context));
+
+        var json = createObjectBuilder()
+                .add(TYPE, DSP_NAMESPACE.toIri(DSPACE_TYPE_TRANSFER_SUSPENSION_MESSAGE_TERM))
+                .add(DSP_NAMESPACE.toIri(DSPACE_PROPERTY_CONSUMER_PID_TERM), "consumerPid")
+                .add(DSP_NAMESPACE.toIri(DSPACE_PROPERTY_PROVIDER_PID_TERM), "providerPid")
+                .add(DSP_NAMESPACE.toIri(DSPACE_PROPERTY_CODE_TERM), "testCode")
+                .add(DSP_NAMESPACE.toIri(DSPACE_PROPERTY_REASON_TERM), Json.createArrayBuilder())
+                .build();
+
+        transformer.transform(TestJsonLd.expand(json), context);
+
+        verify(context).reportProblem(anyString());
+    }
+
 }


### PR DESCRIPTION
## What this PR changes/adds

wrong type when reason validation fails

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
