### PR TITLE
feat: add vc cel helpers

### DIFF
--- a/core/common/cel-core/src/main/java/org/eclipse/edc/policy/cel/CelPolicyCoreExtension.java
+++ b/core/common/cel-core/src/main/java/org/eclipse/edc/policy/cel/CelPolicyCoreExtension.java
@@ -21,6 +21,8 @@ import org.eclipse.edc.connector.policy.monitor.spi.PolicyMonitorContext;
 import org.eclipse.edc.policy.cel.engine.CelExpressionEngine;
 import org.eclipse.edc.policy.cel.engine.CelExpressionEngineImpl;
 import org.eclipse.edc.policy.cel.function.CelExpressionFunction;
+import org.eclipse.edc.policy.cel.function.CelFunctionRegistry;
+import org.eclipse.edc.policy.cel.function.CelFunctionRegistryImpl;
 import org.eclipse.edc.policy.cel.function.context.AgreementContextMapper;
 import org.eclipse.edc.policy.cel.function.context.CelParticipantAgentClaimMapperRegistry;
 import org.eclipse.edc.policy.cel.function.context.CelParticipantAgentClaimMapperRegistryImpl;
@@ -77,6 +79,8 @@ public class CelPolicyCoreExtension implements ServiceExtension {
 
     private CelParticipantAgentClaimMapperRegistry claimMapperRegistry;
 
+    private CelFunctionRegistry celFunctionRegistry;
+
     @Inject
     private Monitor monitor;
 
@@ -107,7 +111,7 @@ public class CelPolicyCoreExtension implements ServiceExtension {
     @Provider
     public CelExpressionEngine policyExpressionEngine() {
         if (celExpressionEngine == null) {
-            celExpressionEngine = new CelExpressionEngineImpl(transactionContext, celExpressionStore, monitor);
+            celExpressionEngine = new CelExpressionEngineImpl(transactionContext, celExpressionStore, monitor, celFunctionRegistry());
         }
         return celExpressionEngine;
     }
@@ -127,6 +131,14 @@ public class CelPolicyCoreExtension implements ServiceExtension {
             claimMapperRegistry = new CelParticipantAgentClaimMapperRegistryImpl();
         }
         return claimMapperRegistry;
+    }
+
+    @Provider
+    public CelFunctionRegistry celFunctionRegistry() {
+        if (celFunctionRegistry == null) {
+            celFunctionRegistry = new CelFunctionRegistryImpl();
+        }
+        return celFunctionRegistry;
     }
 
 }

--- a/core/common/cel-core/src/main/java/org/eclipse/edc/policy/cel/engine/CelExpressionEngineImpl.java
+++ b/core/common/cel-core/src/main/java/org/eclipse/edc/policy/cel/engine/CelExpressionEngineImpl.java
@@ -24,6 +24,8 @@ import dev.cel.parser.CelStandardMacro;
 import dev.cel.runtime.CelEvaluationException;
 import dev.cel.runtime.CelRuntime;
 import dev.cel.runtime.CelRuntimeFactory;
+import org.eclipse.edc.policy.cel.function.CelFunctionRegistry;
+import org.eclipse.edc.policy.cel.function.CelFunctionTranslator;
 import org.eclipse.edc.policy.cel.model.CelExpression;
 import org.eclipse.edc.policy.cel.store.CelExpressionStore;
 import org.eclipse.edc.policy.model.Operator;
@@ -46,22 +48,46 @@ public class CelExpressionEngineImpl implements CelExpressionEngine {
     private final TransactionContext ctx;
     private final CelExpressionStore store;
     private final Monitor monitor;
+    private final CelFunctionRegistry functionRegistry;
 
-    private final CelCompiler celCompiler = CelCompilerFactory.standardCelCompilerBuilder()
-            .addVar("this", SimpleType.DYN)
-            .addVar("ctx", SimpleType.DYN)
-            .addVar("now", SimpleType.TIMESTAMP)
-            .setStandardMacros(CelStandardMacro.STANDARD_MACROS)
-            .setResultType(SimpleType.BOOL)
-            .build();
+    // built lazily on first use: extensions register their custom functions during initialization, which happens
+    // after this engine is constructed. Declarations and bindings are derived from a single snapshot of the registry,
+    // so the compiler can never type-check against a function the runtime cannot dispatch.
+    private volatile CelEnvironment environment;
 
-
-    private final CelRuntime celRuntime = CelRuntimeFactory.standardCelRuntimeBuilder().build();
-
-    public CelExpressionEngineImpl(TransactionContext ctx, CelExpressionStore store, Monitor monitor) {
+    public CelExpressionEngineImpl(TransactionContext ctx, CelExpressionStore store, Monitor monitor, CelFunctionRegistry functionRegistry) {
         this.ctx = ctx;
         this.store = store;
         this.monitor = monitor;
+        this.functionRegistry = functionRegistry;
+    }
+
+    private CelEnvironment environment() {
+        var current = environment;
+        if (current != null) {
+            return current;
+        }
+        synchronized (this) {
+            if (environment == null) {
+                var functions = functionRegistry.seal();
+                environment = new CelEnvironment(
+                        CelCompilerFactory.standardCelCompilerBuilder()
+                                .addVar("this", SimpleType.DYN)
+                                .addVar("ctx", SimpleType.DYN)
+                                .addVar("now", SimpleType.TIMESTAMP)
+                                .setStandardMacros(CelStandardMacro.STANDARD_MACROS)
+                                .setResultType(SimpleType.BOOL)
+                                .addFunctionDeclarations(CelFunctionTranslator.toDeclarations(functions))
+                                .build(),
+                        CelRuntimeFactory.standardCelRuntimeBuilder()
+                                .addFunctionBindings(CelFunctionTranslator.toBindings(functions))
+                                .build());
+            }
+            return environment;
+        }
+    }
+
+    private record CelEnvironment(CelCompiler compiler, CelRuntime runtime) {
     }
 
     @Override
@@ -121,7 +147,7 @@ public class CelExpressionEngineImpl implements CelExpressionEngine {
 
     private Result<Boolean> evaluateAst(CelAbstractSyntaxTree ast, Object leftOperand, Operator operator, Object rightOperand, Map<String, Object> params) {
         try {
-            var program = celRuntime.createProgram(ast);
+            var program = environment().runtime().createProgram(ast);
             Map<String, Object> newParams = new HashMap<>();
             newParams.put("now", ProtoTimeUtils.now());
             newParams.put("this", Map.of("leftOperand", leftOperand, "operator", operator.name(), "rightOperand", rightOperand));
@@ -158,9 +184,10 @@ public class CelExpressionEngineImpl implements CelExpressionEngine {
         CelAbstractSyntaxTree ast;
         try {
             // Parse the expression
-            ast = celCompiler.parse(expression).getAst();
+            var compiler = environment().compiler();
+            ast = compiler.parse(expression).getAst();
             // Type-check the expression for correctness
-            ast = celCompiler.check(ast).getAst();
+            ast = compiler.check(ast).getAst();
         } catch (CelValidationException e) {
             return Result.failure("Failed to validate expression. Reason: " + e.getMessage());
         }

--- a/core/common/cel-core/src/main/java/org/eclipse/edc/policy/cel/function/CelFunctionRegistryImpl.java
+++ b/core/common/cel-core/src/main/java/org/eclipse/edc/policy/cel/function/CelFunctionRegistryImpl.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.policy.cel.function;
+
+import org.eclipse.edc.spi.EdcException;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class CelFunctionRegistryImpl implements CelFunctionRegistry {
+
+    private final List<CelFunction> functions = new CopyOnWriteArrayList<>();
+    private final AtomicBoolean sealed = new AtomicBoolean();
+
+    @Override
+    public void registerFunction(CelFunction function) {
+        if (sealed.get()) {
+            throw new EdcException("Cannot register CEL function '%s': the CEL environment has already been built. "
+                    .formatted(function.name()) + "Functions must be registered during extension initialization.");
+        }
+        functions.add(function);
+    }
+
+    @Override
+    public List<CelFunction> functions() {
+        return List.copyOf(functions);
+    }
+
+    @Override
+    public List<CelFunction> seal() {
+        sealed.set(true);
+        return List.copyOf(functions);
+    }
+}

--- a/core/common/cel-core/src/main/java/org/eclipse/edc/policy/cel/function/CelFunctionTranslator.java
+++ b/core/common/cel-core/src/main/java/org/eclipse/edc/policy/cel/function/CelFunctionTranslator.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.policy.cel.function;
+
+import dev.cel.common.CelFunctionDecl;
+import dev.cel.common.CelOverloadDecl;
+import dev.cel.common.types.CelType;
+import dev.cel.common.types.ListType;
+import dev.cel.common.types.MapType;
+import dev.cel.common.types.SimpleType;
+import dev.cel.runtime.CelFunctionBinding;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Translates the EDC-neutral {@link CelFunction} representation into the CEL compiler declarations and runtime
+ * bindings.
+ */
+public class CelFunctionTranslator {
+
+    private CelFunctionTranslator() {
+    }
+
+    /**
+     * Builds the compiler declarations. All overloads sharing a function name must be declared together, hence the
+     * grouping by {@link CelFunction#name()}.
+     */
+    public static List<CelFunctionDecl> toDeclarations(List<CelFunction> functions) {
+        // preserve registration order to keep declarations stable across runs
+        var byName = functions.stream()
+                .collect(Collectors.groupingBy(CelFunction::name, LinkedHashMap::new, Collectors.toList()));
+
+        return byName.entrySet().stream()
+                .map(entry -> CelFunctionDecl.newFunctionDeclaration(entry.getKey(),
+                        entry.getValue().stream().map(CelFunctionTranslator::toOverload).toList()))
+                .toList();
+    }
+
+    /**
+     * Builds the runtime bindings, one per overload.
+     */
+    public static List<CelFunctionBinding> toBindings(List<CelFunction> functions) {
+        return functions.stream().map(CelFunctionTranslator::toBinding).toList();
+    }
+
+    private static CelOverloadDecl toOverload(CelFunction function) {
+        var resultType = toCelType(function.resultType());
+        var parameterTypes = function.argumentTypes().stream().map(CelFunctionTranslator::toCelType).toList();
+
+        return function.memberFunction()
+                ? CelOverloadDecl.newMemberOverload(function.overloadId(), resultType, parameterTypes)
+                : CelOverloadDecl.newGlobalOverload(function.overloadId(), resultType, parameterTypes);
+    }
+
+    private static CelFunctionBinding toBinding(CelFunction function) {
+        var argClasses = function.argumentTypes().stream().map(CelFunctionTranslator::toRuntimeClass).toList();
+        return CelFunctionBinding.from(function.overloadId(), argClasses,
+                args -> function.implementation().apply(Arrays.asList(args)));
+    }
+
+    private static CelType toCelType(CelValueType type) {
+        return switch (type) {
+            case STRING -> SimpleType.STRING;
+            case BOOL -> SimpleType.BOOL;
+            case INT -> SimpleType.INT;
+            case DOUBLE -> SimpleType.DOUBLE;
+            case LIST -> ListType.create(SimpleType.DYN);
+            case MAP -> MapType.create(SimpleType.DYN, SimpleType.DYN);
+            case DYN -> SimpleType.DYN;
+        };
+    }
+
+    /**
+     * The runtime dispatches overloads on the concrete Java class of the arguments. {@code DYN} therefore binds to
+     * {@link Object}, meaning two overloads of the same arity that differ only in a {@code DYN} position cannot be
+     * told apart at runtime.
+     */
+    private static Class<?> toRuntimeClass(CelValueType type) {
+        return switch (type) {
+            case STRING -> String.class;
+            case BOOL -> Boolean.class;
+            case INT -> Long.class;
+            case DOUBLE -> Double.class;
+            case LIST -> List.class;
+            case MAP -> Map.class;
+            case DYN -> Object.class;
+        };
+    }
+}

--- a/core/common/cel-core/src/test/java/org/eclipse/edc/policy/cel/engine/CelExpressionEngineImplTest.java
+++ b/core/common/cel-core/src/test/java/org/eclipse/edc/policy/cel/engine/CelExpressionEngineImplTest.java
@@ -14,9 +14,14 @@
 
 package org.eclipse.edc.policy.cel.engine;
 
+import org.eclipse.edc.policy.cel.function.CelFunction;
+import org.eclipse.edc.policy.cel.function.CelFunctionRegistry;
+import org.eclipse.edc.policy.cel.function.CelFunctionRegistryImpl;
+import org.eclipse.edc.policy.cel.function.CelValueType;
 import org.eclipse.edc.policy.cel.model.CelExpression;
 import org.eclipse.edc.policy.cel.store.CelExpressionStore;
 import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.jetbrains.annotations.NotNull;
@@ -33,6 +38,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
@@ -42,7 +48,8 @@ import static org.mockito.Mockito.when;
 public class CelExpressionEngineImplTest {
     private final CelExpressionStore store = mock();
     private final TransactionContext transactionContext = new NoopTransactionContext();
-    private final CelExpressionEngineImpl registry = new CelExpressionEngineImpl(transactionContext, store, mock());
+    private final CelFunctionRegistry functionRegistry = new CelFunctionRegistryImpl();
+    private final CelExpressionEngineImpl registry = new CelExpressionEngineImpl(transactionContext, store, mock(), functionRegistry);
 
 
     @Test
@@ -149,6 +156,58 @@ public class CelExpressionEngineImplTest {
 
         assertThat(result).isSucceeded();
         assertThat(result.getContent()).isEqualTo(expectedEvaluation);
+    }
+
+    /**
+     * The CEL environment must be built lazily: extensions register their functions during initialization, which
+     * happens after the engine is constructed — as it is here, in the field initializer.
+     */
+    @Test
+    void evaluateExpression_withCustomFunctionRegisteredAfterConstruction() {
+        functionRegistry.registerFunction(new CelFunction("hasCredential", "test_has_credential", true,
+                CelValueType.BOOL, List.of(CelValueType.LIST, CelValueType.STRING),
+                args -> ((List<?>) args.get(0)).stream()
+                        .anyMatch(c -> ((List<?>) ((Map<?, ?>) c).get("type")).contains(args.get(1)))));
+
+        when(store.query(any())).thenReturn(List.of(expression("ctx.agent.claims.vc.hasCredential('MembershipCredential')")));
+
+        var result = registry.evaluateExpression("test", Operator.EQ, "null", createParams("agent-123"));
+
+        assertThat(result).isSucceeded();
+        assertThat(result.getContent()).isTrue();
+    }
+
+    /**
+     * Once the environment is built the registry is sealed, so a function registered too late fails loudly rather
+     * than being silently missing from expressions.
+     */
+    @Test
+    void registerFunction_afterEnvironmentBuilt_throws() {
+        registry.validate("ctx.agent.id == 'x'");
+
+        assertThatThrownBy(() -> functionRegistry.registerFunction(new CelFunction("tooLate", "test_too_late", true,
+                CelValueType.BOOL, List.of(CelValueType.LIST), args -> true)))
+                .isInstanceOf(EdcException.class)
+                .hasMessageContaining("tooLate");
+    }
+
+    @Test
+    void validate_whenCustomFunctionNotRegistered_fails() {
+        var result = registry.validate("ctx.agent.claims.vc.notRegistered('x')");
+
+        assertThat(result).isFailed();
+    }
+
+    /**
+     * The compiler pins the result type to bool, so an expression returning the filtered list must not type-check.
+     */
+    @Test
+    void validate_whenCustomFunctionReturnsNonBoolean_fails() {
+        functionRegistry.registerFunction(new CelFunction("withType", "test_with_type", true,
+                CelValueType.LIST, List.of(CelValueType.LIST, CelValueType.STRING), args -> List.of()));
+
+        assertThat(registry.validate("ctx.agent.claims.vc.withType('X')")).isFailed();
+        assertThat(registry.validate("ctx.agent.claims.vc.withType('X').size() > 0")).isSucceeded();
     }
 
     @Test

--- a/core/common/cel-core/src/test/java/org/eclipse/edc/policy/cel/function/CelFunctionTranslatorTest.java
+++ b/core/common/cel-core/src/test/java/org/eclipse/edc/policy/cel/function/CelFunctionTranslatorTest.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.policy.cel.function;
+
+import dev.cel.common.CelFunctionDecl;
+import dev.cel.common.CelOverloadDecl;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CelFunctionTranslatorTest {
+
+    /**
+     * CEL requires every overload of a function name to be declared together, so the translator must group them.
+     */
+    @Test
+    void toDeclarations_groupsOverloadsBySharedName() {
+        var functions = List.of(
+                function("hasClaim", "has_claim_1", CelValueType.BOOL, List.of(CelValueType.LIST, CelValueType.STRING)),
+                function("hasClaim", "has_claim_2", CelValueType.BOOL, List.of(CelValueType.LIST, CelValueType.STRING, CelValueType.DYN)),
+                function("withType", "with_type", CelValueType.LIST, List.of(CelValueType.LIST, CelValueType.STRING)));
+
+        var declarations = CelFunctionTranslator.toDeclarations(functions);
+
+        assertThat(declarations).hasSize(2);
+        assertThat(declarations).extracting(CelFunctionDecl::name).containsExactly("hasClaim", "withType");
+        assertThat(declarations.get(0).overloads()).extracting(CelOverloadDecl::overloadId)
+                .containsExactlyInAnyOrder("has_claim_1", "has_claim_2");
+        assertThat(declarations.get(0).overloads()).allMatch(CelOverloadDecl::isInstanceFunction);
+    }
+
+    @Test
+    void toDeclarations_marksGlobalFunctions() {
+        var global = new CelFunction("hasCredential", "global_has_credential", false, CelValueType.BOOL,
+                List.of(CelValueType.LIST, CelValueType.STRING), args -> true);
+
+        var declarations = CelFunctionTranslator.toDeclarations(List.of(global));
+
+        assertThat(declarations).singleElement()
+                .satisfies(decl -> assertThat(decl.overloads()).singleElement()
+                        .matches(overload -> !overload.isInstanceFunction()));
+    }
+
+    @Test
+    void toBindings_emitsOneBindingPerOverload() {
+        var functions = List.of(
+                function("hasClaim", "has_claim_1", CelValueType.BOOL, List.of(CelValueType.LIST, CelValueType.STRING)),
+                function("hasClaim", "has_claim_2", CelValueType.BOOL, List.of(CelValueType.LIST, CelValueType.STRING, CelValueType.DYN)));
+
+        var bindings = CelFunctionTranslator.toBindings(functions);
+
+        assertThat(bindings).hasSize(2).extracting(binding -> binding.getOverloadId())
+                .containsExactly("has_claim_1", "has_claim_2");
+        assertThat(bindings.get(0).getArgTypes()).containsExactly(List.class, String.class);
+        assertThat(bindings.get(1).getArgTypes()).containsExactly(List.class, String.class, Object.class);
+    }
+
+    @Test
+    void toBindings_passesArgumentsInDeclarationOrder() throws Exception {
+        var function = new CelFunction("concat", "concat", true, CelValueType.STRING,
+                List.of(CelValueType.STRING, CelValueType.STRING), args -> args.get(0) + "-" + args.get(1));
+
+        var binding = CelFunctionTranslator.toBindings(List.of(function)).get(0);
+
+        assertThat(binding.getDefinition().apply(new Object[]{ "a", "b" })).isEqualTo("a-b");
+    }
+
+    private CelFunction function(String name, String overloadId, CelValueType resultType, List<CelValueType> argumentTypes) {
+        return new CelFunction(name, overloadId, true, resultType, argumentTypes, args -> null);
+    }
+}

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-cel/build.gradle.kts
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-cel/build.gradle.kts
@@ -22,5 +22,7 @@ dependencies {
     api(project(":spi:core-spi"))
 
     testImplementation(project(":core:common:junit"))
+    // exercises the VC helper functions through the real CEL engine
+    testImplementation(project(":core:common:cel-core"))
 }
 

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-cel/src/main/java/org/eclipse/edc/iam/decentralizedclaims/cel/DcpCelExtension.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-cel/src/main/java/org/eclipse/edc/iam/decentralizedclaims/cel/DcpCelExtension.java
@@ -14,11 +14,14 @@
 
 package org.eclipse.edc.iam.decentralizedclaims.cel;
 
+import org.eclipse.edc.policy.cel.function.CelFunctionRegistry;
 import org.eclipse.edc.policy.cel.function.context.CelParticipantAgentClaimMapperRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+import java.time.Clock;
 
 import static org.eclipse.edc.iam.decentralizedclaims.cel.DcpCelExtension.NAME;
 
@@ -33,9 +36,16 @@ public class DcpCelExtension implements ServiceExtension {
     @Inject
     private CelParticipantAgentClaimMapperRegistry claimMapperRegistry;
 
+    @Inject
+    private CelFunctionRegistry celFunctionRegistry;
+
+    @Inject
+    private Clock clock;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
         claimMapperRegistry.registerClaimMapper(new VcClaimMapper());
+        VcCelFunctions.functions(clock).forEach(celFunctionRegistry::registerFunction);
     }
 
 

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-cel/src/main/java/org/eclipse/edc/iam/decentralizedclaims/cel/VcCelFunctions.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-cel/src/main/java/org/eclipse/edc/iam/decentralizedclaims/cel/VcCelFunctions.java
@@ -1,0 +1,266 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.decentralizedclaims.cel;
+
+import org.eclipse.edc.policy.cel.function.CelFunction;
+import org.eclipse.edc.policy.cel.function.CelValueType;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.eclipse.edc.policy.cel.function.CelValueType.BOOL;
+import static org.eclipse.edc.policy.cel.function.CelValueType.DYN;
+import static org.eclipse.edc.policy.cel.function.CelValueType.LIST;
+import static org.eclipse.edc.policy.cel.function.CelValueType.MAP;
+import static org.eclipse.edc.policy.cel.function.CelValueType.STRING;
+
+/**
+ * Helper functions for querying verifiable credentials from CEL expressions, so that
+ * <pre>
+ * ctx.agent.claims.vc.filter(c, c.type.exists(t, t == 'MembershipCredential'))
+ *                    .exists(c, c.credentialSubject.exists(cs, cs.memberOf == 'Catena-X'))
+ * </pre>
+ * can be written as
+ * <pre>
+ * ctx.agent.claims.vc.withType('MembershipCredential').hasClaim('memberOf', 'Catena-X')
+ * </pre>
+ * <p>
+ * All functions operate on the credential representation produced by {@link VcClaimMapper} and are shape-safe: a
+ * missing key, a wrongly typed value or a non-credential entry yields "no match" rather than an evaluation error.
+ * This is a deliberate departure from plain CEL map access, where reading an absent key aborts evaluation.
+ */
+public class VcCelFunctions {
+
+    private static final String TYPE = "type";
+    private static final String CONTEXT = "@context";
+    private static final String ISSUER = "issuer";
+    private static final String ID = "id";
+    private static final String CREDENTIAL_SUBJECT = "credentialSubject";
+    private static final String ISSUANCE_DATE = "issuanceDate";
+    private static final String EXPIRATION_DATE = "expirationDate";
+
+    private VcCelFunctions() {
+    }
+
+    public static List<CelFunction> functions(Clock clock) {
+        return List.of(
+                // --- list receiver ---------------------------------------------------------------------------
+                fn("withType", "vc_list_with_type", LIST, List.of(LIST, STRING),
+                        args -> withType(args.get(0), string(args.get(1)))),
+                fn("withContext", "vc_list_with_context", LIST, List.of(LIST, STRING),
+                        args -> withContext(args.get(0), string(args.get(1)))),
+                fn("withIssuer", "vc_list_with_issuer", LIST, List.of(LIST, STRING),
+                        args -> withIssuer(args.get(0), string(args.get(1)))),
+                fn("valid", "vc_list_valid", LIST, List.of(LIST),
+                        args -> validOnly(args.get(0), clock.instant())),
+                fn("hasCredential", "vc_list_has_credential", BOOL, List.of(LIST, STRING),
+                        args -> anyCredential(args.get(0), c -> hasType(c, string(args.get(1))))),
+                fn("hasClaim", "vc_list_has_claim_value", BOOL, List.of(LIST, STRING, DYN),
+                        args -> anyClaim(args.get(0), string(args.get(1)), v -> Objects.equals(v, args.get(2)))),
+                fn("hasClaim", "vc_list_has_claim", BOOL, List.of(LIST, STRING),
+                        args -> anyClaim(args.get(0), string(args.get(1)), v -> true)),
+                fn("claim", "vc_list_claim", DYN, List.of(LIST, STRING),
+                        args -> firstClaim(args.get(0), string(args.get(1)))),
+                fn("claims", "vc_list_claims", LIST, List.of(LIST, STRING),
+                        args -> claimValues(args.get(0), string(args.get(1)))),
+
+                // --- single credential receiver, so the helpers compose with the standard macros --------------
+                fn("hasType", "vc_map_has_type", BOOL, List.of(MAP, STRING),
+                        args -> hasType(args.get(0), string(args.get(1)))),
+                fn("hasContext", "vc_map_has_context", BOOL, List.of(MAP, STRING),
+                        args -> hasContext(args.get(0), string(args.get(1)))),
+                fn("valid", "vc_map_valid", BOOL, List.of(MAP),
+                        args -> isValid(args.get(0), clock.instant())),
+                fn("hasClaim", "vc_map_has_claim_value", BOOL, List.of(MAP, STRING, DYN),
+                        args -> anyClaim(List.of(args.get(0)), string(args.get(1)), v -> Objects.equals(v, args.get(2)))),
+                fn("hasClaim", "vc_map_has_claim", BOOL, List.of(MAP, STRING),
+                        args -> anyClaim(List.of(args.get(0)), string(args.get(1)), v -> true)),
+                fn("claim", "vc_map_claim", DYN, List.of(MAP, STRING),
+                        args -> firstClaim(List.of(args.get(0)), string(args.get(1))))
+        );
+    }
+
+    private static CelFunction fn(String name, String overloadId, CelValueType resultType,
+                                  List<CelValueType> argumentTypes, Function<List<Object>, Object> implementation) {
+        return new CelFunction(name, overloadId, true, resultType, argumentTypes, implementation);
+    }
+
+    private static List<?> withType(Object credentials, String type) {
+        return filter(credentials, c -> hasType(c, type));
+    }
+
+    private static List<?> withContext(Object credentials, String context) {
+        return filter(credentials, c -> hasContext(c, context));
+    }
+
+    private static List<?> withIssuer(Object credentials, String issuer) {
+        return filter(credentials, c -> Objects.equals(issuerId(c), issuer));
+    }
+
+    private static List<?> validOnly(Object credentials, Instant now) {
+        return filter(credentials, c -> isValid(c, now));
+    }
+
+    private static List<?> filter(Object credentials, Predicate<Object> predicate) {
+        return asList(credentials).stream().filter(predicate).toList();
+    }
+
+    private static boolean anyCredential(Object credentials, Predicate<Object> predicate) {
+        return asList(credentials).stream().anyMatch(predicate);
+    }
+
+    private static boolean hasType(Object credential, String type) {
+        return asList(asMap(credential).get(TYPE)).contains(type);
+    }
+
+    private static boolean hasContext(Object credential, String context) {
+        return asList(asMap(credential).get(CONTEXT)).contains(context);
+    }
+
+    /**
+     * The issuer is mapped as an object, but a custom claim mapper may emit the bare id, so both shapes are read.
+     */
+    private static String issuerId(Object credential) {
+        var issuer = asMap(credential).get(ISSUER);
+        if (issuer instanceof String s) {
+            return s;
+        }
+        return asMap(issuer).get(ID) instanceof String s ? s : null;
+    }
+
+    /**
+     * Mirrors {@code IsInValidityPeriod}, the rule applied by the credential verification pipeline: a credential is
+     * valid once issued and until it expires, with the expiration instant itself still valid. A malformed date is
+     * treated as invalid so this never widens access relative to that rule. Credentials arriving through the standard
+     * DCP flow have already passed it, so this is defence in depth for other claim sources.
+     */
+    private static boolean isValid(Object credential, Instant now) {
+        var credentialMap = asMap(credential);
+        var issuance = instant(credentialMap.get(ISSUANCE_DATE));
+        if (issuance == null || issuance.isAfter(now)) {
+            return false;
+        }
+        var expiration = credentialMap.get(EXPIRATION_DATE);
+        if (expiration == null) {
+            return true;
+        }
+        var expirationInstant = instant(expiration);
+        return expirationInstant != null && !expirationInstant.isBefore(now);
+    }
+
+    private static boolean anyClaim(Object credentials, String name, Predicate<Object> predicate) {
+        var path = segments(name);
+        for (var credential : asList(credentials)) {
+            for (var subject : asList(asMap(credential).get(CREDENTIAL_SUBJECT))) {
+                var value = resolve(subject, path);
+                if (value != null && predicate.test(value)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static Object firstClaim(Object credentials, String name) {
+        var path = segments(name);
+        for (var credential : asList(credentials)) {
+            for (var subject : asList(asMap(credential).get(CREDENTIAL_SUBJECT))) {
+                var value = resolve(subject, path);
+                if (value != null) {
+                    return value;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Collects the values of a subject claim across all credentials.
+     */
+    private static List<Object> claimValues(Object credentials, String name) {
+        var path = segments(name);
+        var values = new ArrayList<>();
+        for (var credential : asList(credentials)) {
+            for (var subject : asList(asMap(credential).get(CREDENTIAL_SUBJECT))) {
+                var value = resolve(subject, path);
+                if (value != null) {
+                    values.add(value);
+                }
+            }
+        }
+        return values;
+    }
+
+    private static String[] segments(String name) {
+        return name == null ? new String[0] : name.split("\\.");
+    }
+
+    /**
+     * Resolves a claim name against a subject. The whole name is tried as a literal key first, so keys that contain
+     * dots — namespaced credential claims are usually IRIs — remain addressable; only then is it treated as a path
+     * into nested claims.
+     */
+    private static Object resolve(Object subject, String[] path) {
+        if (path.length == 0) {
+            return null;
+        }
+        var subjectMap = asMap(subject);
+        if (path.length == 1) {
+            return subjectMap.get(path[0]);
+        }
+        var literal = subjectMap.get(String.join(".", path));
+        if (literal != null) {
+            return literal;
+        }
+        Object current = subject;
+        for (var segment : path) {
+            if (current == null) {
+                return null;
+            }
+            current = asMap(current).get(segment);
+        }
+        return current;
+    }
+
+    private static Instant instant(Object value) {
+        if (!(value instanceof String s)) {
+            return null;
+        }
+        try {
+            return Instant.parse(s);
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+
+    private static String string(Object value) {
+        return value instanceof String s ? s : null;
+    }
+
+    private static List<?> asList(Object value) {
+        return value instanceof List<?> list ? list : List.of();
+    }
+
+    private static Map<?, ?> asMap(Object value) {
+        return value instanceof Map<?, ?> map ? map : Map.of();
+    }
+}

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-cel/src/main/java/org/eclipse/edc/iam/decentralizedclaims/cel/VcClaimMapper.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-cel/src/main/java/org/eclipse/edc/iam/decentralizedclaims/cel/VcClaimMapper.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.iam.decentralizedclaims.cel;
 
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialSubject;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.participant.spi.ParticipantAgent;
 import org.eclipse.edc.policy.cel.function.context.CelClaim;
@@ -54,10 +55,34 @@ public class VcClaimMapper implements CelParticipantAgentClaimMapper {
         cred.put("@context", credential.getContext());
         cred.put("id", credential.getId());
         cred.put("type", credential.getType());
-        cred.put("credentialSubject", credential.getCredentialSubject().stream().map(CredentialSubject::getClaims).collect(Collectors.toList()));
-        cred.put("issuer", credential.getIssuer().id());
+        cred.put("credentialSubject", credential.getCredentialSubject().stream().map(this::toSubjectMap).collect(Collectors.toList()));
+        cred.put("issuer", toIssuerMap(credential.getIssuer()));
         cred.put("issuanceDate", credential.getIssuanceDate().toString());
+        // optional: only emitted when present, so expressions must not assume it exists
+        if (credential.getExpirationDate() != null) {
+            cred.put("expirationDate", credential.getExpirationDate().toString());
+        }
         return cred;
+    }
+
+    private Map<String, Object> toSubjectMap(CredentialSubject subject) {
+        var claims = subject.getClaims();
+        // an explicit "id" claim takes precedence over the subject id; avoid copying when there is nothing to add
+        if (subject.getId() == null || claims.containsKey("id")) {
+            return claims;
+        }
+        var merged = new HashMap<String, Object>(claims);
+        merged.put("id", subject.getId());
+        return merged;
+    }
+
+    private Map<String, Object> toIssuerMap(Issuer issuer) {
+        if (issuer.additionalProperties().isEmpty()) {
+            return Map.of("id", issuer.id());
+        }
+        var map = new HashMap<String, Object>(issuer.additionalProperties());
+        map.put("id", issuer.id());
+        return map;
     }
 
 }

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-cel/src/test/java/org/eclipse/edc/iam/decentralizedclaims/cel/VcCelFunctionsTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-cel/src/test/java/org/eclipse/edc/iam/decentralizedclaims/cel/VcCelFunctionsTest.java
@@ -1,0 +1,263 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.decentralizedclaims.cel;
+
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialSubject;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
+import org.eclipse.edc.participant.spi.ParticipantAgent;
+import org.eclipse.edc.policy.cel.engine.CelExpressionEngineImpl;
+import org.eclipse.edc.policy.cel.function.CelFunctionRegistryImpl;
+import org.eclipse.edc.policy.cel.model.CelExpression;
+import org.eclipse.edc.policy.cel.store.CelExpressionStore;
+import org.eclipse.edc.policy.model.Operator;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Exercises the VC helper functions through the real CEL engine, over the credential shape actually produced by
+ * {@link VcClaimMapper}.
+ */
+class VcCelFunctionsTest {
+
+    private final CelExpressionStore store = mock();
+    private final CelFunctionRegistryImpl functionRegistry = new CelFunctionRegistryImpl();
+    private final CelExpressionEngineImpl engine =
+            new CelExpressionEngineImpl(new NoopTransactionContext(), store, mock(), functionRegistry);
+
+    VcCelFunctionsTest() {
+        VcCelFunctions.functions(Clock.systemUTC()).forEach(functionRegistry::registerFunction);
+    }
+
+    @Test
+    void shortFormMatchesLongForm() {
+        var longForm = """
+                ctx.agent.claims.vc
+                     .filter(c, c.type.exists(t, t == 'MembershipCredential'))
+                     .exists(c, c.credentialSubject.exists(cs, cs.memberOf == 'Catena-X'))
+                """;
+        var shortForm = "ctx.agent.claims.vc.withType('MembershipCredential').hasClaim('memberOf', 'Catena-X')";
+
+        assertThat(evaluate(longForm)).isTrue();
+        assertThat(evaluate(shortForm)).isTrue();
+    }
+
+    static Stream<Arguments> helpers() {
+        return Stream.of(
+                arguments("ctx.agent.claims.vc.hasCredential('MembershipCredential')", true),
+                arguments("ctx.agent.claims.vc.hasCredential('DataAccessCredential')", false),
+                arguments("ctx.agent.claims.vc.withType('MembershipCredential').hasClaim('memberOf')", true),
+                arguments("ctx.agent.claims.vc.withType('MembershipCredential').hasClaim('memberOf', 'Catena-X')", true),
+                arguments("ctx.agent.claims.vc.withType('MembershipCredential').hasClaim('memberOf', 'Other')", false),
+                arguments("ctx.agent.claims.vc.withType('MembershipCredential').claim('level') == 'gold'", true),
+                arguments("ctx.agent.claims.vc.withIssuer('did:web:issuer').hasCredential('MembershipCredential')", true),
+                arguments("ctx.agent.claims.vc.withIssuer('did:web:other').hasCredential('MembershipCredential')", false),
+                arguments("ctx.agent.claims.vc.withContext('https://www.w3.org/2018/credentials/v1').hasCredential('MembershipCredential')", true),
+                arguments("ctx.agent.claims.vc.withContext('https://example.org/unknown').hasCredential('MembershipCredential')", false),
+                arguments("ctx.agent.claims.vc.exists(c, c.hasContext('https://www.w3.org/2018/credentials/v1'))", true),
+                arguments("ctx.agent.claims.vc.valid().hasCredential('MembershipCredential')", true),
+                arguments("ctx.agent.claims.vc.valid().hasCredential('ExpiredCredential')", false),
+                arguments("ctx.agent.claims.vc.withType('MembershipCredential').claims('level').size() == 1", true),
+                // dotted paths reach nested subject claims
+                arguments("ctx.agent.claims.vc.hasClaim('degree.type', 'BachelorDegree')", true),
+                arguments("ctx.agent.claims.vc.hasClaim('degree.missing', 'x')", false),
+                // the subject id is exposed as a claim
+                arguments("ctx.agent.claims.vc.hasClaim('id', 'did:web:subject')", true),
+                // single-credential receiver composes with the standard macros
+                arguments("ctx.agent.claims.vc.exists(c, c.hasType('MembershipCredential'))", true),
+                arguments("ctx.agent.claims.vc.exists(c, c.hasClaim('memberOf', 'Catena-X'))", true),
+                arguments("ctx.agent.claims.vc.exists(c, c.hasType('MembershipCredential') && c.valid())", true),
+                arguments("ctx.agent.claims.vc.exists(c, c.hasType('ExpiredCredential') && c.valid())", false)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("helpers")
+    void evaluatesHelpers(String expression, boolean expected) {
+        assertThat(evaluate(expression)).isEqualTo(expected);
+    }
+
+    /**
+     * Plain map access aborts evaluation on an absent key; the helpers must return false instead. This is the main
+     * usability benefit over hand-written filter/exists expressions.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "ctx.agent.claims.vc.hasClaim('missingClaim', 'x')",
+            "ctx.agent.claims.vc.hasClaim('missingClaim')",
+            "ctx.agent.claims.vc.withType('NoSuchType').hasClaim('memberOf', 'Catena-X')",
+            "ctx.agent.claims.vc.hasClaim('memberOf.nested.deep', 'x')"
+    })
+    void missingDataYieldsFalseRatherThanError(String expression) {
+        var result = evaluateResult(expression);
+
+        assertThat(result).isSucceeded();
+        assertThat(result.getContent()).isFalse();
+    }
+
+    @Test
+    void plainMapAccessStillErrorsOnMissingKey() {
+        // guards the contrast above: the helpers are what make this safe, not a change to CEL itself
+        assertThat(evaluateResult("ctx.agent.claims.vc.exists(c, c.credentialSubject.exists(cs, cs.missing == 'x'))"))
+                .isFailed();
+    }
+
+    /**
+     * Credential claim names are often IRIs, which contain dots. The whole name must be tried as a literal key before
+     * being interpreted as a path, otherwise such claims are unreachable.
+     */
+    @Test
+    void resolvesClaimNameContainingDots() {
+        var vc = VerifiableCredential.Builder.newInstance()
+                .id("credential-3")
+                .types(List.of("VerifiableCredential", "NamespacedCredential"))
+                .issuer(new Issuer("did:web:issuer", Map.of()))
+                .issuanceDate(Instant.now().minus(1, ChronoUnit.DAYS))
+                .credentialSubject(CredentialSubject.Builder.newInstance()
+                        .claim("https://w3id.org/edc/v0.0.1/ns/level", "gold")
+                        .build())
+                .build();
+        var params = paramsFor(List.of(vc));
+
+        var result = evaluateResult("ctx.agent.claims.vc.hasClaim('https://w3id.org/edc/v0.0.1/ns/level', 'gold')", params);
+
+        assertThat(result).isSucceeded();
+        assertThat(result.getContent()).isTrue();
+    }
+
+    /**
+     * Matches {@code IsInValidityPeriod}, the rule the verification pipeline applies: the expiration instant itself is
+     * still valid, and a credential whose issuance date lies in the future is not.
+     */
+    @Test
+    void validityBoundariesMatchVerificationPipeline() {
+        var now = Instant.parse("2026-01-01T00:00:00Z");
+        var clock = Clock.fixed(now, java.time.ZoneOffset.UTC);
+        var registry = new CelFunctionRegistryImpl();
+        VcCelFunctions.functions(clock).forEach(registry::registerFunction);
+        var fixedEngine = new CelExpressionEngineImpl(new NoopTransactionContext(), store, mock(), registry);
+
+        var expiringNow = credential("ExpiringNow", now.minus(1, ChronoUnit.DAYS), now);
+        var notYetValid = credential("NotYetValid", now.plus(1, ChronoUnit.DAYS), null);
+        var params = paramsFor(List.of(expiringNow, notYetValid));
+
+        when(store.query(any())).thenReturn(List.of(CelExpression.Builder.newInstance().id("id").leftOperand("test")
+                .expression("ctx.agent.claims.vc.valid().hasCredential('ExpiringNow')").description("d").build()));
+        assertThat(fixedEngine.evaluateExpression("test", Operator.EQ, "null", params).getContent()).isTrue();
+
+        when(store.query(any())).thenReturn(List.of(CelExpression.Builder.newInstance().id("id").leftOperand("test")
+                .expression("ctx.agent.claims.vc.valid().hasCredential('NotYetValid')").description("d").build()));
+        assertThat(fixedEngine.evaluateExpression("test", Operator.EQ, "null", params).getContent()).isFalse();
+    }
+
+    @Test
+    void handlesAgentWithoutCredentials() {
+        var params = Map.<String, Object>of("agent", Map.of("id", "agent-1", "claims", Map.of("vc", List.of())));
+
+        var result = evaluateResult("ctx.agent.claims.vc.hasCredential('MembershipCredential')", params);
+
+        assertThat(result).isSucceeded();
+        assertThat(result.getContent()).isFalse();
+    }
+
+    private boolean evaluate(String expression) {
+        var result = evaluateResult(expression);
+        assertThat(result).isSucceeded();
+        return result.getContent();
+    }
+
+    private ServiceResult<Boolean> evaluateResult(String expression) {
+        return evaluateResult(expression, params());
+    }
+
+    private ServiceResult<Boolean> evaluateResult(String expression, Map<String, Object> params) {
+        when(store.query(any())).thenReturn(List.of(CelExpression.Builder.newInstance()
+                .id("id").leftOperand("test").expression(expression).description("d").build()));
+        return engine.evaluateExpression("test", Operator.EQ, "null", params);
+    }
+
+    /**
+     * Builds the context exactly as it is produced at runtime, by running the real {@link VcClaimMapper}.
+     */
+    private Map<String, Object> params() {
+        return paramsFor(credentials());
+    }
+
+    private Map<String, Object> paramsFor(List<VerifiableCredential> credentials) {
+        var agent = new ParticipantAgent("agent-1", Map.of("vc", credentials), Map.of());
+        var vc = new VcClaimMapper().mapClaim(agent);
+        return Map.of("agent", Map.of("id", "agent-1", "claims", Map.of(vc.name(), vc.value())));
+    }
+
+    private VerifiableCredential credential(String type, Instant issuance, Instant expiration) {
+        var builder = VerifiableCredential.Builder.newInstance()
+                .id("credential-" + type)
+                .types(List.of("VerifiableCredential", type))
+                .issuer(new Issuer("did:web:issuer", Map.of()))
+                .issuanceDate(issuance)
+                .credentialSubject(CredentialSubject.Builder.newInstance().claim("memberOf", "Catena-X").build());
+        if (expiration != null) {
+            builder.expirationDate(expiration);
+        }
+        return builder.build();
+    }
+
+    private List<VerifiableCredential> credentials() {
+        var membership = VerifiableCredential.Builder.newInstance()
+                .id("credential-1")
+                .contexts(List.of("https://www.w3.org/2018/credentials/v1"))
+                .types(List.of("VerifiableCredential", "MembershipCredential"))
+                .issuer(new Issuer("did:web:issuer", Map.of()))
+                .issuanceDate(Instant.now().minus(1, ChronoUnit.DAYS))
+                .expirationDate(Instant.now().plus(30, ChronoUnit.DAYS))
+                .credentialSubject(CredentialSubject.Builder.newInstance()
+                        .id("did:web:subject")
+                        .claim("memberOf", "Catena-X")
+                        .claim("level", "gold")
+                        .claim("degree", Map.of("type", "BachelorDegree"))
+                        .build())
+                .build();
+
+        var expired = VerifiableCredential.Builder.newInstance()
+                .id("credential-2")
+                .types(List.of("VerifiableCredential", "ExpiredCredential"))
+                .issuer(new Issuer("did:web:issuer", Map.of()))
+                .issuanceDate(Instant.now().minus(10, ChronoUnit.DAYS))
+                .expirationDate(Instant.now().minus(1, ChronoUnit.DAYS))
+                .credentialSubject(CredentialSubject.Builder.newInstance().claim("memberOf", "Catena-X").build())
+                .build();
+
+        return List.of(membership, expired);
+    }
+}

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-cel/src/test/java/org/eclipse/edc/iam/decentralizedclaims/issuer/configuration/DcpCelExtensionTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-cel/src/test/java/org/eclipse/edc/iam/decentralizedclaims/issuer/configuration/DcpCelExtensionTest.java
@@ -17,12 +17,18 @@ package org.eclipse.edc.iam.decentralizedclaims.issuer.configuration;
 import org.eclipse.edc.iam.decentralizedclaims.cel.DcpCelExtension;
 import org.eclipse.edc.iam.decentralizedclaims.cel.VcClaimMapper;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.policy.cel.function.CelFunction;
+import org.eclipse.edc.policy.cel.function.CelFunctionRegistry;
+import org.eclipse.edc.policy.cel.function.CelFunctionRegistryImpl;
 import org.eclipse.edc.policy.cel.function.context.CelParticipantAgentClaimMapperRegistry;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.time.Clock;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -31,10 +37,13 @@ import static org.mockito.Mockito.verify;
 public class DcpCelExtensionTest {
 
     private final CelParticipantAgentClaimMapperRegistry claimMapperRegistry = mock();
+    private final CelFunctionRegistry celFunctionRegistry = new CelFunctionRegistryImpl();
 
     @BeforeEach
     void setup(ServiceExtensionContext context) {
         context.registerService(CelParticipantAgentClaimMapperRegistry.class, claimMapperRegistry);
+        context.registerService(CelFunctionRegistry.class, celFunctionRegistry);
+        context.registerService(Clock.class, Clock.systemUTC());
     }
 
     @Test
@@ -42,6 +51,18 @@ public class DcpCelExtensionTest {
         ext.initialize(context);
 
         verify(claimMapperRegistry).registerClaimMapper(isA(VcClaimMapper.class));
+    }
+
+    @Test
+    void initialize_registersVcFunctions(ServiceExtensionContext context, DcpCelExtension ext) {
+        ext.initialize(context);
+
+        assertThat(celFunctionRegistry.functions())
+                .isNotEmpty()
+                .extracting(CelFunction::name)
+                .contains("withType", "withContext", "withIssuer", "valid", "hasCredential", "hasClaim", "claim", "claims", "hasType", "hasContext");
+        // overload ids must be unique, otherwise the CEL runtime rejects the bindings
+        assertThat(celFunctionRegistry.functions()).extracting(CelFunction::overloadId).doesNotHaveDuplicates();
     }
 
 }

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-cel/src/test/java/org/eclipse/edc/iam/decentralizedclaims/issuer/configuration/VeClaimMapperTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-cel/src/test/java/org/eclipse/edc/iam/decentralizedclaims/issuer/configuration/VeClaimMapperTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.eclipse.edc.iam.decentralizedclaims.cel.VcClaimMapper.VC_CLAIM;
 
 public class VeClaimMapperTest {
@@ -48,9 +49,11 @@ public class VeClaimMapperTest {
                         "@context", List.of("https://www.w3.org/2018/credentials/v1", "https://www.w3.org/2018/credentials/examples/v1"),
                         "id", "http://example.edu/credentials/3732",
                         "type", List.of("VerifiableCredential", "AlumniCredential"),
-                        "issuer", "https://example.edu/issuers/14",
+                        "issuer", Map.of("id", "https://example.edu/issuers/14"),
                         "issuanceDate", credentials.get(0).getIssuanceDate().toString(),
+                        "expirationDate", credentials.get(0).getExpirationDate().toString(),
                         "credentialSubject", List.of(Map.of(
+                                "id", "did:web:subject",
                                 "alumniOf", "Example University",
                                 "degree", Map.of(
                                         "type", "BachelorDegree",
@@ -62,6 +65,45 @@ public class VeClaimMapperTest {
 
         assertThat(result.name()).isEqualTo(VC_CLAIM);
         assertThat(result.value()).isEqualTo(expectedList);
+    }
+
+    @Test
+    void mapClaim_omitsExpirationDateWhenAbsent() {
+        var vc = VerifiableCredential.Builder.newInstance()
+                .id("credential-1")
+                .types(List.of("VerifiableCredential"))
+                .issuer(new Issuer("https://example.edu/issuers/14", Map.of()))
+                .issuanceDate(Instant.now())
+                .credentialSubject(CredentialSubject.Builder.newInstance().claim("alumniOf", "Example University").build())
+                .build();
+        var agent = new ParticipantAgent("agent-id", Map.of("vc", List.of(vc)), Map.of());
+
+        var result = mapper.mapClaim(agent);
+
+        assertThat(result.value()).asInstanceOf(list(Map.class))
+                .singleElement()
+                .satisfies(credential -> assertThat(credential).doesNotContainKey("expirationDate"));
+    }
+
+    @Test
+    void mapClaim_retainsIssuerAdditionalProperties() {
+        var vc = VerifiableCredential.Builder.newInstance()
+                .id("credential-1")
+                .types(List.of("VerifiableCredential"))
+                .issuer(new Issuer("https://example.edu/issuers/14", Map.of("name", "Example University")))
+                .issuanceDate(Instant.now())
+                .credentialSubject(CredentialSubject.Builder.newInstance().claim("alumniOf", "Example University").build())
+                .build();
+        var agent = new ParticipantAgent("agent-id", Map.of("vc", List.of(vc)), Map.of());
+
+        var result = mapper.mapClaim(agent);
+
+        assertThat(result.value()).asInstanceOf(list(Map.class))
+                .singleElement()
+                .satisfies(credential -> {
+                    assertThat(credential).containsEntry("issuer",
+                            Map.of("id", "https://example.edu/issuers/14", "name", "Example University"));
+                });
     }
 
     @Test
@@ -81,7 +123,9 @@ public class VeClaimMapperTest {
                 .types(List.of("VerifiableCredential", "AlumniCredential"))
                 .issuer(new Issuer("https://example.edu/issuers/14", Map.of()))
                 .issuanceDate(Instant.now())
+                .expirationDate(Instant.now().plusSeconds(3600))
                 .credentialSubject(CredentialSubject.Builder.newInstance()
+                        .id("did:web:subject")
                         .claim("alumniOf", "Example University")
                         .claim("degree", Map.of(
                                 "type", "BachelorDegree",

--- a/spi/control-plane-spi/src/main/java/org/eclipse/edc/policy/cel/function/CelFunction.java
+++ b/spi/control-plane-spi/src/main/java/org/eclipse/edc/policy/cel/function/CelFunction.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.policy.cel.function;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * A single custom function overload that can be made available to CEL expressions.
+ * <p>
+ * Multiple {@link CelFunction}s may share the same {@link #name()} to declare several overloads of the same function;
+ * the {@link #overloadId()} must be unique across all registered functions.
+ * <p>
+ * For member (receiver style) functions the first entry of {@link #argumentTypes()} is the receiver type, so that
+ * {@code vc.withType('X')} is declared with argument types {@code [LIST, STRING]}.
+ *
+ * @param name           the function name as used in expressions, e.g. {@code withType}
+ * @param overloadId     globally unique identifier of this overload, e.g. {@code vc_list_with_type}
+ * @param memberFunction whether the function is invoked receiver style ({@code a.f(b)}) or globally ({@code f(a, b)})
+ * @param resultType     the type this function evaluates to
+ * @param argumentTypes  the argument types; for member functions the first entry is the receiver
+ * @param implementation the function body, receiving arguments in declaration order
+ */
+public record CelFunction(String name,
+                          String overloadId,
+                          boolean memberFunction,
+                          CelValueType resultType,
+                          List<CelValueType> argumentTypes,
+                          Function<List<Object>, Object> implementation) {
+
+    public CelFunction {
+        argumentTypes = List.copyOf(argumentTypes);
+        if (memberFunction && argumentTypes.isEmpty()) {
+            throw new IllegalArgumentException("A member function requires at least the receiver argument type");
+        }
+    }
+}

--- a/spi/control-plane-spi/src/main/java/org/eclipse/edc/policy/cel/function/CelFunctionRegistry.java
+++ b/spi/control-plane-spi/src/main/java/org/eclipse/edc/policy/cel/function/CelFunctionRegistry.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.policy.cel.function;
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+
+import java.util.List;
+
+/**
+ * Registry for custom functions that are made available to CEL expressions.
+ * <p>
+ * Functions must be registered during extension initialization: the CEL environment is built lazily from a single
+ * snapshot of this registry when the first expression is compiled, and cannot be extended afterwards.
+ */
+@ExtensionPoint
+public interface CelFunctionRegistry {
+
+    /**
+     * Registers a function overload.
+     *
+     * @param function the function to register
+     * @throws org.eclipse.edc.spi.EdcException if the registry has already been sealed
+     */
+    void registerFunction(CelFunction function);
+
+    /**
+     * Returns all registered functions.
+     *
+     * @return the registered functions
+     */
+    List<CelFunction> functions();
+
+    /**
+     * Returns the registered functions and closes the registry for further registrations, so that a function
+     * registered too late fails loudly instead of being silently absent from expressions.
+     *
+     * @return the registered functions
+     */
+    List<CelFunction> seal();
+}

--- a/spi/control-plane-spi/src/main/java/org/eclipse/edc/policy/cel/function/CelValueType.java
+++ b/spi/control-plane-spi/src/main/java/org/eclipse/edc/policy/cel/function/CelValueType.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.policy.cel.function;
+
+/**
+ * Value types that can be used in the signature of a {@link CelFunction}.
+ * <p>
+ * This is an EDC-neutral abstraction over the underlying CEL type system, so that modules contributing custom
+ * functions do not need a compile dependency on the CEL implementation.
+ */
+public enum CelValueType {
+    STRING,
+    BOOL,
+    INT,
+    DOUBLE,
+    LIST,
+    MAP,
+    DYN
+}

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualDcpTransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualDcpTransferPullEndToEndTest.java
@@ -158,6 +158,58 @@ class VirtualDcpTransferPullEndToEndTest {
         }
 
         @Test
+        void httpPull_dataTransfer_withMembershipHelperFunctions(ManagementApiClientV5 connectorClient,
+                                                                 Participants participants) {
+
+            var leftOperand = "https://w3id.org/example/credentials/MembershipCredentialHelpers";
+            // short form equivalent of the filter/exists expression above, using the VC helper functions
+            var expression = "ctx.agent.claims.vc.valid().withType('MembershipCredential').hasClaim('status', 'active')";
+
+            var scopes = Set.of("catalog", "contract.negotiation", "transfer.process");
+            var expr = new CelExpressionDto(leftOperand, expression, scopes, "membership helper expression");
+            connectorClient.expressions().createExpression(expr);
+
+            var providerAddress = participants.provider().getProtocolEndpoint();
+
+            var constraint = new AtomicConstraintDto(leftOperand, "eq", "active");
+            var permission = new PermissionDto(constraint);
+            var policy = new PolicyDto(List.of(permission));
+
+            var assetId = setup(connectorClient, participants.provider(), policy);
+            var transferProcessId = connectorClient.startTransfer(participants.consumer().contextId(), participants.consumer().profile(), participants.provider().contextId(), providerAddress, participants.provider().id(), assetId, "NonFinite-PULL");
+
+            var consumerTransfer = connectorClient.transfers().getTransferProcess(participants.consumer().contextId(), transferProcessId);
+            var providerTransfer = connectorClient.transfers().getTransferProcess(participants.provider().contextId(), consumerTransfer.getCorrelationId());
+
+            assertThat(consumerTransfer.getState()).isEqualTo(providerTransfer.getState());
+        }
+
+        @Test
+        void negotiation_fails_withMissingCredentialHelperFunction(ManagementApiClientV5 connectorClient,
+                                                                   Participants participants) {
+
+            var leftOperand = "https://w3id.org/example/credentials/DataAccessCredentialHelpers";
+            var expression = "ctx.agent.claims.vc.hasCredential('DataAccessCredential')";
+
+            var expr = new CelExpressionDto(leftOperand, expression, Set.of("contract.negotiation"), "data credential helper expression");
+            connectorClient.expressions().createExpression(expr);
+
+            var providerAddress = participants.provider().getProtocolEndpoint();
+
+            var constraint = new AtomicConstraintDto(leftOperand, "eq", "active");
+            var permission = new PermissionDto(constraint);
+            var policy = new PolicyDto(List.of(permission));
+
+            var assetId = setup(connectorClient, participants.provider(), policy);
+            var negotiationId = connectorClient.initContractNegotiation(participants.consumer().contextId(), participants.consumer().profile(), assetId, providerAddress, participants.provider().id());
+
+            connectorClient.waitForContractNegotiationState(participants.consumer().contextId(), negotiationId, ContractNegotiationStates.TERMINATED.name());
+            var error = connectorClient.getNegotiationError(participants.consumer().contextId(), negotiationId);
+
+            assertThat(error).isNotNull().contains("Unauthorized");
+        }
+
+        @Test
         void negotiation_fails_withMissingCredential(ManagementApiClientV5 connectorClient,
                                                      Participants participants) {
 


### PR DESCRIPTION
## What this PR changes/adds

Adds a generic CEL custom-function extension that enable simpler credentials checking  

Before

```
ctx.agent.claims.vc.filter(c, c.type.exists(t, t == 'MembershipCredential'))
                   .exists(c, c.credentialSubject.exists(cs, cs.memberOf == 'Dataspace-X'))
```

After 

```
ctx.agent.claims.vc.withType('MembershipCredential').hasClaim('memberOf', 'Dataspace-X')
```

## Why it does that

Simplify usage

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5907 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
