### PR TITLE
refactor: change TypeTransformerRegistry to use a Map instead of Arraylist

### DIFF
--- a/core/catalog-crawler/catalog-crawler-core/src/test/java/org/eclipse/edc/catalog/crawler/cache/query/DspCatalogRequestActionTest.java
+++ b/core/catalog-crawler/catalog-crawler-core/src/test/java/org/eclipse/edc/catalog/crawler/cache/query/DspCatalogRequestActionTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
 class DspCatalogRequestActionTest {
 
     private final ProtocolRemoteMessageDispatcher messageDispatcher = mock();
-    private final TypeTransformerRegistry typeTransformerRegistry = new TypeTransformerRegistryImpl();
+    private final TypeTransformerRegistry typeTransformerRegistry = new TypeTransformerRegistryImpl(mock());
     private final ObjectMapper objectMapper = createObjectMapper();
     private final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(
             ParticipantContext.Builder.newInstance().participantContextId("participantContext").identity("identity").build());

--- a/core/catalog-crawler/catalog-crawler-core/src/test/java/org/eclipse/edc/catalog/crawler/cache/query/PagingCatalogFetcherTest.java
+++ b/core/catalog-crawler/catalog-crawler-core/src/test/java/org/eclipse/edc/catalog/crawler/cache/query/PagingCatalogFetcherTest.java
@@ -55,7 +55,7 @@ class PagingCatalogFetcherTest {
     private final ObjectMapper objectMapper = createObjectMapper();
     private final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(
             ParticipantContext.Builder.newInstance().participantContextId("participantContext").identity("identity").build());
-    private final TypeTransformerRegistry typeTransformerRegistry = new TypeTransformerRegistryImpl();
+    private final TypeTransformerRegistry typeTransformerRegistry = new TypeTransformerRegistryImpl(mock());
     private PagingCatalogFetcher fetcher;
 
     @BeforeEach

--- a/core/common/lib/core-lib/src/test/java/org/eclipse/edc/api/management/schema/ManagementApiSchemaTest.java
+++ b/core/common/lib/core-lib/src/test/java/org/eclipse/edc/api/management/schema/ManagementApiSchemaTest.java
@@ -58,7 +58,7 @@ class ManagementApiSchemaTest {
 
     private final ObjectMapper objectMapper = JacksonJsonLd.createObjectMapper();
     private final TypeManager typeManager = mock();
-    private final TypeTransformerRegistry transformer = new TypeTransformerRegistryImpl();
+    private final TypeTransformerRegistry transformer = new TypeTransformerRegistryImpl(mock());
 
     @BeforeEach
     void setUp() {

--- a/core/common/lib/core-lib/src/test/java/org/eclipse/edc/api/model/ApiCoreSchemaTest.java
+++ b/core/common/lib/core-lib/src/test/java/org/eclipse/edc/api/model/ApiCoreSchemaTest.java
@@ -52,7 +52,7 @@ class ApiCoreSchemaTest {
 
     private final ObjectMapper objectMapper = JacksonJsonLd.createObjectMapper();
     private final TypeManager typeManager = mock();
-    private final TypeTransformerRegistry transformer = new TypeTransformerRegistryImpl();
+    private final TypeTransformerRegistry transformer = new TypeTransformerRegistryImpl(mock());
     private final CriterionOperatorRegistry criterionOperatorRegistry = CriterionOperatorRegistryImpl.ofDefaults();
 
     @BeforeEach

--- a/core/common/lib/jsonld-lib/src/main/java/org/eclipse/edc/transform/TypeTransformerRegistryImpl.java
+++ b/core/common/lib/jsonld-lib/src/main/java/org/eclipse/edc/transform/TypeTransformerRegistryImpl.java
@@ -25,21 +25,16 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BinaryOperator;
 
 import static java.lang.String.format;
 
 public class TypeTransformerRegistryImpl implements TypeTransformerRegistry {
-    private static final Monitor NOOP_MONITOR = new Monitor() {
-    };
 
     private final Map<Class<?>, Map<Class<?>, TypeTransformer<?, ?>>> transformers = new HashMap<>();
     private final Map<String, TypeTransformerRegistry> contextRegistries = new HashMap<>();
     private final Monitor monitor;
     private TypeTransformerRegistry parent;
-
-    public TypeTransformerRegistryImpl() {
-        this(NOOP_MONITOR);
-    }
 
     public TypeTransformerRegistryImpl(Monitor monitor) {
         this.monitor = monitor;
@@ -47,14 +42,14 @@ public class TypeTransformerRegistryImpl implements TypeTransformerRegistry {
 
     private TypeTransformerRegistryImpl(TypeTransformerRegistryImpl parent) {
         this.parent = parent;
-        monitor = parent.monitor;
+        this.monitor = parent.monitor;
     }
 
     @Override
     public void register(TypeTransformer<?, ?> transformer) {
-        var registeredTransformer = transformers.computeIfAbsent(transformer.getInputType(), key -> new HashMap<>())
+        var overriddenTransformer = transformers.computeIfAbsent(transformer.getInputType(), key -> new HashMap<>())
                 .put(transformer.getOutputType(), transformer);
-        if (registeredTransformer != null) {
+        if (overriddenTransformer != null) {
             monitor.warning(format("Overriding transformer registered for %s -> %s", transformer.getInputType(), transformer.getOutputType()));
         }
     }
@@ -64,40 +59,32 @@ public class TypeTransformerRegistryImpl implements TypeTransformerRegistry {
         return contextRegistries.computeIfAbsent(context, k -> new TypeTransformerRegistryImpl(this));
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public @NotNull <INPUT, OUTPUT> TypeTransformer<INPUT, OUTPUT> transformerFor(@NotNull INPUT input, @NotNull Class<OUTPUT> outputType) {
-        return findTransformer(input, outputType)
-                .map(it -> (TypeTransformer<INPUT, OUTPUT>) it)
-                .or(() -> Optional.ofNullable(parent).map(p -> p.transformerFor(input, outputType)))
-                .orElseThrow(() -> new EdcException(format("No Transformer registered that can handle %s -> %s", input.getClass(), outputType)));
-    }
-
-    private Optional<TypeTransformer<?, ?>> findTransformer(Object input, Class<?> outputType) {
-        return findMostSpecificInputType(input, outputType)
-                .map(transformers::get)
-                .map(transformersByOutputType -> transformersByOutputType.get(outputType));
-    }
-
-    private Optional<Class<?>> findMostSpecificInputType(Object input, Class<?> outputType) {
         return transformers.entrySet().stream()
                 .filter(entry -> entry.getKey().isInstance(input))
                 .filter(entry -> entry.getValue().containsKey(outputType))
                 .<Class<?>>map(Map.Entry::getKey)
-                .map(inputType -> Optional.<Class<?>>of(inputType))
-                .reduce(Optional.<Class<?>>empty(), (current, candidate) -> {
-                    if (current.isEmpty()) {
-                        return candidate;
-                    }
+                .reduce(selectMostSpecificType(input.getClass(), outputType))
+                .map(transformers::get)
+                .map(it -> (TypeTransformer<INPUT, OUTPUT>) it.get(outputType))
+                .or(() -> Optional.ofNullable(parent).map(p -> p.transformerFor(input, outputType)))
+                .orElseThrow(() -> new EdcException(format("No Transformer registered that can handle %s -> %s", input.getClass(), outputType)));
+    }
 
-                    if (candidate.get().isAssignableFrom(current.get())) {
-                        return current;
-                    }
+    private BinaryOperator<Class<?>> selectMostSpecificType(Class<?> inputType, Class<?> outputType) {
+        return (current, candidate) -> {
+            if (candidate.isAssignableFrom(current)) {
+                return current;
+            }
 
-                    if (current.get().isAssignableFrom(candidate.get())) {
-                        return candidate;
-                    }
-                    throw new EdcException(format("Ambiguous transformers registered for %s -> %s", input.getClass(), outputType));
-                });
+            if (current.isAssignableFrom(candidate)) {
+                return candidate;
+            }
+
+            throw new EdcException(format("Ambiguous transformers registered for %s -> %s", inputType, outputType));
+        };
     }
 
     @Override

--- a/core/common/lib/jsonld-lib/src/main/java/org/eclipse/edc/transform/TypeTransformerRegistryImpl.java
+++ b/core/common/lib/jsonld-lib/src/main/java/org/eclipse/edc/transform/TypeTransformerRegistryImpl.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.transform;
 
 import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.transform.spi.TypeTransformer;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
@@ -28,22 +29,34 @@ import java.util.Optional;
 import static java.lang.String.format;
 
 public class TypeTransformerRegistryImpl implements TypeTransformerRegistry {
-    private final Map<String, Class<?>> aliases = new HashMap<>();
+    private static final Monitor NOOP_MONITOR = new Monitor() {
+    };
+
     private final Map<Class<?>, Map<Class<?>, TypeTransformer<?, ?>>> transformers = new HashMap<>();
     private final Map<String, TypeTransformerRegistry> contextRegistries = new HashMap<>();
+    private final Monitor monitor;
     private TypeTransformerRegistry parent;
 
     public TypeTransformerRegistryImpl() {
+        this(NOOP_MONITOR);
     }
 
-    private TypeTransformerRegistryImpl(TypeTransformerRegistry parent) {
+    public TypeTransformerRegistryImpl(Monitor monitor) {
+        this.monitor = monitor;
+    }
+
+    private TypeTransformerRegistryImpl(TypeTransformerRegistryImpl parent) {
         this.parent = parent;
+        monitor = parent.monitor;
     }
 
     @Override
     public void register(TypeTransformer<?, ?> transformer) {
-        transformers.computeIfAbsent(transformer.getInputType(), key -> new HashMap<>())
-                    .put(transformer.getOutputType(), transformer);
+        var registeredTransformer = transformers.computeIfAbsent(transformer.getInputType(), key -> new HashMap<>())
+                .put(transformer.getOutputType(), transformer);
+        if (registeredTransformer != null) {
+            monitor.warning(format("Overriding transformer registered for %s -> %s", transformer.getInputType(), transformer.getOutputType()));
+        }
     }
 
     @Override
@@ -60,24 +73,31 @@ public class TypeTransformerRegistryImpl implements TypeTransformerRegistry {
     }
 
     private Optional<TypeTransformer<?, ?>> findTransformer(Object input, Class<?> outputType) {
-        var inputTypes = transformers.entrySet().stream()
+        return findMostSpecificInputType(input, outputType)
+                .map(transformers::get)
+                .map(transformersByOutputType -> transformersByOutputType.get(outputType));
+    }
+
+    private Optional<Class<?>> findMostSpecificInputType(Object input, Class<?> outputType) {
+        return transformers.entrySet().stream()
                 .filter(entry -> entry.getKey().isInstance(input))
                 .filter(entry -> entry.getValue().containsKey(outputType))
-                .map(Map.Entry::getKey)
-                .toList();
+                .<Class<?>>map(Map.Entry::getKey)
+                .map(inputType -> Optional.<Class<?>>of(inputType))
+                .reduce(Optional.<Class<?>>empty(), (current, candidate) -> {
+                    if (current.isEmpty()) {
+                        return candidate;
+                    }
 
-        var mostSpecificInputTypes = inputTypes.stream()
-                .filter(candidate -> inputTypes.stream()
-                        .noneMatch(other -> !candidate.equals(other) && candidate.isAssignableFrom(other)))
-                .toList();
+                    if (candidate.get().isAssignableFrom(current.get())) {
+                        return current;
+                    }
 
-        if (mostSpecificInputTypes.size() > 1) {
-            throw new EdcException(format("Ambiguous transformers registered for %s -> %s", input.getClass(), outputType));
-        }
-
-        return mostSpecificInputTypes.stream()
-                .findFirst()
-            .map(inputType -> transformers.get(inputType).get(outputType));
+                    if (current.get().isAssignableFrom(candidate.get())) {
+                        return candidate;
+                    }
+                    throw new EdcException(format("Ambiguous transformers registered for %s -> %s", input.getClass(), outputType));
+                });
     }
 
     @Override

--- a/core/common/lib/jsonld-lib/src/main/java/org/eclipse/edc/transform/TypeTransformerRegistryImpl.java
+++ b/core/common/lib/jsonld-lib/src/main/java/org/eclipse/edc/transform/TypeTransformerRegistryImpl.java
@@ -20,9 +20,7 @@ import org.eclipse.edc.transform.spi.TypeTransformer;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -31,7 +29,7 @@ import static java.lang.String.format;
 
 public class TypeTransformerRegistryImpl implements TypeTransformerRegistry {
     private final Map<String, Class<?>> aliases = new HashMap<>();
-    private final List<TypeTransformer<?, ?>> transformers = new ArrayList<>();
+    private final Map<Class<?>, Map<Class<?>, TypeTransformer<?, ?>>> transformers = new HashMap<>();
     private final Map<String, TypeTransformerRegistry> contextRegistries = new HashMap<>();
     private TypeTransformerRegistry parent;
 
@@ -44,7 +42,8 @@ public class TypeTransformerRegistryImpl implements TypeTransformerRegistry {
 
     @Override
     public void register(TypeTransformer<?, ?> transformer) {
-        this.transformers.add(transformer);
+        transformers.computeIfAbsent(transformer.getInputType(), key -> new HashMap<>())
+                    .put(transformer.getOutputType(), transformer);
     }
 
     @Override
@@ -54,12 +53,31 @@ public class TypeTransformerRegistryImpl implements TypeTransformerRegistry {
 
     @Override
     public @NotNull <INPUT, OUTPUT> TypeTransformer<INPUT, OUTPUT> transformerFor(@NotNull INPUT input, @NotNull Class<OUTPUT> outputType) {
-        return transformers.stream()
-                .filter(t -> t.getInputType().isInstance(input) && t.getOutputType().equals(outputType))
-                .findAny()
+        return findTransformer(input, outputType)
                 .map(it -> (TypeTransformer<INPUT, OUTPUT>) it)
                 .or(() -> Optional.ofNullable(parent).map(p -> p.transformerFor(input, outputType)))
                 .orElseThrow(() -> new EdcException(format("No Transformer registered that can handle %s -> %s", input.getClass(), outputType)));
+    }
+
+    private Optional<TypeTransformer<?, ?>> findTransformer(Object input, Class<?> outputType) {
+        var inputTypes = transformers.entrySet().stream()
+                .filter(entry -> entry.getKey().isInstance(input))
+                .filter(entry -> entry.getValue().containsKey(outputType))
+                .map(Map.Entry::getKey)
+                .toList();
+
+        var mostSpecificInputTypes = inputTypes.stream()
+                .filter(candidate -> inputTypes.stream()
+                        .noneMatch(other -> !candidate.equals(other) && candidate.isAssignableFrom(other)))
+                .toList();
+
+        if (mostSpecificInputTypes.size() > 1) {
+            throw new EdcException(format("Ambiguous transformers registered for %s -> %s", input.getClass(), outputType));
+        }
+
+        return mostSpecificInputTypes.stream()
+                .findFirst()
+            .map(inputType -> transformers.get(inputType).get(outputType));
     }
 
     @Override

--- a/core/common/lib/jsonld-lib/src/test/java/org/eclipse/edc/transform/TestTypeTransformer.java
+++ b/core/common/lib/jsonld-lib/src/test/java/org/eclipse/edc/transform/TestTypeTransformer.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2022 - 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.transform;
+
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.eclipse.edc.transform.spi.TypeTransformer;
+
+public class TestTypeTransformer<INPUT, OUTPUT> implements TypeTransformer<INPUT, OUTPUT> {
+    private final Class<INPUT> inputType;
+    private final Class<OUTPUT> outputType;
+
+    public TestTypeTransformer(Class<INPUT> inputType, Class<OUTPUT> outputType) {
+        this.inputType = inputType;
+        this.outputType = outputType;
+    }
+
+    @Override
+    public Class<INPUT> getInputType() {
+        return inputType;
+    }
+
+    @Override
+    public Class<OUTPUT> getOutputType() {
+        return outputType;
+    }
+
+    @Override
+    public OUTPUT transform(INPUT input, TransformerContext context) {
+        return null;
+    }
+}

--- a/core/common/lib/jsonld-lib/src/test/java/org/eclipse/edc/transform/TestTypeTransformer.java
+++ b/core/common/lib/jsonld-lib/src/test/java/org/eclipse/edc/transform/TestTypeTransformer.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 - 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2026 Amadeus
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Amadeus - Initial API and Implementation
  *
  */
 

--- a/core/common/lib/jsonld-lib/src/test/java/org/eclipse/edc/transform/TypeTransformerRegistryImplTest.java
+++ b/core/common/lib/jsonld-lib/src/test/java/org/eclipse/edc/transform/TypeTransformerRegistryImplTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -44,6 +45,34 @@ public class TypeTransformerRegistryImplTest {
             var transformer = registry.transformerFor("a string", Integer.class);
 
             assertThat(transformer).isInstanceOf(StringIntegerTypeTransformer.class);
+        }
+
+        @Test
+        void shouldReplaceTransformerForTheSameInputAndOutputTypes() {
+            var replacement = new TestTypeTransformer<>(String.class, Integer.class);
+            registry.register(replacement);
+
+            assertThat(registry.transformerFor("a string", Integer.class)).isSameAs(replacement);
+        }
+
+        @Test
+        void shouldReturnMostSpecificCompatibleTransformer() {
+            var objectTransformer = new TestTypeTransformer<>(Object.class, Long.class);
+            var charSequenceTransformer = new TestTypeTransformer<>(CharSequence.class, Long.class);
+            registry.register(objectTransformer);
+            registry.register(charSequenceTransformer);
+
+            assertThat(registry.transformerFor("a string", Long.class)).isSameAs(charSequenceTransformer);
+        }
+
+        @Test
+        void shouldThrowExceptionWhenCompatibleTransformersAreAmbiguous() {
+            registry.register(new TestTypeTransformer<>(CharSequence.class, Long.class));
+            registry.register(new TestTypeTransformer<>(Comparable.class, Long.class));
+
+            assertThatThrownBy(() -> registry.transformerFor("a string", Long.class))
+                    .isInstanceOf(EdcException.class)
+                    .hasMessageContaining("Ambiguous transformers");
         }
 
         @Test
@@ -96,11 +125,21 @@ public class TypeTransformerRegistryImplTest {
             TypeTransformer<Integer, String> typeTransformer = mock();
             contextRegistry.register(typeTransformer);
             registry.register(typeTransformer);
+            clearInvocations((Object) typeTransformer);
 
             assertThat(nestedContextRegistry.transform(5, String.class))
                     .isSucceeded().isEqualTo("5");
 
             verifyNoInteractions(typeTransformer);
+        }
+
+        @Test
+        void shouldOverrideParentTransformer() {
+            var replacement = new TestTypeTransformer<>(String.class, Integer.class);
+            contextRegistry.register(replacement);
+
+            assertThat(contextRegistry.transformerFor("a string", Integer.class)).isSameAs(replacement);
+            assertThat(registry.transformerFor("a string", Integer.class)).isInstanceOf(StringIntegerTypeTransformer.class);
         }
 
     }

--- a/core/common/lib/jsonld-lib/src/test/java/org/eclipse/edc/transform/TypeTransformerRegistryImplTest.java
+++ b/core/common/lib/jsonld-lib/src/test/java/org/eclipse/edc/transform/TypeTransformerRegistryImplTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.transform;
 
 import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformer;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,13 +25,16 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 public class TypeTransformerRegistryImplTest {
 
-    private final TypeTransformerRegistry registry = new TypeTransformerRegistryImpl();
+    private final Monitor monitor = mock();
+    private final TypeTransformerRegistry registry = new TypeTransformerRegistryImpl(monitor);
 
     @BeforeEach
     void setUp() {
@@ -53,6 +57,7 @@ public class TypeTransformerRegistryImplTest {
             registry.register(replacement);
 
             assertThat(registry.transformerFor("a string", Integer.class)).isSameAs(replacement);
+            verify(monitor).warning(contains("Overriding transformer registered"));
         }
 
         @Test

--- a/core/common/runtime-core/src/main/java/org/eclipse/edc/runtime/core/RuntimeCoreServicesExtension.java
+++ b/core/common/runtime-core/src/main/java/org/eclipse/edc/runtime/core/RuntimeCoreServicesExtension.java
@@ -96,8 +96,8 @@ public class RuntimeCoreServicesExtension implements ServiceExtension {
     }
 
     @Provider
-    public TypeTransformerRegistry typeTransformerRegistry() {
-        return new TypeTransformerRegistryImpl();
+    public TypeTransformerRegistry typeTransformerRegistry(ServiceExtensionContext context) {
+        return new TypeTransformerRegistryImpl(context.getMonitor());
     }
 
     @Provider

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/to/JsonObjectToParticipantContextTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/to/JsonObjectToParticipantContextTransformerTest.java
@@ -43,7 +43,7 @@ class JsonObjectToParticipantContextTransformerTest {
     @BeforeEach
     void setUp() {
         var transformer = new JsonObjectToParticipantContextTransformer();
-        typeTransformerRegistry = new TypeTransformerRegistryImpl();
+        typeTransformerRegistry = new TypeTransformerRegistryImpl(mock());
         typeTransformerRegistry.register(new JsonValueToGenericTypeTransformer(typeManager, "test"));
         typeTransformerRegistry.register(transformer);
         typeTransformerRegistry.register(new JsonObjectToDataAddressTransformer());

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToAssetTransformerTest.java
@@ -68,7 +68,7 @@ class JsonObjectToAssetTransformerTest {
     @BeforeEach
     void setUp() {
         var transformer = new JsonObjectToAssetTransformer();
-        typeTransformerRegistry = new TypeTransformerRegistryImpl();
+        typeTransformerRegistry = new TypeTransformerRegistryImpl(mock());
         typeTransformerRegistry.register(new JsonValueToGenericTypeTransformer(typeManager, "test"));
         typeTransformerRegistry.register(transformer);
         typeTransformerRegistry.register(new JsonObjectToDataAddressTransformer());

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToDataplaneMetadataTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/to/JsonObjectToDataplaneMetadataTransformerTest.java
@@ -61,7 +61,7 @@ class JsonObjectToDataplaneMetadataTransformerTest {
     @BeforeEach
     void setUp() {
         var transformer = new JsonObjectToDataplaneMetadataTransformer();
-        typeTransformerRegistry = new TypeTransformerRegistryImpl();
+        typeTransformerRegistry = new TypeTransformerRegistryImpl(mock());
         typeTransformerRegistry.register(new JsonValueToGenericTypeTransformer(typeManager, "test"));
         typeTransformerRegistry.register(transformer);
 

--- a/data-protocols/dsp/dsp-lib/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/decorator/Base64ContinuationTokenSerDesTest.java
+++ b/data-protocols/dsp/dsp-lib/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/decorator/Base64ContinuationTokenSerDesTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.when;
 class Base64ContinuationTokenSerDesTest {
 
     private final TypeManager typeManager = mock();
-    private final TypeTransformerRegistryImpl typeTransformerRegistry = new TypeTransformerRegistryImpl();
+    private final TypeTransformerRegistryImpl typeTransformerRegistry = new TypeTransformerRegistryImpl(mock());
     private final ObjectMapper objectMapper = JacksonJsonLd.createObjectMapper();
     private final Base64continuationTokenSerDes serDes = new Base64continuationTokenSerDes(typeTransformerRegistry, new TitaniumJsonLd(mock()));
 

--- a/extensions/common/api/document-cache-api/src/test/java/org/eclipse/edc/document/cache/api/v5/transform/JsonObjectToCachedDocumentTransformerTest.java
+++ b/extensions/common/api/document-cache-api/src/test/java/org/eclipse/edc/document/cache/api/v5/transform/JsonObjectToCachedDocumentTransformerTest.java
@@ -33,6 +33,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
+import static org.mockito.Mockito.mock;
 
 class JsonObjectToCachedDocumentTransformerTest {
 
@@ -41,7 +42,7 @@ class JsonObjectToCachedDocumentTransformerTest {
 
     @BeforeEach
     void setUp() {
-        registry = new TypeTransformerRegistryImpl();
+        registry = new TypeTransformerRegistryImpl(mock());
         registry.register(new JsonObjectToCachedDocumentTransformer());
     }
 

--- a/extensions/common/api/schema-validation-api/src/test/java/org/eclipse/edc/validator/registration/api/v5/transform/JsonObjectFromSchemaValidatorRegistrationTransformerTest.java
+++ b/extensions/common/api/schema-validation-api/src/test/java/org/eclipse/edc/validator/registration/api/v5/transform/JsonObjectFromSchemaValidatorRegistrationTransformerTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.Mockito.mock;
 
 class JsonObjectFromSchemaValidatorRegistrationTransformerTest {
 
@@ -36,7 +37,7 @@ class JsonObjectFromSchemaValidatorRegistrationTransformerTest {
 
     @BeforeEach
     void setUp() {
-        registry = new TypeTransformerRegistryImpl();
+        registry = new TypeTransformerRegistryImpl(mock());
         registry.register(new JsonObjectFromSchemaValidatorRegistrationTransformer(jsonFactory));
         registry.register(new JsonObjectToSchemaValidatorRegistrationTransformer());
     }

--- a/extensions/common/api/schema-validation-api/src/test/java/org/eclipse/edc/validator/registration/api/v5/transform/JsonObjectToSchemaValidatorRegistrationTransformerTest.java
+++ b/extensions/common/api/schema-validation-api/src/test/java/org/eclipse/edc/validator/registration/api/v5/transform/JsonObjectToSchemaValidatorRegistrationTransformerTest.java
@@ -32,6 +32,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2;
 import static org.eclipse.edc.validator.registration.spi.SchemaValidatorRegistration.SCHEMA_VALIDATOR_REGISTRATION_TYPE_TERM;
+import static org.mockito.Mockito.mock;
 
 class JsonObjectToSchemaValidatorRegistrationTransformerTest {
 
@@ -40,7 +41,7 @@ class JsonObjectToSchemaValidatorRegistrationTransformerTest {
 
     @BeforeEach
     void setUp() {
-        registry = new TypeTransformerRegistryImpl();
+        registry = new TypeTransformerRegistryImpl(mock());
         registry.register(new JsonObjectToSchemaValidatorRegistrationTransformer());
     }
 

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/test/java/org/eclipse/edc/iam/decentralizedclaims/transform/serde/PresentationResponseMessageSerdeTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/test/java/org/eclipse/edc/iam/decentralizedclaims/transform/serde/PresentationResponseMessageSerdeTest.java
@@ -39,7 +39,7 @@ public class PresentationResponseMessageSerdeTest {
 
     private final ObjectMapper mapper = JacksonJsonLd.createObjectMapper();
     private final TypeManager typeManager = mock();
-    private final TypeTransformerRegistry trr = new TypeTransformerRegistryImpl();
+    private final TypeTransformerRegistry trr = new TypeTransformerRegistryImpl(mock());
     private final TransformerContext context = new TransformerContextImpl(trr);
 
 

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/test/java/org/eclipse/edc/iam/decentralizedclaims/transform/to/JsonObjectToPresentationQueryMessageTransformerTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/test/java/org/eclipse/edc/iam/decentralizedclaims/transform/to/JsonObjectToPresentationQueryMessageTransformerTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.when;
 class JsonObjectToPresentationQueryMessageTransformerTest {
     private final ObjectMapper mapper = JacksonJsonLd.createObjectMapper();
     private final TypeManager typeManager = mock();
-    private final TypeTransformerRegistry trr = new TypeTransformerRegistryImpl();
+    private final TypeTransformerRegistry trr = new TypeTransformerRegistryImpl(mock());
     private final TransformerContext context = new TransformerContextImpl(trr);
 
 

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/test/java/org/eclipse/edc/iam/decentralizedclaims/transform/to/JsonObjectToPresentationResponseMessageTransformerTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/test/java/org/eclipse/edc/iam/decentralizedclaims/transform/to/JsonObjectToPresentationResponseMessageTransformerTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 class JsonObjectToPresentationResponseMessageTransformerTest {
     private final ObjectMapper mapper = JacksonJsonLd.createObjectMapper();
     private final TypeManager typeManager = mock();
-    private final TypeTransformerRegistry trr = new TypeTransformerRegistryImpl();
+    private final TypeTransformerRegistry trr = new TypeTransformerRegistryImpl(mock());
     private final TransformerContext context = new TransformerContextImpl(trr);
 
     @BeforeEach

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/test/java/org/eclipse/edc/iam/decentralizedclaims/transform/to/JsonObjectToVerifiableCredentialTransformerTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/test/java/org/eclipse/edc/iam/decentralizedclaims/transform/to/JsonObjectToVerifiableCredentialTransformerTest.java
@@ -53,7 +53,7 @@ class JsonObjectToVerifiableCredentialTransformerTest {
     @BeforeEach
     void setUp() {
         transformer = new JsonObjectToVerifiableCredentialTransformer();
-        var registry = new TypeTransformerRegistryImpl();
+        var registry = new TypeTransformerRegistryImpl(mock());
         registry.register(new JsonObjectToCredentialSubjectTransformer());
         registry.register(new JsonObjectToCredentialStatusTransformer());
         registry.register(new JsonValueToGenericTypeTransformer(typeManager, "test"));

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/test/java/org/eclipse/edc/iam/decentralizedclaims/transform/to/JsonObjectToVerifiablePresentationTransformerTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/test/java/org/eclipse/edc/iam/decentralizedclaims/transform/to/JsonObjectToVerifiablePresentationTransformerTest.java
@@ -50,7 +50,7 @@ class JsonObjectToVerifiablePresentationTransformerTest {
     @BeforeEach
     void setup() {
         transformer = new JsonObjectToVerifiablePresentationTransformer();
-        var registry = new TypeTransformerRegistryImpl();
+        var registry = new TypeTransformerRegistryImpl(mock());
         registry.register(new JsonObjectToCredentialSubjectTransformer());
         registry.register(new JsonObjectToCredentialStatusTransformer());
         registry.register(new JsonObjectToVerifiableCredentialTransformer());

--- a/extensions/control-plane/api/management-api/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/v4/DataPlaneApiSelectorV4Test.java
+++ b/extensions/control-plane/api/management-api/data-plane-selector-api/src/test/java/org/eclipse/edc/connector/dataplane/selector/api/v4/DataPlaneApiSelectorV4Test.java
@@ -38,7 +38,7 @@ public class DataPlaneApiSelectorV4Test {
 
     private final TypeManager typeManager = mock();
     private final ObjectMapper objectMapper = JacksonJsonLd.createObjectMapper();
-    private final TypeTransformerRegistry transformer = new TypeTransformerRegistryImpl();
+    private final TypeTransformerRegistry transformer = new TypeTransformerRegistryImpl(mock());
 
     @BeforeEach
     void setUp() {

--- a/extensions/federated-catalog/api/federated-catalog-api/src/test/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiControllerTest.java
+++ b/extensions/federated-catalog/api/federated-catalog-api/src/test/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiControllerTest.java
@@ -150,7 +150,7 @@ class FederatedCatalogApiControllerTest extends RestControllerTestBase {
 
     @Override
     protected Object controller() {
-        var typeTransformerRegistry = new TypeTransformerRegistryImpl();
+        var typeTransformerRegistry = new TypeTransformerRegistryImpl(mock());
         var factory = Json.createBuilderFactory(Map.of());
         var mapper = new JacksonTypeManager();
         var participantIdMapper = new TestUtil.NoOpParticipantIdMapper();

--- a/system-tests/e2e-federatedcatalog-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/FederatedCatalogTest.java
+++ b/system-tests/e2e-federatedcatalog-tests/end2end-test/e2e-junit-runner/src/test/java/org/eclipse/edc/end2end/FederatedCatalogTest.java
@@ -75,6 +75,7 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_CONNECTOR_MANAGEME
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
+import static org.mockito.Mockito.mock;
 
 @EndToEndTest
 class FederatedCatalogTest {
@@ -128,7 +129,7 @@ class FederatedCatalogTest {
                     )))
     );
 
-    private final TypeTransformerRegistry typeTransformerRegistry = new TypeTransformerRegistryImpl();
+    private final TypeTransformerRegistry typeTransformerRegistry = new TypeTransformerRegistryImpl(mock());
     private final TypeManager mapper = new JacksonTypeManager();
     private final CatalogApiClient apiClient = new CatalogApiClient(CATALOG_MANAGEMENT, CONNECTOR_MANAGEMENT,
             JacksonJsonLd.createObjectMapper(), () -> catalog.getService(JsonLd.class), typeTransformerRegistry);


### PR DESCRIPTION
## What this PR changes/adds

This PR is to change the current TypeTransformerRegistry from an ArrayList to be a Map. This guarantees the existence of only one unique transformer type in the registry and make the transformer selection more deterministic. The PR is the implementation of this [DR](https://github.com/mokhairymahmoud/Connector/tree/main/docs/developer/decision-records/2026-07-24-transformers-registry) 

## Why it does that

The current way of tackling the typeTransformerRegistry is based on ArrayList with a selection mechanism based on findAny() which makes it indeterministic to select a specific transformer specially if there are two of the same type. 

## Linked Issue(s)

Related to #5921 

_Please be sure to take a look at the [contributing guidelines](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/#submitting-a-pull-request) and our [etiquette for pull requests](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/pr-etiquette/)._
