### PR TITLE
feat: split autocreate config

### DIFF
--- a/core/common/lib/core-lib/src/main/java/org/eclipse/edc/nats/subscriber/NatsSubscriber.java
+++ b/core/common/lib/core-lib/src/main/java/org/eclipse/edc/nats/subscriber/NatsSubscriber.java
@@ -42,7 +42,8 @@ public abstract class NatsSubscriber {
     protected String subject;
     protected ExecutorService executorService;
     protected Monitor monitor;
-    protected boolean autoCreate = false;
+    protected boolean autoCreateStream = false;
+    protected boolean autoCreateConsumer = false;
     protected Integer batchSize = 100;
     protected Integer maxWait = 100;
     // externally contributed connect options (e.g. NKey authentication); the server URL is overwritten
@@ -50,16 +51,28 @@ public abstract class NatsSubscriber {
     private Connection connection;
 
 
+    public boolean isAutoCreateStream() {
+        return autoCreateStream;
+    }
+
+    public boolean isAutoCreateConsumer() {
+        return autoCreateConsumer;
+    }
+
     public void prepare() {
-        if (!autoCreate) {
+        if (!autoCreateStream && !autoCreateConsumer) {
             return;
         }
         try {
             var conn = getOrCreateConnection();
             conn.jetStream();
             var jsm = conn.jetStreamManagement();
-            createStream(jsm, stream, StorageType.Memory, subject);
-            createConsumer(jsm, stream, name, subject);
+            if (autoCreateStream) {
+                createStream(jsm, stream, StorageType.Memory, subject);
+            }
+            if (autoCreateConsumer) {
+                createConsumer(jsm, stream, name, subject);
+            }
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -178,8 +191,13 @@ public abstract class NatsSubscriber {
             return self();
         }
 
-        public B autoCreate(boolean autoCreate) {
-            subscriber.autoCreate = autoCreate;
+        public B autoCreateStream(boolean autoCreateStream) {
+            subscriber.autoCreateStream = autoCreateStream;
+            return self();
+        }
+
+        public B autoCreateConsumer(boolean autoCreateConsumer) {
+            subscriber.autoCreateConsumer = autoCreateConsumer;
             return self();
         }
 

--- a/core/common/lib/core-lib/src/test/java/org/eclipse/edc/nats/subscriber/NatsSubscriberPrepareTest.java
+++ b/core/common/lib/core-lib/src/test/java/org/eclipse/edc/nats/subscriber/NatsSubscriberPrepareTest.java
@@ -1,0 +1,157 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.nats.subscriber;
+
+import io.nats.client.JetStreamApiException;
+import io.nats.client.JetStreamManagement;
+import io.nats.client.Message;
+import io.nats.client.Nats;
+import org.eclipse.edc.nats.testfixtures.NatsEndToEndExtension;
+import org.eclipse.edc.spi.response.StatusResult;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.nats.NatsFunctions.streamExists;
+import static org.mockito.Mockito.mock;
+
+class NatsSubscriberPrepareTest {
+
+    private static final String STREAM_NAME = "prepare_test_stream";
+    private static final String CONSUMER_NAME = "prepare_test_consumer";
+    private static final String SUBJECT = "prepare.test.>";
+
+    @Order(0)
+    @RegisterExtension
+    static final NatsEndToEndExtension NATS_EXTENSION = new NatsEndToEndExtension();
+
+    private static JetStreamManagement jsm;
+
+    private final List<TestSubscriber> subscribers = new ArrayList<>();
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        jsm = Nats.connect(NATS_EXTENSION.getNatsUrl()).jetStreamManagement();
+    }
+
+    @AfterEach
+    void afterEach() {
+        subscribers.forEach(TestSubscriber::stop);
+        subscribers.clear();
+        if (streamExists(jsm, STREAM_NAME)) {
+            NATS_EXTENSION.deleteStream(STREAM_NAME);
+        }
+    }
+
+    @Test
+    void prepare_shouldNotCreateAnything_whenBothFlagsDisabled() {
+        subscriber(false, false).prepare();
+
+        assertThat(streamExists(jsm, STREAM_NAME)).isFalse();
+    }
+
+    @Test
+    void prepare_shouldCreateStreamOnly_whenOnlyStreamEnabled() {
+        subscriber(true, false).prepare();
+
+        assertThat(streamExists(jsm, STREAM_NAME)).isTrue();
+        assertThat(consumerExists()).isFalse();
+    }
+
+    @Test
+    void prepare_shouldCreateConsumerOnly_whenOnlyConsumerEnabled() {
+        NATS_EXTENSION.createStream(STREAM_NAME, SUBJECT);
+
+        subscriber(false, true).prepare();
+
+        assertThat(consumerExists()).isTrue();
+    }
+
+    @Test
+    void prepare_shouldNotCreateStream_whenOnlyConsumerEnabledAndStreamMissing() {
+        var subscriber = subscriber(false, true);
+
+        assertThat(streamExists(jsm, STREAM_NAME)).isFalse();
+        // creating a consumer on a non-existing stream is an error, the stream must be provisioned externally
+        assertThatThrownBy(subscriber::prepare).isInstanceOf(RuntimeException.class);
+        assertThat(streamExists(jsm, STREAM_NAME)).isFalse();
+    }
+
+    @Test
+    void prepare_shouldCreateBoth_whenBothFlagsEnabled() {
+        subscriber(true, true).prepare();
+
+        assertThat(streamExists(jsm, STREAM_NAME)).isTrue();
+        assertThat(consumerExists()).isTrue();
+    }
+
+    private boolean consumerExists() {
+        try {
+            return jsm.getConsumerInfo(STREAM_NAME, CONSUMER_NAME) != null;
+        } catch (JetStreamApiException e) {
+            if (e.getErrorCode() == 404) {
+                return false;
+            }
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private TestSubscriber subscriber(boolean autoCreateStream, boolean autoCreateConsumer) {
+        var subscriber = TestSubscriber.Builder.newInstance()
+                .url(NATS_EXTENSION.getNatsUrl())
+                .name(CONSUMER_NAME)
+                .stream(STREAM_NAME)
+                .subject(SUBJECT)
+                .autoCreateStream(autoCreateStream)
+                .autoCreateConsumer(autoCreateConsumer)
+                .monitor(mock())
+                .build();
+        subscribers.add(subscriber);
+        return subscriber;
+    }
+
+    private static class TestSubscriber extends NatsSubscriber {
+
+        @Override
+        protected StatusResult<Void> handleMessage(Message message) {
+            return StatusResult.success();
+        }
+
+        static class Builder extends NatsSubscriber.Builder<TestSubscriber, Builder> {
+
+            protected Builder(TestSubscriber subscriber) {
+                super(subscriber);
+            }
+
+            static Builder newInstance() {
+                return new Builder(new TestSubscriber());
+            }
+
+            @Override
+            public Builder self() {
+                return this;
+            }
+        }
+    }
+}

--- a/extensions/control-plane/tasks/nats/subscriber/negotiation-tasks-subscriber-nats/src/main/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/subscriber/NatsContractNegotiationSubscriberExtension.java
+++ b/extensions/control-plane/tasks/nats/subscriber/negotiation-tasks-subscriber-nats/src/main/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/subscriber/NatsContractNegotiationSubscriberExtension.java
@@ -61,7 +61,8 @@ public class NatsContractNegotiationSubscriberExtension implements ServiceExtens
     @Inject(required = false)
     private Options authenticationOptions;
 
-    private NatsContractNegotiationTaskSubscriber subscriber;
+    // visible for testing
+    NatsContractNegotiationTaskSubscriber subscriber;
 
 
     @Override
@@ -75,7 +76,8 @@ public class NatsContractNegotiationSubscriberExtension implements ServiceExtens
                 .monitor(monitor)
                 .mapperSupplier(() -> typeManager.getMapper())
                 .taskExecutor(taskExecutor)
-                .autoCreate(subscriberConfig.autoCreate)
+                .autoCreateStream(subscriberConfig.autoCreate() || subscriberConfig.autoCreateStream())
+                .autoCreateConsumer(subscriberConfig.autoCreate() || subscriberConfig.autoCreateConsumer())
                 .executorInstrumentation(executorInstrumentation)
                 .batchSize(subscriberConfig.batchSize)
                 .maxWait(subscriberConfig.maxWait)
@@ -113,8 +115,12 @@ public class NatsContractNegotiationSubscriberExtension implements ServiceExtens
             String url,
             @Setting(key = "edc.nats.cn.subscriber.name", description = "The name of the consumer for contract negotiation events", defaultValue = "cn-subscriber")
             String name,
-            @Setting(key = "edc.nats.cn.subscriber.autocreate", description = "When true, it will automatically create the stream and the consumer if not present", defaultValue = "false")
+            @Setting(key = "edc.nats.cn.subscriber.autocreate", description = "Convenience flag: when true, it will automatically create both the stream and the consumer if not present", defaultValue = "false")
             Boolean autoCreate,
+            @Setting(key = "edc.nats.cn.subscriber.stream.autocreate", description = "When true, it will automatically create the stream if not present", defaultValue = "false")
+            Boolean autoCreateStream,
+            @Setting(key = "edc.nats.cn.subscriber.consumer.autocreate", description = "When true, it will automatically create the consumer if not present", defaultValue = "false")
+            Boolean autoCreateConsumer,
             @Setting(key = "edc.nats.cn.subscriber.stream", description = "The stream name where to attach the consumer", defaultValue = "cn-stream")
             String stream,
             @Setting(key = "edc.nats.cn.subscriber.subject", description = "The subject of the consumer for contract negotiation events", defaultValue = "negotiations.>")

--- a/extensions/control-plane/tasks/nats/subscriber/negotiation-tasks-subscriber-nats/src/test/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/subscriber/NatsContractNegotiationSubscriberExtensionTest.java
+++ b/extensions/control-plane/tasks/nats/subscriber/negotiation-tasks-subscriber-nats/src/test/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/subscriber/NatsContractNegotiationSubscriberExtensionTest.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.contract.negotiation.subscriber;
+
+import org.eclipse.edc.boot.system.injection.ObjectFactory;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class NatsContractNegotiationSubscriberExtensionTest {
+
+    private static final String AUTOCREATE = "edc.nats.cn.subscriber.autocreate";
+    private static final String STREAM_AUTOCREATE = "edc.nats.cn.subscriber.stream.autocreate";
+    private static final String CONSUMER_AUTOCREATE = "edc.nats.cn.subscriber.consumer.autocreate";
+
+    @Test
+    void initialize_shouldNotAutoCreate_whenNoSettingProvided(ServiceExtensionContext context, ObjectFactory objectFactory) {
+        var subscriber = subscriberFor(Map.of(), context, objectFactory);
+
+        assertThat(subscriber.isAutoCreateStream()).isFalse();
+        assertThat(subscriber.isAutoCreateConsumer()).isFalse();
+    }
+
+    /**
+     * The legacy {@code edc.nats.cn.subscriber.autocreate} setting must keep provisioning both the stream and the
+     * consumer, while the granular settings only enable their own component.
+     */
+    @ParameterizedTest
+    @CsvSource({
+            "true,  false, false, true,  true",
+            "false, true,  false, true,  false",
+            "false, false, true,  false, true",
+            "false, true,  true,  true,  true",
+            "true,  true,  false, true,  true",
+    })
+    void initialize_shouldMapAutoCreateSettings(boolean autoCreate, boolean streamAutoCreate, boolean consumerAutoCreate,
+                                                boolean expectedStream, boolean expectedConsumer,
+                                                ServiceExtensionContext context, ObjectFactory objectFactory) {
+        var settings = Map.of(
+                AUTOCREATE, String.valueOf(autoCreate),
+                STREAM_AUTOCREATE, String.valueOf(streamAutoCreate),
+                CONSUMER_AUTOCREATE, String.valueOf(consumerAutoCreate)
+        );
+
+        var subscriber = subscriberFor(settings, context, objectFactory);
+
+        assertThat(subscriber.isAutoCreateStream()).isEqualTo(expectedStream);
+        assertThat(subscriber.isAutoCreateConsumer()).isEqualTo(expectedConsumer);
+    }
+
+    private NatsContractNegotiationTaskSubscriber subscriberFor(Map<String, String> settings, ServiceExtensionContext context,
+                                                                ObjectFactory objectFactory) {
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(settings));
+        var extension = objectFactory.constructInstance(NatsContractNegotiationSubscriberExtension.class);
+
+        extension.initialize(context);
+
+        return extension.subscriber;
+    }
+}

--- a/extensions/control-plane/tasks/nats/subscriber/transfer-tasks-subscriber-nats/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/subscriber/nats/NatsTransferProcessTaskSubscriberExtension.java
+++ b/extensions/control-plane/tasks/nats/subscriber/transfer-tasks-subscriber-nats/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/subscriber/nats/NatsTransferProcessTaskSubscriberExtension.java
@@ -61,7 +61,8 @@ public class NatsTransferProcessTaskSubscriberExtension implements ServiceExtens
     @Inject(required = false)
     private Options authenticationOptions;
 
-    private NatsTransferProcessTaskSubscriber subscriber;
+    // visible for testing
+    NatsTransferProcessTaskSubscriber subscriber;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
@@ -74,7 +75,8 @@ public class NatsTransferProcessTaskSubscriberExtension implements ServiceExtens
                 .monitor(monitor)
                 .mapperSupplier(() -> typeManager.getMapper())
                 .taskExecutor(taskExecutor)
-                .autoCreate(subscriberConfig.autoCreate)
+                .autoCreateStream(subscriberConfig.autoCreate() || subscriberConfig.autoCreateStream())
+                .autoCreateConsumer(subscriberConfig.autoCreate() || subscriberConfig.autoCreateConsumer())
                 .executorInstrumentation(executorInstrumentation)
                 .batchSize(subscriberConfig.batchSize)
                 .maxWait(subscriberConfig.maxWait)
@@ -113,11 +115,15 @@ public class NatsTransferProcessTaskSubscriberExtension implements ServiceExtens
             String url,
             @Setting(key = "edc.nats.tp.subscriber.name", description = "The name of the consumer for transfer process events", defaultValue = "tp-subscriber")
             String name,
-            @Setting(key = "edc.nats.tp.subscriber.autocreate", description = "When true, it will automatically create the stream and the consumer if not present", defaultValue = "false")
+            @Setting(key = "edc.nats.tp.subscriber.autocreate", description = "Convenience flag: when true, it will automatically create both the stream and the consumer if not present", defaultValue = "false")
             Boolean autoCreate,
+            @Setting(key = "edc.nats.tp.subscriber.stream.autocreate", description = "When true, it will automatically create the stream if not present", defaultValue = "false")
+            Boolean autoCreateStream,
+            @Setting(key = "edc.nats.tp.subscriber.consumer.autocreate", description = "When true, it will automatically create the consumer if not present", defaultValue = "false")
+            Boolean autoCreateConsumer,
             @Setting(key = "edc.nats.tp.subscriber.stream", description = "The stream name where to attach the consumer", defaultValue = "tp-stream")
             String stream,
-            @Setting(key = "edc.nats.tp.subscriber.subject", description = "The subject of the consumer for contract negotiation events", defaultValue = "transfers.>")
+            @Setting(key = "edc.nats.tp.subscriber.subject", description = "The subject of the consumer for transfer process events", defaultValue = "transfers.>")
             String subject,
             @Setting(key = "edc.nats.tp.subscriber.batch-size", description = "The size of the batch when fetching messages", defaultValue = "100")
             Integer batchSize,

--- a/extensions/control-plane/tasks/nats/subscriber/transfer-tasks-subscriber-nats/src/test/java/org/eclipse/edc/virtual/controlplane/transfer/subscriber/nats/NatsTransferProcessTaskSubscriberExtensionTest.java
+++ b/extensions/control-plane/tasks/nats/subscriber/transfer-tasks-subscriber-nats/src/test/java/org/eclipse/edc/virtual/controlplane/transfer/subscriber/nats/NatsTransferProcessTaskSubscriberExtensionTest.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.virtual.controlplane.transfer.subscriber.nats;
+
+import org.eclipse.edc.boot.system.injection.ObjectFactory;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class NatsTransferProcessTaskSubscriberExtensionTest {
+
+    private static final String AUTOCREATE = "edc.nats.tp.subscriber.autocreate";
+    private static final String STREAM_AUTOCREATE = "edc.nats.tp.subscriber.stream.autocreate";
+    private static final String CONSUMER_AUTOCREATE = "edc.nats.tp.subscriber.consumer.autocreate";
+
+    @Test
+    void initialize_shouldNotAutoCreate_whenNoSettingProvided(ServiceExtensionContext context, ObjectFactory objectFactory) {
+        var subscriber = subscriberFor(Map.of(), context, objectFactory);
+
+        assertThat(subscriber.isAutoCreateStream()).isFalse();
+        assertThat(subscriber.isAutoCreateConsumer()).isFalse();
+    }
+
+    /**
+     * The legacy {@code edc.nats.tp.subscriber.autocreate} setting must keep provisioning both the stream and the
+     * consumer, while the granular settings only enable their own component.
+     */
+    @ParameterizedTest
+    @CsvSource({
+            "true,  false, false, true,  true",
+            "false, true,  false, true,  false",
+            "false, false, true,  false, true",
+            "false, true,  true,  true,  true",
+            "true,  true,  false, true,  true",
+    })
+    void initialize_shouldMapAutoCreateSettings(boolean autoCreate, boolean streamAutoCreate, boolean consumerAutoCreate,
+                                                boolean expectedStream, boolean expectedConsumer,
+                                                ServiceExtensionContext context, ObjectFactory objectFactory) {
+        var settings = Map.of(
+                AUTOCREATE, String.valueOf(autoCreate),
+                STREAM_AUTOCREATE, String.valueOf(streamAutoCreate),
+                CONSUMER_AUTOCREATE, String.valueOf(consumerAutoCreate)
+        );
+
+        var subscriber = subscriberFor(settings, context, objectFactory);
+
+        assertThat(subscriber.isAutoCreateStream()).isEqualTo(expectedStream);
+        assertThat(subscriber.isAutoCreateConsumer()).isEqualTo(expectedConsumer);
+    }
+
+    private NatsTransferProcessTaskSubscriber subscriberFor(Map<String, String> settings, ServiceExtensionContext context,
+                                                            ObjectFactory objectFactory) {
+        when(context.getConfig()).thenReturn(ConfigFactory.fromMap(settings));
+        var extension = objectFactory.constructInstance(NatsTransferProcessTaskSubscriberExtension.class);
+
+        extension.initialize(context);
+
+        return extension.subscriber;
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

split autocreate config on nats config for tp and cn

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5902 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
