### PR TITLE
feat: permit trusted issuers setting by configuration

### DIFF
--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPoint.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationInjectionPoint.java
@@ -103,8 +103,7 @@ public class ConfigurationInjectionPoint<T> implements InjectionPoint<T> {
 
     @Override
     public Object resolve(ServiceExtensionContext context, DefaultServiceSupplier defaultServiceSupplier) {
-        var keyPrefix = getPrefix();
-        return configurationObjectFactory.instantiate(context, keyPrefix, configurationField.getType());
+        return configurationObjectFactory.instantiate(context, getPrefix(), configurationField.getType());
     }
 
     @Override

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationMapInjectionPoint.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationMapInjectionPoint.java
@@ -23,7 +23,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -93,18 +92,7 @@ public class ConfigurationMapInjectionPoint<T> implements InjectionPoint<T> {
 
     @Override
     public Object resolve(ServiceExtensionContext context, DefaultServiceSupplier defaultServiceSupplier) {
-        var prefix = getPrefix();
-
-        var baseConfig = prefix != null ? context.getConfig(prefix) : context.getConfig();
-
-        var result = new HashMap<String, Object>();
-        baseConfig.partition().forEach(partitionConfig -> {
-            var partitionKey = partitionConfig.currentNode();
-            var partitionPrefix = prefix != null ? prefix + "." + partitionKey : partitionKey;
-            var value = configurationObjectFactory.instantiate(context, partitionPrefix, valueType);
-            result.put(partitionKey, value);
-        });
-        return result;
+        return configurationObjectFactory.instantiateMap(context, getPrefix(), valueType);
     }
 
     @Override

--- a/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationObjectFactory.java
+++ b/core/common/boot/src/main/java/org/eclipse/edc/boot/system/injection/ConfigurationObjectFactory.java
@@ -14,14 +14,19 @@
 
 package org.eclipse.edc.boot.system.injection;
 
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.ParameterizedType;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 public class ConfigurationObjectFactory {
@@ -30,25 +35,68 @@ public class ConfigurationObjectFactory {
      * Instantiates a configuration object (record or POJO) from the context.
      */
     public Object instantiate(ServiceExtensionContext context, String keyPrefix, Class<?> type) {
-        var settingsFields = Arrays.stream(type.getDeclaredFields())
-                .filter(f -> f.getAnnotation(Setting.class) != null)
-                .map(f -> toFieldValue(context, keyPrefix, f))
+        var allFields = Arrays.stream(type.getDeclaredFields())
+                .map(f -> {
+                    if (f.getAnnotation(Setting.class) != null) {
+                        return toFieldValue(context, keyPrefix, f);
+                    } else if (f.getAnnotation(Configuration.class) != null) {
+                        return toConfigFieldValue(context, keyPrefix, f);
+                    } else {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
                 .toList();
 
         if (type.isRecord()) {
             // records are treated specially, because they only contain final fields, and must be constructed with a non-default CTOR
             // where every constructor arg MUST be named the same as the field value. We can't rely on this with normal classes
-            return instantiateFromRecord(type, settingsFields);
+            return instantiateFromRecord(type, allFields);
         } else {
             // all other classes MUST have a default constructor.
-            return instantiateFromClass(type, settingsFields);
+            return instantiateFromClass(type, allFields);
         }
+    }
+
+    /**
+     * Instantiates a configuration Map from the context
+     *
+     * @param context the context.
+     * @param keyPrefix the configuration prefix.
+     * @param valueType the value type.
+     * @return the map containing the configuration objects.
+     */
+    public Map<String, Object> instantiateMap(ServiceExtensionContext context, String keyPrefix, Class<?> valueType) {
+        var baseConfig = keyPrefix != null ? context.getConfig(keyPrefix) : context.getConfig();
+        var result = new HashMap<String, Object>();
+        baseConfig.partition().forEach(partitionConfig -> {
+            var partitionKey = partitionConfig.currentNode();
+            var partitionPrefix = keyPrefix != null ? keyPrefix + "." + partitionKey : partitionKey;
+            result.put(partitionKey, instantiate(context, partitionPrefix, valueType));
+        });
+        return result;
     }
 
     private @NotNull FieldValue toFieldValue(ServiceExtensionContext context, String keyPrefix, Field field) {
         var ip = new SettingInjectionPoint<>(null, field, keyPrefix);
         var value = ip.resolve(context, new InjectionPointDefaultServiceSupplier());
         return new FieldValue(field.getName(), value);
+    }
+
+    private @NotNull FieldValue toConfigFieldValue(ServiceExtensionContext context, String keyPrefix, Field field) {
+        var configContext = field.getAnnotation(Configuration.class).context();
+        if (configContext.isEmpty()) {
+            throw new EdcInjectionException("Nested @Configuration field '%s' in '%s' must declare a non-empty context".formatted(field.getName(), field.getDeclaringClass().getName()));
+        }
+        var nestedPrefix = keyPrefix != null ? keyPrefix + "." + configContext : configContext;
+
+        if (Map.class.isAssignableFrom(field.getType())) {
+            var genericType = (ParameterizedType) field.getGenericType();
+            var valueType = (Class<?>) genericType.getActualTypeArguments()[1];
+            return new FieldValue(field.getName(), instantiateMap(context, nestedPrefix, valueType));
+        } else {
+            return new FieldValue(field.getName(), instantiate(context, nestedPrefix, field.getType()));
+        }
     }
 
     private @NotNull Object instantiateFromClass(Class<?> type, List<FieldValue> settingsFields) {

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ConfigurationMapInjectionPointTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ConfigurationMapInjectionPointTest.java
@@ -34,7 +34,6 @@ import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -98,8 +97,8 @@ class ConfigurationMapInjectionPointTest {
         @Test
         void resolve_singleEntry() {
             var key1 = new TestExtension.ConfigurationRecord("any");
-            when(configurationObjectFactory.instantiate(any(), any(), any())).thenReturn(key1);
-            context.setConfig(ConfigFactory.fromMap(Map.of("prefix.key1.required", "any")));
+            var expected = Map.of("key1", key1);
+            when(configurationObjectFactory.instantiateMap(any(), any(), any())).thenReturn((Map) expected);
 
             var result = injectionPoint.resolve(context, mock());
 
@@ -111,23 +110,23 @@ class ConfigurationMapInjectionPointTest {
                                     assertThat(entry).isSameAs(key1);
                                 });
                     });
+            verify(configurationObjectFactory).instantiateMap(context, "prefix", TestExtension.ConfigurationRecord.class);
         }
 
         @Test
         void resolve_multipleEntries() {
-            when(configurationObjectFactory.instantiate(any(), any(), any())).thenReturn(new TestExtension.ConfigurationRecord("any"));
-            context.setConfig(ConfigFactory.fromMap(Map.of(
-                    "prefix.key1.required", "value1",
-                    "prefix.key2.required", "value2"
-            )));
+            var expected = Map.of(
+                    "key1", new TestExtension.ConfigurationRecord("value1"),
+                    "key2", new TestExtension.ConfigurationRecord("value2")
+            );
+            when(configurationObjectFactory.instantiateMap(any(), any(), any())).thenReturn((Map) expected);
 
             var result = injectionPoint.resolve(context, mock());
 
             assertThat(result).isInstanceOf(Map.class)
                     .asInstanceOf(map(String.class, TestExtension.ConfigurationRecord.class))
                     .hasSize(2);
-            verify(configurationObjectFactory, times(1)).instantiate(context, "prefix.key1", TestExtension.ConfigurationRecord.class);
-            verify(configurationObjectFactory, times(1)).instantiate(context, "prefix.key2", TestExtension.ConfigurationRecord.class);
+            verify(configurationObjectFactory).instantiateMap(context, "prefix", TestExtension.ConfigurationRecord.class);
         }
     }
 

--- a/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ConfigurationObjectFactoryTest.java
+++ b/core/common/boot/src/test/java/org/eclipse/edc/boot/system/injection/ConfigurationObjectFactoryTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.boot.system.injection;
 
 import org.eclipse.edc.junit.extensions.TestExtensionContext;
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
@@ -145,6 +146,123 @@ class ConfigurationObjectFactoryTest {
                                           @Setting(key = "duration", defaultValue = "PT1S") Duration duration) {
             public static final String DEFAULT_VALUE = "default-value";
         }
+    }
+
+    @Nested
+    class NestedConfiguration {
+
+        @Test
+        void shouldInstantiateRecordWithNestedConfigurationMap() {
+            context.setConfig(ConfigFactory.fromMap(Map.of(
+                    "required", "requiredValue",
+                    "nested.entry1.key", "value1",
+                    "nested.entry2.key", "value2"
+            )));
+
+            var object = factory.instantiate(context, null, RecordWithNestedMap.class);
+
+            assertThat(object).isInstanceOfSatisfying(RecordWithNestedMap.class, configuration -> {
+                assertThat(configuration.required()).isEqualTo("requiredValue");
+                assertThat(configuration.nested()).containsKeys("entry1", "entry2");
+                assertThat(configuration.nested().get("entry1").key()).isEqualTo("value1");
+                assertThat(configuration.nested().get("entry2").key()).isEqualTo("value2");
+            });
+        }
+
+        @Test
+        void shouldInstantiateRecordWithNestedConfigurationMapAndPrefix() {
+            context.setConfig(ConfigFactory.fromMap(Map.of(
+                    "prefix.required", "requiredValue",
+                    "prefix.nested.entry1.key", "value1",
+                    "prefix.nested.entry2.key", "value2"
+            )));
+
+            var object = factory.instantiate(context, "prefix", RecordWithNestedMap.class);
+
+            assertThat(object).isInstanceOfSatisfying(RecordWithNestedMap.class, configuration -> {
+                assertThat(configuration.required()).isEqualTo("requiredValue");
+                assertThat(configuration.nested()).containsKeys("entry1", "entry2");
+                assertThat(configuration.nested().get("entry1").key()).isEqualTo("value1");
+                assertThat(configuration.nested().get("entry2").key()).isEqualTo("value2");
+            });
+        }
+
+        @Test
+        void shouldInstantiateClassWithNestedConfigurationMap() {
+            context.setConfig(ConfigFactory.fromMap(Map.of(
+                    "required", "requiredValue",
+                    "nested.entry1.key", "value1"
+            )));
+
+            var object = factory.instantiate(context, null, ClassWithNestedMap.class);
+
+            assertThat(object).isInstanceOfSatisfying(ClassWithNestedMap.class, configuration -> {
+                assertThat(configuration.getRequired()).isEqualTo("requiredValue");
+                assertThat(configuration.getNested()).containsKey("entry1");
+                assertThat(configuration.getNested().get("entry1").key()).isEqualTo("value1");
+            });
+        }
+
+        @Test
+        void shouldThrowException_whenNestedConfigurationContextIsEmpty() {
+            context.setConfig(ConfigFactory.fromMap(Map.of("required", "requiredValue")));
+
+            assertThatThrownBy(() -> factory.instantiate(context, null, RecordWithEmptyContextConfig.class))
+                    .isInstanceOf(EdcInjectionException.class);
+        }
+
+        @Test
+        void shouldInstantiateRecordWithNestedConfigurationObject() {
+            context.setConfig(ConfigFactory.fromMap(Map.of(
+                    "required", "requiredValue",
+                    "sub.key", "nestedValue"
+            )));
+
+            var object = factory.instantiate(context, null, RecordWithNestedObject.class);
+
+            assertThat(object).isInstanceOfSatisfying(RecordWithNestedObject.class, configuration -> {
+                assertThat(configuration.required()).isEqualTo("requiredValue");
+                assertThat(configuration.sub().key()).isEqualTo("nestedValue");
+            });
+        }
+
+        @Settings
+        public record RecordWithNestedMap(
+                @Setting(key = "required") String required,
+                @Configuration(context = "nested") Map<String, NestedEntry> nested
+        ) {}
+
+        @Settings
+        public record RecordWithNestedObject(
+                @Setting(key = "required") String required,
+                @Configuration(context = "sub") NestedEntry sub
+        ) {}
+
+        @Settings
+        public static class ClassWithNestedMap {
+            @Setting(key = "required")
+            private String required;
+
+            @Configuration(context = "nested")
+            private Map<String, NestedEntry> nested;
+
+            public String getRequired() {
+                return required;
+            }
+
+            public Map<String, NestedEntry> getNested() {
+                return nested;
+            }
+        }
+
+        @Settings
+        public record RecordWithEmptyContextConfig(
+                @Setting(key = "required") String required,
+                @Configuration Map<String, NestedEntry> nested
+        ) {}
+
+        @Settings
+        public record NestedEntry(@Setting(key = "key") String key) {}
     }
 
 }

--- a/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/main/java/org/eclipse/edc/protocol/dsp/http/profile/DataspaceProfileConfigurationExtension.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/main/java/org/eclipse/edc/protocol/dsp/http/profile/DataspaceProfileConfigurationExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.protocol.dsp.http.spi.api.DspBaseWebhookAddress;
 import org.eclipse.edc.protocol.spi.DataspaceProfile;
 import org.eclipse.edc.protocol.spi.DataspaceProfileContextRegistry;
 import org.eclipse.edc.protocol.spi.DefaultParticipantIdExtractionFunction;
+import org.eclipse.edc.protocol.spi.TrustedIssuer;
 import org.eclipse.edc.protocol.spi.service.DataspaceProfileService;
 import org.eclipse.edc.protocol.spi.store.DataspaceProfileStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
@@ -30,8 +31,10 @@ import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import static org.eclipse.edc.spi.result.StoreFailure.Reason.ALREADY_EXISTS;
@@ -104,9 +107,13 @@ public class DataspaceProfileConfigurationExtension implements ServiceExtension 
     }
 
     private DataspaceProfile toDataspaceProfile(DataspaceProfileConfiguration config) {
-        var jsonLdContextsUrl = Arrays.stream(config.jsonLdContextsUrl().split(","))
-                .map(String::trim)
-                .filter(s -> !s.isBlank())
+        var jsonLdContextsUrl = splitToList(config.jsonLdContextsUrl());
+
+        var trustedIssuers = config.trustedIssuers().values().stream()
+                .map(issuerConfig -> TrustedIssuer.Builder.newInstance()
+                        .id(issuerConfig.id())
+                        .supportedTypes(splitToList(issuerConfig.supportedTypes()))
+                        .build())
                 .toList();
 
         return DataspaceProfile.Builder.newInstance()
@@ -116,7 +123,15 @@ public class DataspaceProfileConfigurationExtension implements ServiceExtension 
                 .binding(config.protocolBinding())
                 .namespace(config.protocolNamespace())
                 .jsonLdContextsUrl(jsonLdContextsUrl)
+                .trustedIssuers(trustedIssuers)
                 .build();
+    }
+
+    private @NotNull List<String> splitToList(String s1) {
+        return Arrays.stream(s1.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .toList();
     }
 
     @Settings
@@ -140,7 +155,19 @@ public class DataspaceProfileConfigurationExtension implements ServiceExtension 
             @Setting(
                     key = PROFILE_JSON_LD_CONTEXT,
                     description = "The JSON-LD context URLs of the dataspace profile.")
-            String jsonLdContextsUrl
+            String jsonLdContextsUrl,
+            @Configuration(context = "trustedissuers")
+            Map<String, TrustedIssuerConfiguration> trustedIssuers
+    ) {
+
+    }
+
+    @Settings
+    private record TrustedIssuerConfiguration(
+            @Setting(key = "id", description = "trusted issuer id.")
+            String id,
+            @Setting(key = "supportedtypes", description = "trusted issuer supported credential types")
+            String supportedTypes
     ) {
 
     }

--- a/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/test/java/org/eclipse/edc/protocol/dsp/http/profile/DataspaceProfileConfigurationExtensionTest.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-http-core-virtual/src/test/java/org/eclipse/edc/protocol/dsp/http/profile/DataspaceProfileConfigurationExtensionTest.java
@@ -71,7 +71,9 @@ class DataspaceProfileConfigurationExtensionTest {
                 "edc.dataspace.profiles.dsp2025_1.protocol.version", "2025-1",
                 "edc.dataspace.profiles.dsp2025_1.protocol.binding", "HTTPS",
                 "edc.dataspace.profiles.dsp2025_1.protocol.namespace", "https://w3id.org/dspace/v1",
-                "edc.dataspace.profiles.dsp2025_1.jsonld.context.urls", "https://w3id.org/dspace/v1/context.jsonld , https://example.org/extra.jsonld"
+                "edc.dataspace.profiles.dsp2025_1.jsonld.context.urls", "https://w3id.org/dspace/v1/context.jsonld , https://example.org/extra.jsonld",
+                "edc.dataspace.profiles.dsp2025_1.trustedissuers.alias.id", "did:web:trusted.issuer",
+                "edc.dataspace.profiles.dsp2025_1.trustedissuers.alias.supportedtypes", "MembershipCredential , AlternativeCredential"
         )));
         when(store.create(any())).thenAnswer(i -> StoreResult.success(i.getArgument(0)));
         var stored = DataspaceProfile.Builder.newInstance()
@@ -95,6 +97,10 @@ class DataspaceProfileConfigurationExtensionTest {
         assertThat(seeded.getNamespace()).isEqualTo("https://w3id.org/dspace/v1");
         assertThat(seeded.getJsonLdContextsUrl())
                 .containsExactly("https://w3id.org/dspace/v1/context.jsonld", "https://example.org/extra.jsonld");
+        assertThat(seeded.getTrustedIssuers()).hasSize(1).first().satisfies(trustedIssuer -> {
+            assertThat(trustedIssuer.getId()).isEqualTo("did:web:trusted.issuer");
+            assertThat(trustedIssuer.getSupportedTypes()).containsExactlyInAnyOrder("MembershipCredential", "AlternativeCredential");
+        });
 
         var contextCaptor = ArgumentCaptor.forClass(DataspaceProfileContext.class);
         verify(registry).register(contextCaptor.capture());


### PR DESCRIPTION
## What this PR changes/adds

Permits trustedIssers to be added to a DataspaceProfile by configuration.
To enable that, the configuration injection mechanism has been enhanced to permit nested `@Configuration` objects (see `DataspaceProfileConfiguration` containing a `Map<String, TrustedIssuerConfiguration>`)

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5912 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
