### PR TITLE
feat: avoid double deserialization on json-ld ingress calls

### DIFF
--- a/core/common/lib/core-lib/src/main/java/org/eclipse/edc/web/jersey/providers/jsonld/AbstractJerseyJsonLdInterceptor.java
+++ b/core/common/lib/core-lib/src/main/java/org/eclipse/edc/web/jersey/providers/jsonld/AbstractJerseyJsonLdInterceptor.java
@@ -17,87 +17,24 @@ package org.eclipse.edc.web.jersey.providers.jsonld;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.ext.ReaderInterceptor;
-import jakarta.ws.rs.ext.ReaderInterceptorContext;
 import jakarta.ws.rs.ext.WriterInterceptor;
 import jakarta.ws.rs.ext.WriterInterceptorContext;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
-import org.eclipse.edc.web.spi.exception.InvalidRequestException;
-import org.eclipse.edc.web.spi.exception.ValidationFailureException;
-import org.eclipse.edc.web.spi.validation.SchemaType;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.Arrays;
 
 import static jakarta.json.stream.JsonCollectors.toJsonArray;
-import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
-public abstract class AbstractJerseyJsonLdInterceptor implements ReaderInterceptor, WriterInterceptor {
+public abstract class AbstractJerseyJsonLdInterceptor implements WriterInterceptor {
     protected final JsonLd jsonLd;
     protected final TypeManager typeManager;
     protected final String typeContext;
-    protected final JsonObjectValidatorRegistry validatorRegistry;
-    protected final String schemaVersion;
 
-    public AbstractJerseyJsonLdInterceptor(JsonLd jsonLd, TypeManager typeManager, String typeContext, JsonObjectValidatorRegistry validatorRegistry, String schemaVersion) {
+    public AbstractJerseyJsonLdInterceptor(JsonLd jsonLd, TypeManager typeManager, String typeContext) {
         this.jsonLd = jsonLd;
         this.typeManager = typeManager;
         this.typeContext = typeContext;
-        this.validatorRegistry = validatorRegistry;
-        this.schemaVersion = schemaVersion;
-    }
-
-    @Override
-    public Object aroundReadFrom(ReaderInterceptorContext context) throws IOException, WebApplicationException {
-        if (context.getType().equals(JsonObject.class)) {
-            var bytes = context.getInputStream().readAllBytes();
-            if (bytes.length > 0) {
-                var jsonObject = typeManager.getMapper(typeContext).readValue(bytes, JsonObject.class);
-
-                validateIfNeeded(context, jsonObject);
-
-                var expanded = jsonLd.expand(jsonObject)
-                        .orElseThrow(f -> new InvalidRequestException("Failed to expand JsonObject: " + f.getFailureDetail()));
-
-                var expandedBytes = typeManager.getMapper(typeContext).writeValueAsBytes(expanded);
-                context.setInputStream(new ByteArrayInputStream(expandedBytes));
-            }
-        }
-
-        return context.proceed();
-    }
-
-    private void validateIfNeeded(ReaderInterceptorContext context, JsonObject jsonObject) {
-        if (validatorRegistry != null && schemaVersion != null) {
-            var expectedType = getExpectedType(context);
-            if (expectedType == null) {
-                throw new InvalidRequestException("SchemaType annotation is required for JsonObject validation");
-            }
-            var type = jsonObject.getString(TYPE, null);
-            if (type != null) {
-                checkExpectedType(type, expectedType);
-                validatorRegistry.validate(schemaVersion + ":" + type, jsonObject).orElseThrow(ValidationFailureException::new);
-            } else {
-                throw new InvalidRequestException("JsonObject is missing required property: " + TYPE);
-            }
-        }
-    }
-
-    private void checkExpectedType(String type, SchemaType schemaType) {
-        if (!Arrays.asList(schemaType.value()).contains(type)) {
-            throw new InvalidRequestException("JsonObject type '" + type + "' does not match expected types: " + Arrays.toString(schemaType.value()));
-        }
-    }
-
-    private SchemaType getExpectedType(ReaderInterceptorContext context) {
-        return Arrays.stream(context.getAnnotations())
-                .filter(annotation -> annotation.annotationType().equals(SchemaType.class))
-                .map(a -> (SchemaType) a)
-                .findFirst()
-                .orElse(null);
     }
 
     @Override

--- a/core/common/lib/core-lib/src/main/java/org/eclipse/edc/web/jersey/providers/jsonld/JerseyJsonLdInterceptor.java
+++ b/core/common/lib/core-lib/src/main/java/org/eclipse/edc/web/jersey/providers/jsonld/JerseyJsonLdInterceptor.java
@@ -20,7 +20,6 @@ import jakarta.ws.rs.ext.Provider;
 import jakarta.ws.rs.ext.WriterInterceptorContext;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
 @Provider
 public class JerseyJsonLdInterceptor extends AbstractJerseyJsonLdInterceptor {
@@ -28,11 +27,7 @@ public class JerseyJsonLdInterceptor extends AbstractJerseyJsonLdInterceptor {
     private final String scope;
 
     public JerseyJsonLdInterceptor(JsonLd jsonLd, TypeManager typeManager, String typeContext, String scope) {
-        this(jsonLd, typeManager, typeContext, scope, null, null);
-    }
-
-    public JerseyJsonLdInterceptor(JsonLd jsonLd, TypeManager typeManager, String typeContext, String scope, JsonObjectValidatorRegistry validatorRegistry, String schemaVersion) {
-        super(jsonLd, typeManager, typeContext, validatorRegistry, schemaVersion);
+        super(jsonLd, typeManager, typeContext);
         this.scope = scope;
     }
 

--- a/core/common/lib/core-lib/src/main/java/org/eclipse/edc/web/jersey/providers/jsonld/JsonObjectMessageBodyReader.java
+++ b/core/common/lib/core-lib/src/main/java/org/eclipse/edc/web/jersey/providers/jsonld/JsonObjectMessageBodyReader.java
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.web.jersey.providers.jsonld;
+
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.Provider;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
+import org.eclipse.edc.web.spi.exception.ValidationFailureException;
+import org.eclipse.edc.web.spi.validation.SchemaType;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+
+@Provider
+@Consumes(MediaType.APPLICATION_JSON)
+public class JsonObjectMessageBodyReader implements MessageBodyReader<JsonObject> {
+
+    private final JsonLd jsonLd;
+    private final TypeManager typeManager;
+    private final String typeContext;
+    private final JsonObjectValidatorRegistry validatorRegistry;
+
+    public JsonObjectMessageBodyReader(JsonLd jsonLd, TypeManager typeManager, String typeContext, JsonObjectValidatorRegistry validatorRegistry) {
+        this.jsonLd = jsonLd;
+        this.typeManager = typeManager;
+        this.typeContext = typeContext;
+        this.validatorRegistry = validatorRegistry;
+    }
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return JsonObject.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public JsonObject readFrom(Class<JsonObject> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                               MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+        var bytes = entityStream.readAllBytes();
+        if (bytes.length == 0) {
+            return null;
+        }
+
+        var jsonObject = typeManager.getMapper(typeContext).readValue(bytes, JsonObject.class);
+
+        var schemaType = Arrays.stream(annotations)
+                .filter(a -> a.annotationType().equals(SchemaType.class))
+                .map(a -> (SchemaType) a)
+                .findFirst()
+                .orElse(null);
+
+        if (schemaType != null) {
+            var objectType = jsonObject.getString(TYPE, null);
+            if (objectType == null) {
+                throw new InvalidRequestException("JsonObject is missing required property: " + TYPE);
+            }
+            if (!Arrays.asList(schemaType.value()).contains(objectType)) {
+                throw new InvalidRequestException("JsonObject type '" + objectType + "' does not match expected types: " + Arrays.toString(schemaType.value()));
+            }
+            validatorRegistry.validate(schemaType.version() + ":" + objectType, jsonObject)
+                    .orElseThrow(ValidationFailureException::new);
+        }
+
+        return jsonLd.expand(jsonObject)
+                .orElseThrow(f -> new InvalidRequestException("Failed to expand JsonObject: " + f.getFailureDetail()));
+    }
+}

--- a/core/common/lib/core-lib/src/main/java/org/eclipse/edc/web/jersey/providers/jsonld/ProfileJerseyJsonLdInterceptor.java
+++ b/core/common/lib/core-lib/src/main/java/org/eclipse/edc/web/jersey/providers/jsonld/ProfileJerseyJsonLdInterceptor.java
@@ -23,7 +23,6 @@ import jakarta.ws.rs.ext.WriterInterceptorContext;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 
 import java.util.function.Function;
 
@@ -34,11 +33,7 @@ public class ProfileJerseyJsonLdInterceptor extends AbstractJerseyJsonLdIntercep
     private final Function<UriInfo, String> profileProvider;
 
     public ProfileJerseyJsonLdInterceptor(JsonLd jsonLd, TypeManager typeManager, String typeContext, String scopePrefix, Function<UriInfo, String> profileProvider) {
-        this(jsonLd, typeManager, typeContext, scopePrefix, profileProvider, null, null);
-    }
-
-    public ProfileJerseyJsonLdInterceptor(JsonLd jsonLd, TypeManager typeManager, String typeContext, String scopePrefix, Function<UriInfo, String> profileProvider, JsonObjectValidatorRegistry validatorRegistry, String schemaVersion) {
-        super(jsonLd, typeManager, typeContext, validatorRegistry, schemaVersion);
+        super(jsonLd, typeManager, typeContext);
         this.profileProvider = profileProvider;
         this.scopePrefix = scopePrefix;
     }

--- a/core/common/lib/core-lib/src/test/java/org/eclipse/edc/web/jersey/providers/jsonld/JerseyJsonLdInterceptorTest.java
+++ b/core/common/lib/core-lib/src/test/java/org/eclipse/edc/web/jersey/providers/jsonld/JerseyJsonLdInterceptorTest.java
@@ -20,7 +20,6 @@ import jakarta.json.JsonObject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
-import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
@@ -34,7 +33,6 @@ import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -43,7 +41,6 @@ import static org.mockito.Mockito.when;
 class JerseyJsonLdInterceptorTest extends RestControllerTestBase {
 
     private static final String SCOPE = "scope";
-    private final JsonLd jsonLd = mock();
     private final JerseyJsonLdInterceptor interceptor = new JerseyJsonLdInterceptor(jsonLd, typeManager, "test", SCOPE);
 
     @Test

--- a/core/common/lib/core-lib/src/test/java/org/eclipse/edc/web/jersey/providers/jsonld/JsonObjectMessageBodyReaderTest.java
+++ b/core/common/lib/core-lib/src/test/java/org/eclipse/edc/web/jersey/providers/jsonld/JsonObjectMessageBodyReaderTest.java
@@ -1,0 +1,207 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.web.jersey.providers.jsonld;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
+import org.eclipse.edc.web.spi.exception.ValidationFailureException;
+import org.eclipse.edc.web.spi.validation.SchemaType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.validator.spi.Violation.violation;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class JsonObjectMessageBodyReaderTest {
+
+    private static final String EXPECTED_TYPE = "TestType";
+    private static final String SCHEMA_VERSION = "v1";
+    private static final String TYPE_CONTEXT = "test";
+
+    private final JsonLd jsonLd = mock();
+    private final TypeManager typeManager = mock();
+    private final JsonObjectValidatorRegistry validatorRegistry = mock();
+    private final com.fasterxml.jackson.databind.ObjectMapper objectMapper = org.eclipse.edc.jsonld.util.JacksonJsonLd.createObjectMapper();
+
+    private JsonObjectMessageBodyReader reader;
+
+    @BeforeEach
+    void setUp() {
+        reader = new JsonObjectMessageBodyReader(jsonLd, typeManager, TYPE_CONTEXT, validatorRegistry);
+        when(typeManager.getMapper(TYPE_CONTEXT)).thenReturn(objectMapper);
+    }
+
+    @Test
+    void isReadable_shouldReturnTrue_forJsonObjectType() {
+        assertThat(reader.isReadable(JsonObject.class, JsonObject.class, new Annotation[0], MediaType.APPLICATION_JSON_TYPE)).isTrue();
+    }
+
+    @Test
+    void isReadable_shouldReturnFalse_forOtherType() {
+        assertThat(reader.isReadable(String.class, String.class, new Annotation[0], MediaType.APPLICATION_JSON_TYPE)).isFalse();
+    }
+
+    @Test
+    void readFrom_shouldReturnNull_whenBodyIsEmpty() throws IOException {
+        var result = reader.readFrom(JsonObject.class, JsonObject.class, noAnnotations(), MediaType.APPLICATION_JSON_TYPE, null, emptyStream());
+
+        assertThat(result).isNull();
+        verifyNoInteractions(jsonLd, validatorRegistry);
+    }
+
+    @Test
+    void readFrom_shouldExpandAndReturn_whenNoSchemaTypeAnnotation() throws IOException {
+        var expanded = Json.createObjectBuilder().add("expanded-key", "value").build();
+        when(jsonLd.expand(any())).thenReturn(Result.success(expanded));
+
+        var result = reader.readFrom(JsonObject.class, JsonObject.class, noAnnotations(), MediaType.APPLICATION_JSON_TYPE, null, toStream("{\"key\":\"value\"}"));
+
+        assertThat(result).isEqualTo(expanded);
+        verify(jsonLd).expand(any());
+        verifyNoInteractions(validatorRegistry);
+    }
+
+    @Test
+    void readFrom_shouldValidateAndExpand_whenSchemaTypeAnnotationPresent() throws IOException {
+        var input = Json.createObjectBuilder().add("@type", EXPECTED_TYPE).add("key", "value").build();
+        var expanded = Json.createObjectBuilder().add("expanded-key", "value").build();
+        when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
+        when(jsonLd.expand(any())).thenReturn(Result.success(expanded));
+
+        var result = reader.readFrom(JsonObject.class, JsonObject.class, schemaTypeAnnotation(), MediaType.APPLICATION_JSON_TYPE, null, toStream(input.toString()));
+
+        assertThat(result).isEqualTo(expanded);
+        verify(validatorRegistry).validate(eq(SCHEMA_VERSION + ":" + EXPECTED_TYPE), any());
+        verify(jsonLd).expand(any());
+    }
+
+    @Test
+    void readFrom_shouldThrowInvalidRequest_whenTypePropertyMissing() {
+        assertThatThrownBy(() ->
+                reader.readFrom(JsonObject.class, JsonObject.class, schemaTypeAnnotation(), MediaType.APPLICATION_JSON_TYPE, null, toStream("{\"key\":\"value\"}")))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("@type");
+
+        verifyNoInteractions(validatorRegistry, jsonLd);
+    }
+
+    @Test
+    void readFrom_shouldThrowInvalidRequest_whenTypeMismatch() {
+        var input = Json.createObjectBuilder().add("@type", "WrongType").build();
+
+        assertThatThrownBy(() ->
+                reader.readFrom(JsonObject.class, JsonObject.class, schemaTypeAnnotation(), MediaType.APPLICATION_JSON_TYPE, null, toStream(input.toString())))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("WrongType");
+
+        verifyNoInteractions(validatorRegistry, jsonLd);
+    }
+
+    @Test
+    void readFrom_shouldThrowValidationFailure_whenValidationFails() {
+        var input = Json.createObjectBuilder().add("@type", EXPECTED_TYPE).build();
+        when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.failure(violation("invalid", "field")));
+
+        assertThatThrownBy(() ->
+                reader.readFrom(JsonObject.class, JsonObject.class, schemaTypeAnnotation(), MediaType.APPLICATION_JSON_TYPE, null, toStream(input.toString())))
+                .isInstanceOf(ValidationFailureException.class);
+
+        verify(validatorRegistry).validate(eq(SCHEMA_VERSION + ":" + EXPECTED_TYPE), any());
+        verifyNoInteractions(jsonLd);
+    }
+
+    @Test
+    void readFrom_shouldThrowInvalidRequest_whenExpansionFails() {
+        var input = Json.createObjectBuilder().add("@type", EXPECTED_TYPE).build();
+        when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
+        when(jsonLd.expand(any())).thenReturn(Result.failure("expansion error"));
+
+        assertThatThrownBy(() ->
+                reader.readFrom(JsonObject.class, JsonObject.class, schemaTypeAnnotation(), MediaType.APPLICATION_JSON_TYPE, null, toStream(input.toString())))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessageContaining("expansion error");
+    }
+
+    @Test
+    void readFrom_shouldAcceptAnyOfMultipleTypes_whenSchemaTypeHasMultipleValues() throws IOException {
+        var input = Json.createObjectBuilder().add("@type", "TypeB").build();
+        var expanded = Json.createObjectBuilder().add("expanded-key", "value").build();
+        when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
+        when(jsonLd.expand(any())).thenReturn(Result.success(expanded));
+
+        var result = reader.readFrom(JsonObject.class, JsonObject.class, multiTypeAnnotation(), MediaType.APPLICATION_JSON_TYPE, null, toStream(input.toString()));
+
+        assertThat(result).isEqualTo(expanded);
+        verify(validatorRegistry).validate(eq(SCHEMA_VERSION + ":TypeB"), any());
+    }
+
+    private Annotation[] noAnnotations() {
+        return new Annotation[0];
+    }
+
+    private Annotation[] schemaTypeAnnotation() {
+        return new Annotation[]{ schemaType(new String[]{ EXPECTED_TYPE }, SCHEMA_VERSION) };
+    }
+
+    private Annotation[] multiTypeAnnotation() {
+        return new Annotation[]{ schemaType(new String[]{ "TypeA", "TypeB" }, SCHEMA_VERSION) };
+    }
+
+    private SchemaType schemaType(String[] value, String version) {
+        return new SchemaType() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return SchemaType.class;
+            }
+
+            @Override
+            public String[] value() {
+                return value;
+            }
+
+            @Override
+            public String version() {
+                return version;
+            }
+        };
+    }
+
+    private InputStream toStream(String json) {
+        return new ByteArrayInputStream(json.getBytes());
+    }
+
+    private InputStream emptyStream() {
+        return new ByteArrayInputStream(new byte[0]);
+    }
+}

--- a/data-protocols/dsp/dsp-core/dsp-http-api-base-configuration/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiBaseConfigurationExtension.java
+++ b/data-protocols/dsp/dsp-core/dsp-http-api-base-configuration/src/main/java/org/eclipse/edc/protocol/dsp/http/api/configuration/DspApiBaseConfigurationExtension.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.protocol.dsp.http.api.configuration;
 
+import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.policy.model.AtomicConstraint;
 import org.eclipse.edc.policy.model.LiteralExpression;
 import org.eclipse.edc.protocol.dsp.http.spi.api.DspBaseWebhookAddress;
@@ -27,6 +28,7 @@ import org.eclipse.edc.spi.system.Hostname;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.web.jersey.providers.jsonld.JsonObjectMessageBodyReader;
 import org.eclipse.edc.web.jersey.providers.jsonld.ObjectMapperProvider;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
@@ -60,6 +62,8 @@ public class DspApiBaseConfigurationExtension implements ServiceExtension {
     private WebService webService;
     @Inject
     private TypeManager typeManager;
+    @Inject
+    private JsonLd jsonLd;
 
     @Override
     public String name() {
@@ -72,6 +76,7 @@ public class DspApiBaseConfigurationExtension implements ServiceExtension {
         portMappingRegistry.register(portMapping);
 
         webService.registerResource(ApiContext.PROTOCOL, new ObjectMapperProvider(typeManager, JSON_LD));
+        webService.registerResource(ApiContext.PROTOCOL, new JsonObjectMessageBodyReader(jsonLd, typeManager, JSON_LD, null));
     }
 
     @Override

--- a/extensions/common/api/document-cache-api/src/main/java/org/eclipse/edc/document/cache/api/CachedDocumentApiExtension.java
+++ b/extensions/common/api/document-cache-api/src/main/java/org/eclipse/edc/document/cache/api/CachedDocumentApiExtension.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.document.cache.api;
 
 import jakarta.json.Json;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.document.cache.api.v5.CachedDocumentApiV5Controller;
 import org.eclipse.edc.document.cache.api.v5.transform.JsonObjectFromCachedDocumentTransformer;
 import org.eclipse.edc.document.cache.api.v5.transform.JsonObjectToCachedDocumentTransformer;
@@ -71,6 +70,6 @@ public class CachedDocumentApiExtension implements ServiceExtension {
         webService.registerResource(ApiContext.MANAGEMENT,
                 new CachedDocumentApiV5Controller(service, managementApiTransformerRegistry));
         webService.registerDynamicResource(ApiContext.MANAGEMENT, CachedDocumentApiV5Controller.class,
-                new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V5.version()));
+                new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
     }
 }

--- a/extensions/common/api/document-cache-api/src/main/java/org/eclipse/edc/document/cache/api/v5/CachedDocumentApiV5Controller.java
+++ b/extensions/common/api/document-cache-api/src/main/java/org/eclipse/edc/document/cache/api/v5/CachedDocumentApiV5Controller.java
@@ -82,7 +82,7 @@ public class CachedDocumentApiV5Controller implements CachedDocumentApiV5 {
     @POST
     @RequiredScope("management-api:admin")
     @Override
-    public JsonObject create(@SchemaType(CACHED_DOCUMENT_TYPE_TERM) JsonObject request) {
+    public JsonObject create(@SchemaType(value = CACHED_DOCUMENT_TYPE_TERM, version = "v5") JsonObject request) {
         var context = fromJson(request);
         var created = service.create(context)
                 .orElseThrow(exceptionMapper(CachedDocument.class, context.getUrl()));
@@ -99,7 +99,7 @@ public class CachedDocumentApiV5Controller implements CachedDocumentApiV5 {
     @Path("{id}")
     @RequiredScope("management-api:admin")
     @Override
-    public void update(@PathParam("id") String id, @SchemaType(CACHED_DOCUMENT_TYPE_TERM) JsonObject request) {
+    public void update(@PathParam("id") String id, @SchemaType(value = CACHED_DOCUMENT_TYPE_TERM, version = "v5") JsonObject request) {
         var context = fromJson(request).toBuilder().id(id).build();
         service.update(context)
                 .orElseThrow(exceptionMapper(CachedDocument.class, id));

--- a/extensions/common/api/document-cache-api/src/test/java/org/eclipse/edc/document/cache/api/v5/CachedDocumentApiV5ControllerTest.java
+++ b/extensions/common/api/document-cache-api/src/test/java/org/eclipse/edc/document/cache/api/v5/CachedDocumentApiV5ControllerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static io.restassured.RestAssured.given;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -60,10 +61,14 @@ class CachedDocumentApiV5ControllerTest extends RestControllerTestBase {
         when(service.create(any())).thenAnswer(i -> ServiceResult.success(i.getArgument(0)));
         when(transformerRegistry.transform(any(IdResponse.class), eq(JsonObject.class)))
                 .thenReturn(Result.success(Json.createObjectBuilder().add("@id", context.getId()).build()));
+        var requestBody = Json.createObjectBuilder()
+                .add(TYPE, "CachedDocument")
+                .add("url", "https://example.com/context.jsonld")
+                .build();
 
         baseRequest()
                 .contentType("application/json")
-                .body("{ \"url\": \"https://example.com/context.jsonld\" }")
+                .body(requestBody)
                 .post("/v5beta/cacheddocuments")
                 .then()
                 .statusCode(200)
@@ -143,10 +148,14 @@ class CachedDocumentApiV5ControllerTest extends RestControllerTestBase {
         when(service.update(any())).thenAnswer(i -> ServiceResult.success(i.getArgument(0)));
         when(transformerRegistry.transform(any(CachedDocument.class), eq(JsonObject.class)))
                 .thenReturn(Result.success(Json.createObjectBuilder().add("@id", "id1").build()));
+        var requestBody = Json.createObjectBuilder()
+                .add(TYPE, "CachedDocument")
+                .add("url", "https://example.com/context.jsonld")
+                .build();
 
         baseRequest()
                 .contentType("application/json")
-                .body("{ \"url\": \"https://example.com/context.jsonld\" }")
+                .body(requestBody)
                 .put("/v5beta/cacheddocuments/id1")
                 .then()
                 .statusCode(204);

--- a/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtension.java
+++ b/extensions/common/api/management-api-configuration/src/main/java/org/eclipse/edc/connector/api/management/configuration/ManagementApiConfigurationExtension.java
@@ -45,6 +45,8 @@ import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToCriterionTransfo
 import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToDataAddressTransformer;
 import org.eclipse.edc.transform.transformer.edc.to.JsonObjectToQuerySpecTransformer;
 import org.eclipse.edc.transform.transformer.edc.to.JsonValueToGenericTypeTransformer;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.jersey.providers.jsonld.JsonObjectMessageBodyReader;
 import org.eclipse.edc.web.jersey.providers.jsonld.ObjectMapperProvider;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.ApiContext;
@@ -100,6 +102,8 @@ public class ManagementApiConfigurationExtension implements ServiceExtension {
     private CriterionOperatorRegistry criterionOperatorRegistry;
     @Inject
     private ApiVersionService apiVersionService;
+    @Inject
+    private JsonObjectValidatorRegistry validatorRegistry;
 
     @Override
     public String name() {
@@ -117,6 +121,7 @@ public class ManagementApiConfigurationExtension implements ServiceExtension {
         jsonLd.registerContext(EDC_CONNECTOR_MANAGEMENT_CONTEXT_V2, MANAGEMENT_SCOPE_V5);
 
         webService.registerResource(ApiContext.MANAGEMENT, new ObjectMapperProvider(typeManager, JSON_LD));
+        webService.registerResource(ApiContext.MANAGEMENT, new JsonObjectMessageBodyReader(jsonLd, typeManager, JSON_LD, validatorRegistry));
 
         var managementApiTransformerRegistry = transformerRegistry.forContext(MANAGEMENT_API_CONTEXT);
 

--- a/extensions/common/api/schema-validation-api/src/main/java/org/eclipse/edc/validator/registration/api/SchemaValidationApiExtension.java
+++ b/extensions/common/api/schema-validation-api/src/main/java/org/eclipse/edc/validator/registration/api/SchemaValidationApiExtension.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.validator.registration.api;
 
 import jakarta.json.Json;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -71,6 +70,6 @@ public class SchemaValidationApiExtension implements ServiceExtension {
         webService.registerResource(ApiContext.MANAGEMENT,
                 new SchemaValidatorRegistrationApiV5Controller(service, managementApiTransformerRegistry));
         webService.registerDynamicResource(ApiContext.MANAGEMENT, SchemaValidatorRegistrationApiV5Controller.class,
-                new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V5.version()));
+                new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
     }
 }

--- a/extensions/common/api/schema-validation-api/src/main/java/org/eclipse/edc/validator/registration/api/v5/SchemaValidatorRegistrationApiV5Controller.java
+++ b/extensions/common/api/schema-validation-api/src/main/java/org/eclipse/edc/validator/registration/api/v5/SchemaValidatorRegistrationApiV5Controller.java
@@ -82,7 +82,7 @@ public class SchemaValidatorRegistrationApiV5Controller implements SchemaValidat
     @POST
     @RequiredScope("management-api:admin")
     @Override
-    public JsonObject create(@SchemaType(SCHEMA_VALIDATOR_REGISTRATION_TYPE_TERM) JsonObject request) {
+    public JsonObject create(@SchemaType(value = SCHEMA_VALIDATOR_REGISTRATION_TYPE_TERM, version = "v5") JsonObject request) {
         var registration = fromJson(request);
         var created = service.create(registration)
                 .orElseThrow(exceptionMapper(SchemaValidatorRegistration.class, registration.getId()));
@@ -99,7 +99,7 @@ public class SchemaValidatorRegistrationApiV5Controller implements SchemaValidat
     @Path("{id}")
     @RequiredScope("management-api:admin")
     @Override
-    public void update(@PathParam("id") String id, @SchemaType(SCHEMA_VALIDATOR_REGISTRATION_TYPE_TERM) JsonObject request) {
+    public void update(@PathParam("id") String id, @SchemaType(value = SCHEMA_VALIDATOR_REGISTRATION_TYPE_TERM, version = "v5") JsonObject request) {
         var registration = fromJson(request).toBuilder().id(id).build();
         service.update(registration)
                 .orElseThrow(exceptionMapper(SchemaValidatorRegistration.class, id));

--- a/extensions/common/api/schema-validation-api/src/test/java/org/eclipse/edc/validator/registration/api/v5/SchemaValidatorRegistrationApiV5ControllerTest.java
+++ b/extensions/common/api/schema-validation-api/src/test/java/org/eclipse/edc/validator/registration/api/v5/SchemaValidatorRegistrationApiV5ControllerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static io.restassured.RestAssured.given;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -56,10 +57,13 @@ class SchemaValidatorRegistrationApiV5ControllerTest extends RestControllerTestB
         when(service.create(any())).thenAnswer(i -> ServiceResult.success(i.getArgument(0)));
         when(transformerRegistry.transform(any(IdResponse.class), eq(JsonObject.class)))
                 .thenReturn(Result.success(Json.createObjectBuilder().add("@id", registration.getId()).build()));
+        var requestBody = Json.createObjectBuilder()
+                .add(TYPE, "SchemaValidatorRegistration")
+                .add("version", "v5").build();
 
         baseRequest()
                 .contentType("application/json")
-                .body("{ \"version\": \"v5\" }")
+                .body(requestBody)
                 .post("/v5beta/schemavalidators")
                 .then()
                 .statusCode(200)

--- a/extensions/common/http/jersey-core/src/testFixtures/java/org/eclipse/edc/web/jersey/testfixtures/RestControllerTestBase.java
+++ b/extensions/common/http/jersey-core/src/testFixtures/java/org/eclipse/edc/web/jersey/testfixtures/RestControllerTestBase.java
@@ -16,11 +16,16 @@ package org.eclipse.edc.web.jersey.testfixtures;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.json.JacksonTypeManager;
+import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.web.jersey.JerseyConfiguration;
 import org.eclipse.edc.web.jersey.JerseyRestService;
+import org.eclipse.edc.web.jersey.providers.jsonld.JsonObjectMessageBodyReader;
 import org.eclipse.edc.web.jersey.providers.jsonld.ObjectMapperProvider;
 import org.eclipse.edc.web.jetty.JettyConfiguration;
 import org.eclipse.edc.web.jetty.JettyService;
@@ -30,6 +35,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 import static org.eclipse.edc.util.io.Ports.getFreePort;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -44,6 +50,7 @@ public abstract class RestControllerTestBase {
     protected final ObjectMapper objectMapper = JacksonJsonLd.createObjectMapper();
     protected final TypeManager typeManager = mock();
     private JettyService jetty;
+    protected final JsonLd jsonLd = mock(JsonLd.class);
 
     @BeforeEach
     final void startJetty() {
@@ -52,8 +59,12 @@ public abstract class RestControllerTestBase {
         portMappings.register(new PortMapping("test", port, "/"));
         jetty = new JettyService(config, monitor, portMappings);
         var jerseyService = new JerseyRestService(jetty, new JacksonTypeManager(), mock(JerseyConfiguration.class), monitor);
-        jerseyService.registerResource("test", new ObjectMapperProvider(typeManager, "test"));
+        var validatorRegistry = mock(JsonObjectValidatorRegistry.class);
+        when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
+        when(jsonLd.expand(any())).thenAnswer(i -> Result.success(i.getArgument(0)));
         when(typeManager.getMapper("test")).thenReturn(objectMapper);
+        jerseyService.registerResource("test", new ObjectMapperProvider(typeManager, "test"));
+        jerseyService.registerResource("test", new JsonObjectMessageBodyReader(jsonLd, typeManager, "test", validatorRegistry));
         jerseyService.registerResource("test", controller());
         var additionalResource = additionalResource();
         if (additionalResource != null) {

--- a/extensions/control-plane/api/management-api-v5/asset-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/AssetApiV5Extension.java
+++ b/extensions/control-plane/api/management-api-v5/asset-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/AssetApiV5Extension.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.controlplane.api.management.asset;
 
 import org.eclipse.edc.api.auth.spi.AuthorizationService;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.asset.v5.AssetApiV5Controller;
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
 import org.eclipse.edc.connector.controlplane.services.spi.asset.AssetService;
@@ -78,7 +77,7 @@ public class AssetApiV5Extension implements ServiceExtension {
         webService.registerResource(MANAGEMENT, new AssetApiV5Controller(assetService, managementTypeTransformerRegistry,
                 validatorRegistry, monitor, authorizationService));
         webService.registerDynamicResource(MANAGEMENT, AssetApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd,
-                typeManager, JSON_LD, MANAGEMENT_SCOPE_V5, validatorRegistry, ManagementApiJsonSchema.V5.version()));
+                typeManager, JSON_LD, MANAGEMENT_SCOPE_V5));
 
     }
 

--- a/extensions/control-plane/api/management-api-v5/asset-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/v5/AssetApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/asset-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/v5/AssetApiV5Controller.java
@@ -76,7 +76,7 @@ public class AssetApiV5Controller implements AssetApiV5 {
     @RequiredScope("management-api:assets:write")
     @Override
     public JsonObject createAssetV5(@PathParam("participantContextId") String participantContextId,
-                                    @SchemaType({EDC_ASSET_TYPE_TERM, EDC_CATALOG_ASSET_TYPE_TERM}) JsonObject assetJson,
+                                    @SchemaType(value = {EDC_ASSET_TYPE_TERM, EDC_CATALOG_ASSET_TYPE_TERM}, version = "v5") JsonObject assetJson,
                                     @Context SecurityContext securityContext) {
 
         authorizationService.authorize(securityContext, participantContextId, participantContextId, ParticipantContext.class)
@@ -107,7 +107,7 @@ public class AssetApiV5Controller implements AssetApiV5 {
     @Override
     @RequiredScope("management-api:assets:read")
     public JsonArray queryAssetsV5(@PathParam("participantContextId") String participantContextId,
-                                   @SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson,
+                                   @SchemaType(value = EDC_QUERY_SPEC_TYPE_TERM, version = "v4") JsonObject querySpecJson,
                                    @Context SecurityContext securityContext) {
         authorizationService.authorize(securityContext, participantContextId, participantContextId, ParticipantContext.class)
                 .orElseThrow(exceptionMapper(ParticipantContext.class, participantContextId));
@@ -168,7 +168,7 @@ public class AssetApiV5Controller implements AssetApiV5 {
     @RequiredScope("management-api:assets:write")
     @Override
     public void updateAssetV5(@PathParam("participantContextId") String participantContextId,
-                              @SchemaType({EDC_ASSET_TYPE_TERM, EDC_CATALOG_ASSET_TYPE_TERM}) JsonObject assetJson,
+                              @SchemaType(value = {EDC_ASSET_TYPE_TERM, EDC_CATALOG_ASSET_TYPE_TERM}, version = "v5") JsonObject assetJson,
                               @Context SecurityContext securityContext) {
 
         validator.validate(EDC_ASSET_TYPE, assetJson).orElseThrow(ValidationFailureException::new);

--- a/extensions/control-plane/api/management-api-v5/asset-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/AssetApiControllerTest.java
+++ b/extensions/control-plane/api/management-api-v5/asset-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/AssetApiControllerTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
@@ -43,12 +42,14 @@ import static jakarta.json.Json.createObjectBuilder;
 import static org.eclipse.edc.api.model.IdResponse.ID_RESPONSE_CREATED_AT;
 import static org.eclipse.edc.api.model.IdResponse.ID_RESPONSE_TYPE;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_TYPE;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_TYPE_TERM;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_PREFIX;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -98,7 +99,7 @@ public abstract class AssetApiControllerTest extends RestControllerTestBase {
     private JsonObjectBuilder createAssetJson() {
         return createObjectBuilder()
                 .add(CONTEXT, createContextBuilder().build())
-                .add(TYPE, EDC_ASSET_TYPE)
+                .add(TYPE, EDC_ASSET_TYPE_TERM)
                 .add(ID, TEST_ASSET_ID)
                 .add("properties", createPropertiesBuilder().build());
     }
@@ -434,7 +435,7 @@ public abstract class AssetApiControllerTest extends RestControllerTestBase {
 
             baseRequest(participantContextId)
                     .contentType(JSON)
-                    .body("{}")
+                    .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                     .post("/assets/request")
                     .then()
                     .log().ifError()
@@ -456,7 +457,7 @@ public abstract class AssetApiControllerTest extends RestControllerTestBase {
 
             baseRequest(participantContextId)
                     .contentType(JSON)
-                    .body("{}")
+                    .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                     .post("/assets/request")
                     .then()
                     .log().ifError()
@@ -491,7 +492,7 @@ public abstract class AssetApiControllerTest extends RestControllerTestBase {
             when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
 
             baseRequest(participantContextId)
-                    .body(Map.of("offset", -1))
+                    .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).add("offset", -1).build())
                     .contentType(JSON)
                     .post("/assets/request")
                     .then()
@@ -507,7 +508,7 @@ public abstract class AssetApiControllerTest extends RestControllerTestBase {
 
             baseRequest(participantContextId)
                     .contentType(JSON)
-                    .body("{}")
+                    .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                     .post("/assets/request")
                     .then()
                     .statusCode(400);
@@ -535,7 +536,7 @@ public abstract class AssetApiControllerTest extends RestControllerTestBase {
 
             baseRequest(participantContextId)
                     .contentType(JSON)
-                    .body("{}")
+                    .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                     .post("/assets/request")
                     .then()
                     .statusCode(400);

--- a/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/CatalogApiV5Extension.java
+++ b/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/CatalogApiV5Extension.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.controlplane.api.management.catalog;
 
 import org.eclipse.edc.api.auth.spi.AuthorizationService;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.catalog.v5.CatalogApiV5Controller;
 import org.eclipse.edc.connector.controlplane.services.spi.catalog.CatalogService;
 import org.eclipse.edc.connector.controlplane.transform.edc.catalog.to.JsonObjectToCatalogRequestTransformer;
@@ -81,6 +80,6 @@ public class CatalogApiV5Extension implements ServiceExtension {
         // authorization service does need an additional lookup function - catalogs are not a persisted entity
 
         webService.registerResource(ApiContext.MANAGEMENT, new CatalogApiV5Controller(service, managementApiTransformerRegistry, authorizationService, participantContextService, profileResolver));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, CatalogApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, CatalogApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
     }
 }

--- a/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v5/CatalogApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v5/CatalogApiV5Controller.java
@@ -74,7 +74,7 @@ public class CatalogApiV5Controller implements CatalogApiV5 {
     @RequiredScope("management-api:catalog:read")
     @Override
     public void requestCatalogV5(@PathParam("participantContextId") String participantContextId,
-                                 @SchemaType(CATALOG_REQUEST_TYPE_TERM) JsonObject requestBody,
+                                 @SchemaType(value = CATALOG_REQUEST_TYPE_TERM, version = "v4") JsonObject requestBody,
                                  @Suspended AsyncResponse response,
                                  @Context SecurityContext securityContext) {
 
@@ -102,7 +102,7 @@ public class CatalogApiV5Controller implements CatalogApiV5 {
     @RequiredScope("management-api:catalog:read")
     @Override
     public void getDatasetV5(@PathParam("participantContextId") String participantContextId,
-                             @SchemaType(DATASET_REQUEST_TYPE_TERM) JsonObject requestBody,
+                             @SchemaType(value = DATASET_REQUEST_TYPE_TERM, version = "v4") JsonObject requestBody,
                              @Suspended AsyncResponse response,
                              @Context SecurityContext securityContext) {
 

--- a/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/BaseCatalogApiControllerTest.java
+++ b/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/BaseCatalogApiControllerTest.java
@@ -43,7 +43,10 @@ import static io.restassured.http.ContentType.JSON;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_TYPE_TERM;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_PROTOCOL;
+import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_TYPE_TERM;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -81,7 +84,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
         var request = CatalogRequest.Builder.newInstance().counterPartyAddress("http://url").build();
         when(transformerRegistry.transform(any(), eq(CatalogRequest.class))).thenReturn(Result.success(request));
         when(service.requestCatalog(any(), any(), any(), any(), any())).thenReturn(completedFuture(StatusResult.success("{}".getBytes())));
-        var requestBody = Json.createObjectBuilder().add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, CATALOG_REQUEST_TYPE_TERM).add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -111,7 +114,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
     @Test
     void requestCatalog_shouldReturnBadRequest_whenTransformFails() {
         when(transformerRegistry.transform(any(), eq(CatalogRequest.class))).thenReturn(Result.failure("error"));
-        var requestBody = Json.createObjectBuilder().add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, CATALOG_REQUEST_TYPE_TERM).add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -129,7 +132,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
         when(transformerRegistry.transform(any(), eq(CatalogRequest.class))).thenReturn(Result.success(request));
         when(service.requestCatalog(any(), any(), any(), any(), any())).thenReturn(completedFuture(StatusResult.failure(FATAL_ERROR, "error")));
 
-        var requestBody = Json.createObjectBuilder().add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, CATALOG_REQUEST_TYPE_TERM).add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -145,7 +148,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
         var request = CatalogRequest.Builder.newInstance().counterPartyAddress("http://url").build();
         when(transformerRegistry.transform(any(), eq(CatalogRequest.class))).thenReturn(Result.success(request));
         when(service.requestCatalog(any(), any(), any(), any(), any())).thenReturn(failedFuture(new EdcException("error")));
-        var requestBody = Json.createObjectBuilder().add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, CATALOG_REQUEST_TYPE_TERM).add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -166,7 +169,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
                 .build();
         when(transformerRegistry.transform(any(), any())).thenReturn(Result.success(request));
         when(service.requestDataset(any(), any(), any(), any(), any())).thenReturn(CompletableFuture.completedFuture(StatusResult.success("{}".getBytes())));
-        var requestBody = Json.createObjectBuilder().add(DATASET_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, DATASET_REQUEST_TYPE_TERM).add(DATASET_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -198,7 +201,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
     @Test
     void requestDataset_shouldReturnBadRequest_whenTransformFails() {
         when(transformerRegistry.transform(any(), eq(DatasetRequest.class))).thenReturn(Result.failure("error"));
-        var requestBody = Json.createObjectBuilder().add(DATASET_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, DATASET_REQUEST_TYPE_TERM).add(DATASET_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -216,7 +219,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
         when(transformerRegistry.transform(any(), eq(DatasetRequest.class))).thenReturn(Result.success(request));
         when(service.requestDataset(any(), any(), any(), any(), any())).thenReturn(completedFuture(StatusResult.failure(FATAL_ERROR, "error")));
 
-        var requestBody = Json.createObjectBuilder().add(DATASET_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, DATASET_REQUEST_TYPE_TERM).add(DATASET_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -232,7 +235,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
         var request = DatasetRequest.Builder.newInstance().counterPartyAddress("http://url").build();
         when(transformerRegistry.transform(any(), eq(DatasetRequest.class))).thenReturn(Result.success(request));
         when(service.requestDataset(any(), any(), any(), any(), any())).thenReturn(failedFuture(new EdcException("error")));
-        var requestBody = Json.createObjectBuilder().add(DATASET_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, DATASET_REQUEST_TYPE_TERM).add(DATASET_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -249,6 +252,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
         when(transformerRegistry.transform(argThat(o -> o instanceof JsonObject jo && jo.containsKey(CatalogRequest.CATALOG_REQUEST_ADDITIONAL_SCOPES)), eq(CatalogRequest.class))).thenReturn(Result.success(request));
         when(service.requestCatalog(any(), any(), any(), any(), any())).thenReturn(completedFuture(StatusResult.success("{}".getBytes())));
         var requestBody = Json.createObjectBuilder()
+                .add(TYPE, CATALOG_REQUEST_TYPE_TERM)
                 .add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any")
                 .add(CatalogRequest.CATALOG_REQUEST_ADDITIONAL_SCOPES, Json.createArrayBuilder(List.of("scope1", "scope2")).build())
                 .build();

--- a/extensions/control-plane/api/management-api-v5/cel-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/cel/CelExpressionManagementApiExtension.java
+++ b/extensions/control-plane/api/management-api-v5/cel-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/cel/CelExpressionManagementApiExtension.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.controlplane.api.management.cel;
 
 import jakarta.json.Json;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.cel.v5.CelExpressionApiV5Controller;
 import org.eclipse.edc.connector.controlplane.transform.edc.cel.from.JsonObjectFromCelExpressionTestResponseTransformer;
 import org.eclipse.edc.connector.controlplane.transform.edc.cel.from.JsonObjectFromCelExpressionTransformer;
@@ -75,7 +74,7 @@ public class CelExpressionManagementApiExtension implements ServiceExtension {
         managementApiTransformerRegistry.register(new JsonObjectToCelExpressionTestRequestTransformer());
 
         webService.registerResource(ApiContext.MANAGEMENT, new CelExpressionApiV5Controller(service, managementApiTransformerRegistry));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, CelExpressionApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V5.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, CelExpressionApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
 
     }
 }

--- a/extensions/control-plane/api/management-api-v5/cel-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/cel/v5/CelExpressionApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/cel-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/cel/v5/CelExpressionApiV5Controller.java
@@ -62,7 +62,7 @@ public class CelExpressionApiV5Controller implements CelExpressionApiV5 {
     @POST
     @RequiredScope("management-api:admin")
     @Override
-    public JsonObject createExpressionV5(@SchemaType(CEL_EXPRESSION_TYPE_TERM) JsonObject expression) {
+    public JsonObject createExpressionV5(@SchemaType(value = CEL_EXPRESSION_TYPE_TERM, version = "v5") JsonObject expression) {
 
         var expr = transformerRegistry.transform(expression, CelExpression.class)
                 .orElseThrow(InvalidRequestException::new);
@@ -83,7 +83,7 @@ public class CelExpressionApiV5Controller implements CelExpressionApiV5 {
     @Path("test")
     @RequiredScope("management-api:admin")
     @Override
-    public JsonObject testExpressionV5(@SchemaType(CEL_EXPRESSION_TEST_REQUEST_TYPE_TERM) JsonObject test) {
+    public JsonObject testExpressionV5(@SchemaType(value = CEL_EXPRESSION_TEST_REQUEST_TYPE_TERM, version = "v5") JsonObject test) {
 
         var expr = transformerRegistry.transform(test, CelExpressionTestRequest.class)
                 .orElseThrow(InvalidRequestException::new);
@@ -113,7 +113,7 @@ public class CelExpressionApiV5Controller implements CelExpressionApiV5 {
     @Path("{id}")
     @RequiredScope("management-api:admin")
     @Override
-    public void updateExpressionV5(@PathParam("id") String id, @SchemaType(CEL_EXPRESSION_TYPE_TERM) JsonObject expression) {
+    public void updateExpressionV5(@PathParam("id") String id, @SchemaType(value = CEL_EXPRESSION_TYPE_TERM, version = "v5") JsonObject expression) {
 
         var expr = transformerRegistry.transform(expression, CelExpression.class)
                 .orElseThrow(InvalidRequestException::new);
@@ -128,7 +128,7 @@ public class CelExpressionApiV5Controller implements CelExpressionApiV5 {
     @Path("request")
     @RequiredScope("management-api:admin")
     @Override
-    public JsonArray queryExpressionV5(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson) {
+    public JsonArray queryExpressionV5(@SchemaType(value = EDC_QUERY_SPEC_TYPE_TERM, version = "v4") JsonObject querySpecJson) {
         QuerySpec querySpec;
         if (querySpecJson == null) {
             querySpec = QuerySpec.Builder.newInstance().build();

--- a/extensions/control-plane/api/management-api-v5/cel-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/cel/CelExpressionApiControllerTestBase.java
+++ b/extensions/control-plane/api/management-api-v5/cel-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/cel/CelExpressionApiControllerTestBase.java
@@ -18,7 +18,6 @@ import io.restassured.specification.RequestSpecification;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.api.model.IdResponse;
-import org.eclipse.edc.participantcontext.spi.config.model.ParticipantContextConfiguration;
 import org.eclipse.edc.policy.cel.model.CelExpression;
 import org.eclipse.edc.policy.cel.model.CelExpressionTestRequest;
 import org.eclipse.edc.policy.cel.model.CelExpressionTestResponse;
@@ -40,7 +39,6 @@ import static io.restassured.http.ContentType.JSON;
 import static jakarta.json.Json.createObjectBuilder;
 import static org.eclipse.edc.api.model.IdResponse.ID_RESPONSE_CREATED_AT;
 import static org.eclipse.edc.api.model.IdResponse.ID_RESPONSE_TYPE;
-import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.hamcrest.Matchers.is;
@@ -74,19 +72,6 @@ public abstract class CelExpressionApiControllerTestBase extends RestControllerT
                 .build();
     }
 
-    private CelExpression celExpressionTestRequest() {
-        return CelExpression.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .leftOperand("leftOperand")
-                .expression("expr")
-                .description("description")
-                .build();
-    }
-
-    private ParticipantContextConfiguration.Builder createParticipantContextBuilder() {
-        return ParticipantContextConfiguration.Builder.newInstance();
-    }
-
     @BeforeEach
     void setup() {
         when(transformerRegistry.transform(isA(IdResponse.class), eq(JsonObject.class))).thenAnswer(a -> {
@@ -106,20 +91,14 @@ public abstract class CelExpressionApiControllerTestBase extends RestControllerT
         void create() {
             var expr = celExpression();
             when(transformerRegistry.transform(any(), eq(CelExpression.class))).thenReturn(Result.success(expr));
-
             when(service.create(any())).thenReturn(ServiceResult.success());
-            var requestBody = Json.createObjectBuilder()
-                    .add("policy", Json.createObjectBuilder()
-                            .add(CONTEXT, "context")
-                            .add(TYPE, "Set")
-                            .build())
-                    .build();
 
             baseRequest()
-                    .body(requestBody)
+                    .body(requestBody("CelExpression"))
                     .contentType(JSON)
                     .post("/celexpressions")
                     .then()
+                    .log().ifValidationFails()
                     .statusCode(200);
             verify(transformerRegistry).transform(isA(JsonObject.class), eq(CelExpression.class));
             verify(service).create(expr);
@@ -128,15 +107,9 @@ public abstract class CelExpressionApiControllerTestBase extends RestControllerT
         @Test
         void create_shouldReturnBadRequest_whenTransformationFails() {
             when(transformerRegistry.transform(any(), any())).thenReturn(Result.failure("error"));
-            var requestBody = Json.createObjectBuilder()
-                    .add("policy", Json.createObjectBuilder()
-                            .add(CONTEXT, "context")
-                            .add(TYPE, "Set")
-                            .build())
-                    .build();
 
             baseRequest()
-                    .body(requestBody)
+                    .body(requestBody("CelExpression"))
                     .contentType(JSON)
                     .post("/celexpressions")
                     .then()
@@ -186,11 +159,10 @@ public abstract class CelExpressionApiControllerTestBase extends RestControllerT
         void update() {
             var expr = celExpression();
             when(transformerRegistry.transform(any(), eq(CelExpression.class))).thenReturn(Result.success(expr));
-
             when(service.update(any())).thenReturn(ServiceResult.success());
 
             baseRequest()
-                    .body("{}")
+                    .body(requestBody("CelExpression"))
                     .contentType(JSON)
                     .put("/celexpressions/" + expr.getId())
                     .then()
@@ -202,15 +174,9 @@ public abstract class CelExpressionApiControllerTestBase extends RestControllerT
         @Test
         void update_shouldReturnBadRequest_whenTransformationFails() {
             when(transformerRegistry.transform(any(), any())).thenReturn(Result.failure("error"));
-            var requestBody = Json.createObjectBuilder()
-                    .add("policy", Json.createObjectBuilder()
-                            .add(CONTEXT, "context")
-                            .add(TYPE, "Set")
-                            .build())
-                    .build();
 
             baseRequest()
-                    .body(requestBody)
+                    .body(requestBody("CelExpression"))
                     .contentType(JSON)
                     .put("/celexpressions/1")
                     .then()
@@ -232,7 +198,7 @@ public abstract class CelExpressionApiControllerTestBase extends RestControllerT
 
             baseRequest()
                     .contentType(JSON)
-                    .body("{}")
+                    .body(requestBody("QuerySpec"))
                     .post("/celexpressions/request")
                     .then()
                     .statusCode(200)
@@ -251,7 +217,7 @@ public abstract class CelExpressionApiControllerTestBase extends RestControllerT
             when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.failure("failure"));
 
             baseRequest()
-                    .body("{}")
+                    .body(requestBody("CelExpression"))
                     .contentType(JSON)
                     .post("/celexpressions/request")
                     .then()
@@ -313,7 +279,7 @@ public abstract class CelExpressionApiControllerTestBase extends RestControllerT
             when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(expandedBody));
 
             baseRequest()
-                    .body("{}")
+                    .body(requestBody("CelExpressionTestRequest"))
                     .contentType(JSON)
                     .post("/celexpressions/test")
                     .then()
@@ -323,8 +289,12 @@ public abstract class CelExpressionApiControllerTestBase extends RestControllerT
 
         }
 
-
     }
 
+    private JsonObject requestBody(String type) {
+        return Json.createObjectBuilder()
+                .add(TYPE, type)
+                .build();
+    }
 
 }

--- a/extensions/control-plane/api/management-api-v5/contract-agreement-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/ContractAgreementApiV5Extension.java
+++ b/extensions/control-plane/api/management-api-v5/contract-agreement-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/ContractAgreementApiV5Extension.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.controlplane.api.management.contractagreement;
 
 import org.eclipse.edc.api.auth.spi.AuthorizationService;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.contractagreement.v5.ContractAgreementApiV5Controller;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.agreement.ContractAgreement;
 import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.ContractAgreementService;
@@ -80,7 +79,7 @@ public class ContractAgreementApiV5Extension implements ServiceExtension {
         authorizationService.addLookupFunction(ContractAgreement.class, this::findContractAgreement);
 
         webService.registerResource(ApiContext.MANAGEMENT, new ContractAgreementApiV5Controller(service, authorizationService, managementApiTransformerRegistryV4, monitor, validatorRegistry));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractAgreementApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractAgreementApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
 
     }
 

--- a/extensions/control-plane/api/management-api-v5/contract-agreement-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/v5/ContractAgreementApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/contract-agreement-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/v5/ContractAgreementApiV5Controller.java
@@ -49,7 +49,7 @@ public class ContractAgreementApiV5Controller extends BaseContractAgreementApiV5
     @RequiredScope("management-api:agreements:read")
     @Override
     public JsonArray queryAgreementsV5(@PathParam("participantContextId") String participantContextId,
-                                       @SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson,
+                                       @SchemaType(value = EDC_QUERY_SPEC_TYPE_TERM, version = "v4") JsonObject querySpecJson,
                                        @Context SecurityContext securityContext) {
         return queryAgreements(participantContextId, querySpecJson, securityContext);
     }

--- a/extensions/control-plane/api/management-api-v5/contract-agreement-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/BaseContractAgreementApiV5ControllerTest.java
+++ b/extensions/control-plane/api/management-api-v5/contract-agreement-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/BaseContractAgreementApiV5ControllerTest.java
@@ -40,9 +40,12 @@ import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createObjectBuilder;
 import static java.util.Collections.emptyList;
 import static java.util.UUID.randomUUID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
@@ -82,7 +85,7 @@ public abstract class BaseContractAgreementApiV5ControllerTest extends RestContr
 
         baseRequest(participantContextId)
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/request")
                 .then()
                 .statusCode(200)
@@ -103,7 +106,7 @@ public abstract class BaseContractAgreementApiV5ControllerTest extends RestContr
 
         baseRequest(participantContextId)
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/request")
                 .then()
                 .statusCode(200)
@@ -121,7 +124,7 @@ public abstract class BaseContractAgreementApiV5ControllerTest extends RestContr
 
         baseRequest(participantContextId)
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/request")
                 .then()
                 .statusCode(400);
@@ -138,7 +141,7 @@ public abstract class BaseContractAgreementApiV5ControllerTest extends RestContr
 
         baseRequest(participantContextId)
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/request")
                 .then()
                 .statusCode(200)

--- a/extensions/control-plane/api/management-api-v5/contract-definition-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/ContractDefinitionApiV5Extension.java
+++ b/extensions/control-plane/api/management-api-v5/contract-definition-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/ContractDefinitionApiV5Extension.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.connector.controlplane.api.management.contractdefinition
 
 import jakarta.json.Json;
 import org.eclipse.edc.api.auth.spi.AuthorizationService;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.v5.ContractDefinitionApiV5Controller;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.controlplane.services.spi.contractdefinition.ContractDefinitionService;
@@ -81,7 +80,7 @@ public class ContractDefinitionApiV5Extension implements ServiceExtension {
         var managementApiTransformerRegistry = transformerRegistry.forContext("management-api");
         authorizationService.addLookupFunction(ContractDefinition.class, this::findContractDef);
         webService.registerResource(ApiContext.MANAGEMENT, new ContractDefinitionApiV5Controller(managementApiTransformerRegistry, contractDefinitionService, context.getMonitor(), authorizationService));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractDefinitionApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractDefinitionApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
 
     }
 

--- a/extensions/control-plane/api/management-api-v5/contract-definition-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v5/ContractDefinitionApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/contract-definition-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v5/ContractDefinitionApiV5Controller.java
@@ -71,7 +71,7 @@ public class ContractDefinitionApiV5Controller implements ContractDefinitionApiV
     @Override
     @RequiredScope("management-api:contractdefinitions:read")
     public JsonArray queryContractDefinitionsV5(@PathParam("participantContextId") String participantContextId,
-                                                @SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson,
+                                                @SchemaType(value = EDC_QUERY_SPEC_TYPE_TERM, version = "v4") JsonObject querySpecJson,
                                                 @Context SecurityContext securityContext) {
 
         authorizationService.authorize(securityContext, participantContextId, participantContextId, ParticipantContext.class)
@@ -117,7 +117,7 @@ public class ContractDefinitionApiV5Controller implements ContractDefinitionApiV
     @RequiredScope("management-api:contractdefinitions:write")
     @Override
     public JsonObject createContractDefinitionV5(@PathParam("participantContextId") String participantContextId,
-                                                 @SchemaType(CONTRACT_DEFINITION_TYPE_TERM) JsonObject createObject,
+                                                 @SchemaType(value = CONTRACT_DEFINITION_TYPE_TERM, version = "v4") JsonObject createObject,
                                                  @Context SecurityContext securityContext) {
 
         authorizationService.authorize(securityContext, participantContextId, participantContextId, ParticipantContext.class)
@@ -158,7 +158,7 @@ public class ContractDefinitionApiV5Controller implements ContractDefinitionApiV
     @RequiredScope("management-api:contractdefinitions:write")
     @Override
     public void updateContractDefinitionV5(@PathParam("participantContextId") String participantContextId,
-                                           @SchemaType(CONTRACT_DEFINITION_TYPE_TERM) JsonObject updateObject,
+                                           @SchemaType(value = CONTRACT_DEFINITION_TYPE_TERM, version = "v4") JsonObject updateObject,
                                            @Context SecurityContext securityContext) {
 
         var updateObj = typeTransformerRegistry.transform(updateObject, ContractDefinition.class)

--- a/extensions/control-plane/api/management-api-v5/contract-definition-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/ContractDefinitionApiControllerTest.java
+++ b/extensions/control-plane/api/management-api-v5/contract-definition-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/ContractDefinitionApiControllerTest.java
@@ -43,10 +43,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_ACCESSPOLICY_ID;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_ASSETS_SELECTOR;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_CONTRACTPOLICY_ID;
-import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_TYPE;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_TYPE_TERM;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -72,7 +73,7 @@ public abstract class ContractDefinitionApiControllerTest extends RestController
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"", "{}"})
+    @ValueSource(strings = {"", "{\"@type\":\"QuerySpec\"}"})
     void queryAllContractDefinitions(String body) {
         when(service.search(any())).thenReturn(ServiceResult.success(List.of(createContractDefinition().build())));
         when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.Builder.newInstance().build()));
@@ -94,7 +95,7 @@ public abstract class ContractDefinitionApiControllerTest extends RestController
         when(authService.authorize(any(), eq(participantContextId), any(), any())).thenReturn(ServiceResult.unauthorized("unauthorized"));
         baseRequest(participantContextId)
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/request")
                 .then()
                 .statusCode(403);
@@ -108,7 +109,7 @@ public abstract class ContractDefinitionApiControllerTest extends RestController
 
         baseRequest(participantContextId)
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/request")
                 .then()
                 .statusCode(400);
@@ -124,7 +125,7 @@ public abstract class ContractDefinitionApiControllerTest extends RestController
 
         var error = baseRequest(participantContextId)
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/request")
                 .then()
                 .statusCode(400)
@@ -217,7 +218,7 @@ public abstract class ContractDefinitionApiControllerTest extends RestController
     @Test
     void create_transformationFails() {
         var requestJson = createObjectBuilder()
-                .add(TYPE, CONTRACT_DEFINITION_TYPE)
+                .add(TYPE, CONTRACT_DEFINITION_TYPE_TERM)
                 .add(CONTRACT_DEFINITION_ACCESSPOLICY_ID, "ap1")
                 .add(CONTRACT_DEFINITION_CONTRACTPOLICY_ID, "cp1")
                 .add(CONTRACT_DEFINITION_ASSETS_SELECTOR, createCriterionBuilder().build())
@@ -239,7 +240,7 @@ public abstract class ContractDefinitionApiControllerTest extends RestController
         when(authService.authorize(any(), eq(participantContextId), any(), any())).thenReturn(ServiceResult.unauthorized("unauthorized"));
         baseRequest(participantContextId)
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, CONTRACT_DEFINITION_TYPE_TERM).build())
                 .post()
                 .then()
                 .statusCode(403);
@@ -356,7 +357,7 @@ public abstract class ContractDefinitionApiControllerTest extends RestController
 
         baseRequest(participantContextId)
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, CONTRACT_DEFINITION_TYPE_TERM).build())
                 .put()
                 .then()
                 .statusCode(403);
@@ -378,7 +379,7 @@ public abstract class ContractDefinitionApiControllerTest extends RestController
 
     private JsonObject createExpandedJsonObject() {
         return createObjectBuilder()
-                .add(TYPE, CONTRACT_DEFINITION_TYPE)
+                .add(TYPE, CONTRACT_DEFINITION_TYPE_TERM)
                 .add(ID, "test-id")
                 .add(CONTRACT_DEFINITION_ACCESSPOLICY_ID, "ap1")
                 .add(CONTRACT_DEFINITION_CONTRACTPOLICY_ID, "cp1")

--- a/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiV5Extension.java
+++ b/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiV5Extension.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.connector.controlplane.api.management.contractnegotiatio
 
 import jakarta.json.Json;
 import org.eclipse.edc.api.auth.spi.AuthorizationService;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.v5.ContractNegotiationApiV5Controller;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.controlplane.services.spi.contractnegotiation.ContractNegotiationService;
@@ -105,7 +104,7 @@ public class ContractNegotiationApiV5Extension implements ServiceExtension {
         authorizationService.addLookupFunction(ContractNegotiation.class, this::findContractNegotiation);
 
         webService.registerResource(ApiContext.MANAGEMENT, new ContractNegotiationApiV5Controller(service, participantContextService, authorizationService, managementApiTransformerRegistry, profileResolver, monitor));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractNegotiationApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractNegotiationApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
     }
 
     private ParticipantResource findContractNegotiation(String ownerId, String assetId) {

--- a/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v5/ContractNegotiationApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v5/ContractNegotiationApiV5Controller.java
@@ -86,7 +86,7 @@ public class ContractNegotiationApiV5Controller implements ContractNegotiationAp
     @RequiredScope("management-api:negotiations:read")
     @Override
     public JsonArray queryNegotiationsV5(@PathParam("participantContextId") String participantContextId,
-                                         @SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson,
+                                         @SchemaType(value = EDC_QUERY_SPEC_TYPE_TERM, version = "v4") JsonObject querySpecJson,
                                          @Context SecurityContext securityContext) {
 
         authorizationService.authorize(securityContext, participantContextId, participantContextId, ParticipantContext.class)
@@ -170,7 +170,7 @@ public class ContractNegotiationApiV5Controller implements ContractNegotiationAp
     @RequiredScope("management-api:negotiations:write")
     @Override
     public JsonObject initiateContractNegotiationV5(@PathParam("participantContextId") String participantContextId,
-                                                    @SchemaType(CONTRACT_REQUEST_TYPE_TERM) JsonObject requestObject,
+                                                    @SchemaType(value = CONTRACT_REQUEST_TYPE_TERM, version = "v4") JsonObject requestObject,
                                                     @Context SecurityContext securityContext) {
 
 
@@ -198,7 +198,7 @@ public class ContractNegotiationApiV5Controller implements ContractNegotiationAp
     @Override
     public void terminateNegotiationV5(@PathParam("participantContextId") String participantContextId,
                                        @PathParam("id") String id,
-                                       @SchemaType(TERMINATE_NEGOTIATION_TYPE_TERM) JsonObject terminateNegotiation,
+                                       @SchemaType(value = TERMINATE_NEGOTIATION_TYPE_TERM, version = "v4") JsonObject terminateNegotiation,
                                        @Context SecurityContext securityContext) {
 
         authorizationService.authorize(securityContext, participantContextId, id, ContractNegotiation.class)

--- a/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiControllerTestBase.java
+++ b/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiControllerTestBase.java
@@ -51,11 +51,14 @@ import static jakarta.json.Json.createObjectBuilder;
 import static java.lang.String.format;
 import static java.util.UUID.randomUUID;
 import static org.eclipse.edc.api.model.IdResponse.ID_RESPONSE_TYPE;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest.CONTRACT_REQUEST_TYPE_TERM;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.NegotiationState.NEGOTIATION_STATE_TYPE;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.TerminateNegotiation.TERMINATE_NEGOTIATION_TYPE_TERM;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
@@ -171,7 +174,7 @@ public abstract class ContractNegotiationApiControllerTestBase extends RestContr
             when(service.terminate(any())).thenReturn(ServiceResult.success());
 
             baseRequest(participantContextId)
-                    .body(Json.createObjectBuilder().build())
+                    .body(Json.createObjectBuilder().add(TYPE, TERMINATE_NEGOTIATION_TYPE_TERM).build())
                     .contentType(JSON)
                     .post("/contractnegotiations/cn1/terminate")
                     .then()
@@ -185,7 +188,7 @@ public abstract class ContractNegotiationApiControllerTestBase extends RestContr
             when(transformerRegistry.transform(any(JsonObject.class), eq(TerminateNegotiation.class))).thenReturn(Result.failure("error"));
 
             baseRequest(participantContextId)
-                    .body(Json.createObjectBuilder().build())
+                    .body(Json.createObjectBuilder().add(TYPE, TERMINATE_NEGOTIATION_TYPE_TERM).build())
                     .contentType(JSON)
                     .post("/contractnegotiations/cn1/terminate")
                     .then()
@@ -201,7 +204,7 @@ public abstract class ContractNegotiationApiControllerTestBase extends RestContr
             when(service.terminate(any())).thenReturn(ServiceResult.conflict("conflict"));
 
             baseRequest(participantContextId)
-                    .body(Json.createObjectBuilder().add(ID, "id").build())
+                    .body(Json.createObjectBuilder().add(TYPE, TERMINATE_NEGOTIATION_TYPE_TERM).add(ID, "id").build())
                     .contentType(JSON)
                     .post("/contractnegotiations/cn1/terminate")
                     .then()
@@ -238,7 +241,7 @@ public abstract class ContractNegotiationApiControllerTestBase extends RestContr
 
             baseRequest(participantContextId)
                     .contentType(JSON)
-                    .body(createObjectBuilder().build())
+                    .body(createObjectBuilder().add(TYPE, CONTRACT_REQUEST_TYPE_TERM).build())
                     .post("/contractnegotiations")
                     .then()
                     .statusCode(200)
@@ -256,7 +259,7 @@ public abstract class ContractNegotiationApiControllerTestBase extends RestContr
 
             baseRequest(participantContextId)
                     .contentType(JSON)
-                    .body(createObjectBuilder().build())
+                    .body(createObjectBuilder().add(TYPE, CONTRACT_REQUEST_TYPE_TERM).build())
                     .post("/contractnegotiations")
                     .then()
                     .statusCode(400);
@@ -429,7 +432,7 @@ public abstract class ContractNegotiationApiControllerTestBase extends RestContr
             )));
             when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.failure("test-failure"));
 
-            var requestBody = createObjectBuilder().build();
+            var requestBody = createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
             baseRequest(participantContextId)
                     .contentType(JSON)
                     .body(requestBody)
@@ -495,7 +498,7 @@ public abstract class ContractNegotiationApiControllerTestBase extends RestContr
             when(transformerRegistry.transform(any(ContractNegotiation.class), eq(JsonObject.class)))
                     .thenReturn(Result.failure("test-failure"));
 
-            var requestBody = createObjectBuilder().build();
+            var requestBody = createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
             baseRequest(participantContextId)
                     .contentType(JSON)
                     .body(requestBody)

--- a/extensions/control-plane/api/management-api-v5/dataspace-profile-context-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/profile/DataspaceProfileContextManagementApiExtension.java
+++ b/extensions/control-plane/api/management-api-v5/dataspace-profile-context-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/profile/DataspaceProfileContextManagementApiExtension.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.connector.controlplane.api.management.participantcontext
 
 import jakarta.json.Json;
 import org.eclipse.edc.api.auth.spi.AuthorizationService;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.participantcontext.profile.v5.DataspaceProfileApiV5Controller;
 import org.eclipse.edc.connector.controlplane.api.management.participantcontext.profile.v5.DataspaceProfileContextApiV5Controller;
 import org.eclipse.edc.connector.controlplane.transform.edc.dataspaceprofile.from.JsonObjectFromDataspaceProfileContextTransformer;
@@ -88,7 +87,7 @@ public class DataspaceProfileContextManagementApiExtension implements ServiceExt
         managementApiTransformerRegistry.register(new JsonObjectToTrustedIssuerTransformer());
         managementApiTransformerRegistry.register(new JsonObjectFromTrustedIssuerTransformer(factory));
 
-        var jsonLdInterceptor = new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V5.version());
+        var jsonLdInterceptor = new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4);
 
         webService.registerResource(ApiContext.MANAGEMENT, new DataspaceProfileContextApiV5Controller(authorizationService, profileResolver, managementApiTransformerRegistry, monitor));
         webService.registerDynamicResource(ApiContext.MANAGEMENT, DataspaceProfileContextApiV5Controller.class, jsonLdInterceptor);

--- a/extensions/control-plane/api/management-api-v5/dataspace-profile-context-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/profile/v5/DataspaceProfileApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/dataspace-profile-context-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/profile/v5/DataspaceProfileApiV5Controller.java
@@ -61,7 +61,7 @@ public class DataspaceProfileApiV5Controller implements DataspaceProfileApiV5 {
     @POST
     @RequiredScope("management-api:profiles:write")
     @Override
-    public JsonObject createProfileV5(@SchemaType(DATASPACE_PROFILE_CONTEXT_TYPE_TERM) JsonObject request) {
+    public JsonObject createProfileV5(@SchemaType(value = DATASPACE_PROFILE_CONTEXT_TYPE_TERM, version = "v5") JsonObject request) {
 
         var profile = transformerRegistry.transform(request, DataspaceProfile.class)
                 .orElseThrow(InvalidRequestException::new);
@@ -77,7 +77,7 @@ public class DataspaceProfileApiV5Controller implements DataspaceProfileApiV5 {
     @PUT
     @RequiredScope("management-api:profiles:write")
     @Override
-    public void updateProfileV5(@SchemaType(DATASPACE_PROFILE_CONTEXT_TYPE_TERM) JsonObject request) {
+    public void updateProfileV5(@SchemaType(value = DATASPACE_PROFILE_CONTEXT_TYPE_TERM, version = "v5") JsonObject request) {
 
         var profile = transformerRegistry.transform(request, DataspaceProfile.class)
                 .orElseThrow(InvalidRequestException::new);
@@ -91,7 +91,7 @@ public class DataspaceProfileApiV5Controller implements DataspaceProfileApiV5 {
     @Path("request")
     @RequiredScope("management-api:profiles:read")
     @Override
-    public JsonArray queryProfilesV5(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson) {
+    public JsonArray queryProfilesV5(@SchemaType(value = EDC_QUERY_SPEC_TYPE_TERM, version = "v4") JsonObject querySpecJson) {
 
         QuerySpec querySpec;
         if (querySpecJson == null) {

--- a/extensions/control-plane/api/management-api-v5/dataspace-profile-context-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/profile/v5/DataspaceProfileContextApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/dataspace-profile-context-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/profile/v5/DataspaceProfileContextApiV5Controller.java
@@ -81,7 +81,7 @@ public class DataspaceProfileContextApiV5Controller implements DataspaceProfileC
     @PUT
     @RequiredScope("management-api:admin")
     @Override
-    public void associateProfiles(@PathParam("participantContextId") String participantContextId, @SchemaType(ASSOCIATE_DATASPACE_PROFILE_CONTEXT_TYPE_TERM) JsonObject request) {
+    public void associateProfiles(@PathParam("participantContextId") String participantContextId, @SchemaType(value = ASSOCIATE_DATASPACE_PROFILE_CONTEXT_TYPE_TERM, version = "v5") JsonObject request) {
 
         var context = transformerRegistry.transform(request, AssociateDataspaceProfileContext.class)
                 .orElseThrow(InvalidRequestException::new);

--- a/extensions/control-plane/api/management-api-v5/dataspace-profile-context-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/profile/v5/DataspaceProfileApiV5ControllerTest.java
+++ b/extensions/control-plane/api/management-api-v5/dataspace-profile-context-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/profile/v5/DataspaceProfileApiV5ControllerTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static jakarta.json.Json.createObjectBuilder;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -140,7 +141,7 @@ class DataspaceProfileApiV5ControllerTest extends RestControllerTestBase {
         when(transformerRegistry.transform(isA(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.max()));
         when(service.search(any())).thenReturn(ServiceResult.success(List.of(profile("dsp2025_1"))));
 
-        baseRequest().contentType(JSON).body("{}")
+        baseRequest().contentType(JSON).body(Json.createObjectBuilder().add(TYPE, "QuerySpec").build())
                 .post("/dataspaceprofiles/request")
                 .then().statusCode(200).contentType(JSON).body("size()", is(1));
     }

--- a/extensions/control-plane/api/management-api-v5/dcp-scope-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/dcpscope/DcpScopeApiV5Extension.java
+++ b/extensions/control-plane/api/management-api-v5/dcp-scope-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/dcpscope/DcpScopeApiV5Extension.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.controlplane.api.management.dcpscope;
 
 import jakarta.json.Json;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.dcpscope.transform.JsonObjectFromDcpScopeTransformer;
 import org.eclipse.edc.connector.controlplane.api.management.dcpscope.transform.JsonObjectToDcpScopeTransformer;
 import org.eclipse.edc.connector.controlplane.api.management.dcpscope.v5.DcpScopeApiV5Controller;
@@ -76,6 +75,6 @@ public class DcpScopeApiV5Extension implements ServiceExtension {
 
         webService.registerResource(ApiContext.MANAGEMENT, new DcpScopeApiV5Controller(scopeRegistry, managementApiTransformerRegistry, monitor));
         webService.registerDynamicResource(ApiContext.MANAGEMENT, DcpScopeApiV5Controller.class,
-                new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V5.version()));
+                new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
     }
 }

--- a/extensions/control-plane/api/management-api-v5/dcp-scope-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/dcpscope/v5/DcpScopeApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/dcp-scope-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/dcpscope/v5/DcpScopeApiV5Controller.java
@@ -59,7 +59,7 @@ public class DcpScopeApiV5Controller implements DcpScopeApiV5 {
     @POST
     @RequiredScope("management-api:admin")
     @Override
-    public JsonObject createDcpScopeV5(@SchemaType(DCP_SCOPE_TYPE_TERM) JsonObject request) {
+    public JsonObject createDcpScopeV5(@SchemaType(value = DCP_SCOPE_TYPE_TERM, version = "v5") JsonObject request) {
         var scope = transformerRegistry.transform(request, DcpScope.class)
                 .orElseThrow(InvalidRequestException::new);
 
@@ -78,7 +78,7 @@ public class DcpScopeApiV5Controller implements DcpScopeApiV5 {
     @Path("{id}")
     @RequiredScope("management-api:admin")
     @Override
-    public void updateDcpScopeV5(@PathParam("id") String id, @SchemaType(DCP_SCOPE_TYPE_TERM) JsonObject request) {
+    public void updateDcpScopeV5(@PathParam("id") String id, @SchemaType(value = DCP_SCOPE_TYPE_TERM, version = "v5") JsonObject request) {
         var scope = transformerRegistry.transform(request, DcpScope.class)
                 .orElseThrow(InvalidRequestException::new);
 
@@ -99,7 +99,7 @@ public class DcpScopeApiV5Controller implements DcpScopeApiV5 {
     @Path("/request")
     @RequiredScope("management-api:admin")
     @Override
-    public JsonArray queryDcpScopesV5(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson) {
+    public JsonArray queryDcpScopesV5(@SchemaType(value = EDC_QUERY_SPEC_TYPE_TERM, version = "v4") JsonObject querySpecJson) {
         QuerySpec querySpec;
         if (querySpecJson == null) {
             querySpec = QuerySpec.Builder.newInstance().build();

--- a/extensions/control-plane/api/management-api-v5/discovery-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/discovery/DiscoveryApiV5Extension.java
+++ b/extensions/control-plane/api/management-api-v5/discovery-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/discovery/DiscoveryApiV5Extension.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.connector.controlplane.api.management.discovery;
 
 import jakarta.json.Json;
 import org.eclipse.edc.api.auth.spi.AuthorizationService;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.discovery.v5.DiscoveryApiV5Controller;
 import org.eclipse.edc.connector.controlplane.transform.edc.discovery.from.JsonObjectFromDiscoveryResponseTransformer;
 import org.eclipse.edc.connector.controlplane.transform.edc.discovery.to.JsonObjectToDiscoveryRequestTransformer;
@@ -82,6 +81,6 @@ public class DiscoveryApiV5Extension implements ServiceExtension {
 
         webService.registerResource(ApiContext.MANAGEMENT, new DiscoveryApiV5Controller(authorizationService, discoveryService, managementApiTransformerRegistry, monitor));
         webService.registerDynamicResource(ApiContext.MANAGEMENT, DiscoveryApiV5Controller.class,
-                new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V5.version()));
+                new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
     }
 }

--- a/extensions/control-plane/api/management-api-v5/discovery-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/discovery/v5/DiscoveryApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/discovery-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/discovery/v5/DiscoveryApiV5Controller.java
@@ -64,7 +64,7 @@ public class DiscoveryApiV5Controller implements DiscoveryApiV5 {
     @RequiredScope("management-api:discovery:read")
     @Override
     public JsonArray discoverV5(@PathParam("participantContextId") String participantContextId,
-                                @SchemaType(DISCOVERY_REQUEST_TYPE_TERM) JsonObject request,
+                                @SchemaType(value = DISCOVERY_REQUEST_TYPE_TERM, version = "v5") JsonObject request,
                                 @Context SecurityContext securityContext) {
 
         authorizationService.authorize(securityContext, participantContextId, participantContextId, ParticipantContext.class)

--- a/extensions/control-plane/api/management-api-v5/participant-context-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/ParticipantContextManagementApiExtension.java
+++ b/extensions/control-plane/api/management-api-v5/participant-context-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/ParticipantContextManagementApiExtension.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.connector.controlplane.api.management.participantcontext
 
 import jakarta.json.Json;
 import org.eclipse.edc.api.auth.spi.AuthorizationService;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.participantcontext.v5.ParticipantContextApiV5Controller;
 import org.eclipse.edc.connector.controlplane.transform.edc.participantcontext.from.JsonObjectFromParticipantContextTransformer;
 import org.eclipse.edc.connector.controlplane.transform.edc.participantcontext.to.JsonObjectToParticipantContextTransformer;
@@ -80,7 +79,7 @@ public class ParticipantContextManagementApiExtension implements ServiceExtensio
         managementApiTransformerRegistry.register(new JsonObjectToParticipantContextTransformer());
 
         webService.registerResource(ApiContext.MANAGEMENT, new ParticipantContextApiV5Controller(participantContextService, authorizationService, managementApiTransformerRegistry, monitor));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, ParticipantContextApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V5.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, ParticipantContextApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
 
         authorizationService.addLookupFunction(ParticipantContext.class, this::findParticipant);
     }

--- a/extensions/control-plane/api/management-api-v5/participant-context-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/v5/ParticipantContextApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/participant-context-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/v5/ParticipantContextApiV5Controller.java
@@ -69,7 +69,7 @@ public class ParticipantContextApiV5Controller implements ParticipantContextApiV
     @POST
     @RequiredScope("management-api:admin")
     @Override
-    public JsonObject createParticipantV5(@SchemaType(PARTICIPANT_CONTEXT_TYPE_TERM) JsonObject request) {
+    public JsonObject createParticipantV5(@SchemaType(value = PARTICIPANT_CONTEXT_TYPE_TERM, version = "v5") JsonObject request) {
 
         var participantContext = transformerRegistry.transform(request, ParticipantContext.class)
                 .orElseThrow(InvalidRequestException::new);
@@ -103,7 +103,7 @@ public class ParticipantContextApiV5Controller implements ParticipantContextApiV
     @Path("{id}")
     @RequiredScope("management-api:admin")
     @Override
-    public void updateParticipantV5(@PathParam("id") String id, @SchemaType(PARTICIPANT_CONTEXT_TYPE_TERM) JsonObject request) {
+    public void updateParticipantV5(@PathParam("id") String id, @SchemaType(value = PARTICIPANT_CONTEXT_TYPE_TERM, version = "v5") JsonObject request) {
         var participantContext = transformerRegistry.transform(request, ParticipantContext.class)
                 .orElseThrow(InvalidRequestException::new);
 

--- a/extensions/control-plane/api/management-api-v5/participant-context-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/ParticipantContextApiControllerTestBase.java
+++ b/extensions/control-plane/api/management-api-v5/participant-context-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/ParticipantContextApiControllerTestBase.java
@@ -223,10 +223,7 @@ public abstract class ParticipantContextApiControllerTestBase extends RestContro
             when(service.getParticipantContext(any())).thenReturn(ServiceResult.success(participantContext));
             when(service.updateParticipantContext(any())).thenReturn(ServiceResult.success());
             var requestBody = Json.createObjectBuilder()
-                    .add("policy", Json.createObjectBuilder()
-                            .add(CONTEXT, "context")
-                            .add(TYPE, "Set")
-                            .build())
+                    .add(TYPE, "ParticipantContext")
                     .build();
 
             baseRequest()
@@ -264,6 +261,7 @@ public abstract class ParticipantContextApiControllerTestBase extends RestContro
             when(transformerRegistry.transform(any(), eq(ParticipantContext.class))).thenReturn(Result.success(participantContext));
             when(service.updateParticipantContext(participantContext)).thenReturn(ServiceResult.notFound("not found"));
             var requestBody = Json.createObjectBuilder()
+                    .add(TYPE, "ParticipantContext")
                     .build();
 
             baseRequest()
@@ -292,10 +290,7 @@ public abstract class ParticipantContextApiControllerTestBase extends RestContro
             when(transformerRegistry.transform(any(IdResponse.class), eq(JsonObject.class))).thenReturn(Result.success(response));
 
             var requestBody = Json.createObjectBuilder()
-                    .add("policy", Json.createObjectBuilder()
-                            .add(CONTEXT, "context")
-                            .add(TYPE, "Set")
-                            .build())
+                    .add(TYPE, "ParticipantContext")
                     .build();
 
             baseRequest()
@@ -338,6 +333,7 @@ public abstract class ParticipantContextApiControllerTestBase extends RestContro
             when(transformerRegistry.transform(any(), eq(ParticipantContext.class))).thenReturn(Result.success(participantContext));
             when(service.createParticipantContext(any())).thenReturn(ServiceResult.conflict("already exists"));
             var requestBody = Json.createObjectBuilder()
+                    .add(TYPE, "ParticipantContext")
                     .build();
 
             baseRequest()

--- a/extensions/control-plane/api/management-api-v5/participant-context-config-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/config/ParticipantContextConfigManagementApiExtension.java
+++ b/extensions/control-plane/api/management-api-v5/participant-context-config-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/config/ParticipantContextConfigManagementApiExtension.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.controlplane.api.management.participantcontext.config;
 
 import jakarta.json.Json;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.participantcontext.config.v5.ParticipantContextConfigApiV5Controller;
 import org.eclipse.edc.connector.controlplane.transform.edc.participantcontext.config.from.JsonObjectFromParticipantContextConfigurationTransformer;
 import org.eclipse.edc.connector.controlplane.transform.edc.participantcontext.config.to.JsonObjectToParticipantContextConfigurationTransformer;
@@ -71,7 +70,7 @@ public class ParticipantContextConfigManagementApiExtension implements ServiceEx
         managementApiTransformerRegistry.register(new JsonObjectToParticipantContextConfigurationTransformer());
 
         webService.registerResource(ApiContext.MANAGEMENT, new ParticipantContextConfigApiV5Controller(configService, managementApiTransformerRegistry));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, ParticipantContextConfigApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V5.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, ParticipantContextConfigApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
 
     }
 }

--- a/extensions/control-plane/api/management-api-v5/participant-context-config-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/config/v5/ParticipantContextConfigApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/participant-context-config-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/config/v5/ParticipantContextConfigApiV5Controller.java
@@ -55,7 +55,7 @@ public class ParticipantContextConfigApiV5Controller implements ParticipantConte
     @PUT
     @RequiredScope("management-api:admin")
     @Override
-    public void setConfigV5(@PathParam("participantContextId") String participantContextId, @SchemaType(PARTICIPANT_CONTEXT_CONFIG_TYPE_TERM) JsonObject request) {
+    public void setConfigV5(@PathParam("participantContextId") String participantContextId, @SchemaType(value = PARTICIPANT_CONTEXT_CONFIG_TYPE_TERM, version = "v5") JsonObject request) {
 
         var config = transformerRegistry.transform(request, ParticipantContextConfiguration.class)
                 .orElseThrow(InvalidRequestException::new)
@@ -71,7 +71,7 @@ public class ParticipantContextConfigApiV5Controller implements ParticipantConte
     @PATCH
     @RequiredScope("management-api:admin")
     @Override
-    public void patchConfigV5(@PathParam("participantContextId") String participantContextId, @SchemaType(PARTICIPANT_CONTEXT_CONFIG_TYPE_TERM) JsonObject request) {
+    public void patchConfigV5(@PathParam("participantContextId") String participantContextId, @SchemaType(value = PARTICIPANT_CONTEXT_CONFIG_TYPE_TERM, version = "v5") JsonObject request) {
 
         var config = transformerRegistry.transform(request, ParticipantContextConfiguration.class)
                 .orElseThrow(InvalidRequestException::new)

--- a/extensions/control-plane/api/management-api-v5/participant-context-config-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/config/ParticipantContextConfigApiControllerTestBase.java
+++ b/extensions/control-plane/api/management-api-v5/participant-context-config-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/config/ParticipantContextConfigApiControllerTestBase.java
@@ -110,10 +110,7 @@ public abstract class ParticipantContextConfigApiControllerTestBase extends Rest
 
             when(service.save(any())).thenReturn(ServiceResult.success());
             var requestBody = Json.createObjectBuilder()
-                    .add("policy", Json.createObjectBuilder()
-                            .add(CONTEXT, "context")
-                            .add(TYPE, "Set")
-                            .build())
+                    .add(TYPE, "ParticipantContextConfig")
                     .build();
 
             baseRequest()
@@ -176,10 +173,7 @@ public abstract class ParticipantContextConfigApiControllerTestBase extends Rest
             when(transformerRegistry.transform(any(), eq(ParticipantContextConfiguration.class))).thenReturn(Result.success(contextConfig));
             when(service.merge(any())).thenReturn(ServiceResult.success());
             var requestBody = Json.createObjectBuilder()
-                    .add("policy", Json.createObjectBuilder()
-                            .add(CONTEXT, "context")
-                            .add(TYPE, "Set")
-                            .build())
+                    .add(TYPE, "ParticipantContextConfig")
                     .build();
 
             baseRequest()

--- a/extensions/control-plane/api/management-api-v5/policy-definition-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/PolicyDefinitionApiV5Extension.java
+++ b/extensions/control-plane/api/management-api-v5/policy-definition-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/PolicyDefinitionApiV5Extension.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.connector.controlplane.api.management.policy;
 
 import jakarta.json.Json;
 import org.eclipse.edc.api.auth.spi.AuthorizationService;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.policy.v5.PolicyDefinitionApiV5Controller;
 import org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition;
 import org.eclipse.edc.connector.controlplane.services.spi.policydefinition.PolicyDefinitionService;
@@ -89,7 +88,7 @@ public class PolicyDefinitionApiV5Extension implements ServiceExtension {
 
         authorizationService.addLookupFunction(PolicyDefinition.class, this::findPolicyDefinition);
         webService.registerResource(ApiContext.MANAGEMENT, new PolicyDefinitionApiV5Controller(policyDefinitionService, managementApiTransformerRegistry, monitor, authorizationService));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, PolicyDefinitionApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, PolicyDefinitionApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
 
     }
 

--- a/extensions/control-plane/api/management-api-v5/policy-definition-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v5/PolicyDefinitionApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/policy-definition-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v5/PolicyDefinitionApiV5Controller.java
@@ -76,7 +76,7 @@ public class PolicyDefinitionApiV5Controller implements PolicyDefinitionApiV5 {
     @RequiredScope("management-api:policies:read")
     @Override
     public JsonArray queryPolicyDefinitionsV5(@PathParam("participantContextId") String participantContextId,
-                                              @SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson,
+                                              @SchemaType(value = EDC_QUERY_SPEC_TYPE_TERM, version = "v4") JsonObject querySpecJson,
                                               @Context SecurityContext securityContext) {
 
         authorizationService.authorize(securityContext, participantContextId, participantContextId, ParticipantContext.class)
@@ -126,7 +126,7 @@ public class PolicyDefinitionApiV5Controller implements PolicyDefinitionApiV5 {
     @RequiredScope("management-api:policies:write")
     @Override
     public JsonObject createPolicyDefinitionV5(@PathParam("participantContextId") String participantContextId,
-                                               @SchemaType(EDC_POLICY_DEFINITION_TYPE_TERM) JsonObject policyDefinition,
+                                               @SchemaType(value = EDC_POLICY_DEFINITION_TYPE_TERM, version = "v4") JsonObject policyDefinition,
                                                @Context SecurityContext securityContext) {
 
         authorizationService.authorize(securityContext, participantContextId, participantContextId, ParticipantContext.class)
@@ -173,7 +173,7 @@ public class PolicyDefinitionApiV5Controller implements PolicyDefinitionApiV5 {
     @Override
     public void updatePolicyDefinitionV5(@PathParam("participantContextId") String participantContextId,
                                          @PathParam("id") String id,
-                                         @SchemaType(EDC_POLICY_DEFINITION_TYPE_TERM) JsonObject input,
+                                         @SchemaType(value = EDC_POLICY_DEFINITION_TYPE_TERM, version = "v4") JsonObject input,
                                          @Context SecurityContext securityContext) {
 
         authorizationService.authorize(securityContext, participantContextId, id, PolicyDefinition.class)
@@ -223,7 +223,7 @@ public class PolicyDefinitionApiV5Controller implements PolicyDefinitionApiV5 {
     @Override
     public JsonObject createExecutionPlanV5(@PathParam("participantContextId") String participantContextId,
                                             @PathParam("id") String id,
-                                            @SchemaType("PolicyEvaluationPlanRequest") JsonObject input,
+                                            @SchemaType(value = "PolicyEvaluationPlanRequest", version = "v4") JsonObject input,
                                             @Context SecurityContext securityContext) {
 
         authorizationService.authorize(securityContext, participantContextId, id, PolicyDefinition.class)

--- a/extensions/control-plane/api/management-api-v5/policy-definition-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/PolicyDefinitionApiControllerTestBase.java
+++ b/extensions/control-plane/api/management-api-v5/policy-definition-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/PolicyDefinitionApiControllerTestBase.java
@@ -43,9 +43,12 @@ import static io.restassured.http.ContentType.JSON;
 import static jakarta.json.Json.createObjectBuilder;
 import static org.eclipse.edc.api.model.IdResponse.ID_RESPONSE_CREATED_AT;
 import static org.eclipse.edc.api.model.IdResponse.ID_RESPONSE_TYPE;
+import static org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_TYPE_TERM;
+import static org.eclipse.edc.connector.controlplane.policy.spi.PolicyEvaluationPlanRequest.EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE_TERM;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -106,7 +109,7 @@ public abstract class PolicyDefinitionApiControllerTestBase extends RestControll
             var policyDefinition = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
             var plan = PolicyEvaluationPlan.Builder.newInstance().build();
             var response = Json.createObjectBuilder().build();
-            var body = Json.createObjectBuilder().add("policyScope", policyScope).build();
+            var body = Json.createObjectBuilder().add(TYPE, EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE_TERM).add("policyScope", policyScope).build();
 
             when(service.findById(any())).thenReturn(policyDefinition);
             when(service.createEvaluationPlan(policyScope, policyDefinition.getPolicy())).thenReturn(ServiceResult.success(plan));
@@ -129,7 +132,7 @@ public abstract class PolicyDefinitionApiControllerTestBase extends RestControll
         void createEvaluationPlan_fails_whenPolicyNotFound() {
 
             var policyScope = "scope";
-            var body = Json.createObjectBuilder().add("policyScope", policyScope).build();
+            var body = Json.createObjectBuilder().add(TYPE, EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE_TERM).add("policyScope", policyScope).build();
 
             when(service.findById(any())).thenReturn(null);
             when(transformerRegistry.transform(any(JsonObject.class), eq(PolicyEvaluationPlanRequest.class)))
@@ -149,7 +152,7 @@ public abstract class PolicyDefinitionApiControllerTestBase extends RestControll
             when(authorizationService.authorize(any(), any(), any(), any()))
                     .thenReturn(ServiceResult.unauthorized("unauthorized"));
             var policyScope = "scope";
-            var body = Json.createObjectBuilder().add("policyScope", policyScope).build();
+            var body = Json.createObjectBuilder().add(TYPE, EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE_TERM).add("policyScope", policyScope).build();
 
             baseRequest(participantContextId)
                     .contentType(JSON)
@@ -306,7 +309,7 @@ public abstract class PolicyDefinitionApiControllerTestBase extends RestControll
             when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.success(querySpec));
             when(service.search(any())).thenReturn(ServiceResult.success(List.of(policyDefinition)));
             when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(expandedResponseBody));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
 
             baseRequest(participantContextId)
                     .body(requestBody)
@@ -330,6 +333,7 @@ public abstract class PolicyDefinitionApiControllerTestBase extends RestControll
         @Test
         void search_shouldReturn400_whenInvalidQuery() {
             var requestBody = Json.createObjectBuilder()
+                    .add(TYPE, EDC_QUERY_SPEC_TYPE_TERM)
                     .add("offset", -1)
                     .build();
             when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.failure("failure"));
@@ -367,7 +371,7 @@ public abstract class PolicyDefinitionApiControllerTestBase extends RestControll
             var querySpec = QuerySpec.none();
             when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.success(querySpec));
             when(service.search(any())).thenReturn(ServiceResult.badRequest("error"));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
 
             baseRequest(participantContextId)
                     .body(requestBody)
@@ -385,7 +389,7 @@ public abstract class PolicyDefinitionApiControllerTestBase extends RestControll
             when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.success(querySpec));
             when(service.search(any())).thenReturn(ServiceResult.success(List.of(policyDefinition)));
             when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.failure("error"));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
 
             baseRequest(participantContextId)
                     .body(requestBody)
@@ -403,7 +407,7 @@ public abstract class PolicyDefinitionApiControllerTestBase extends RestControll
                     .thenReturn(ServiceResult.unauthorized("unauthorized"));
 
             baseRequest(participantContextId)
-                    .body("{}")
+                    .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                     .contentType(JSON)
                     .post("/policydefinitions/request")
                     .then()
@@ -457,6 +461,7 @@ public abstract class PolicyDefinitionApiControllerTestBase extends RestControll
             when(transformerRegistry.transform(any(), eq(PolicyDefinition.class))).thenReturn(Result.success(policyDefinition));
             when(service.update(any())).thenReturn(ServiceResult.success(policyDefinition));
             var requestBody = Json.createObjectBuilder()
+                    .add(TYPE, EDC_POLICY_DEFINITION_TYPE_TERM)
                     .add("policy", Json.createObjectBuilder()
                             .add(CONTEXT, "context")
                             .add(TYPE, "Set")
@@ -477,6 +482,7 @@ public abstract class PolicyDefinitionApiControllerTestBase extends RestControll
         void update_shouldReturnBadRequest_whenTransformationFails() {
             when(transformerRegistry.transform(any(), any())).thenReturn(Result.failure("error"));
             var requestBody = Json.createObjectBuilder()
+                    .add(TYPE, EDC_POLICY_DEFINITION_TYPE_TERM)
                     .add("policy", Json.createObjectBuilder()
                             .add(CONTEXT, "context")
                             .add(TYPE, "Set")
@@ -498,6 +504,7 @@ public abstract class PolicyDefinitionApiControllerTestBase extends RestControll
             when(transformerRegistry.transform(any(), eq(PolicyDefinition.class))).thenReturn(Result.success(policyDefinition));
             when(service.update(any())).thenReturn(ServiceResult.notFound("not found"));
             var requestBody = Json.createObjectBuilder()
+                    .add(TYPE, EDC_POLICY_DEFINITION_TYPE_TERM)
                     .add("policy", Json.createObjectBuilder()
                             .add(CONTEXT, "context")
                             .add(TYPE, "Set")
@@ -540,6 +547,7 @@ public abstract class PolicyDefinitionApiControllerTestBase extends RestControll
             when(transformerRegistry.transform(any(IdResponse.class), eq(JsonObject.class))).thenReturn(Result.success(response));
 
             var requestBody = Json.createObjectBuilder()
+                    .add(TYPE, EDC_POLICY_DEFINITION_TYPE_TERM)
                     .add("policy", Json.createObjectBuilder()
                             .add(CONTEXT, "context")
                             .add(TYPE, "Set")
@@ -564,6 +572,7 @@ public abstract class PolicyDefinitionApiControllerTestBase extends RestControll
         void create_shouldReturnBadRequest_whenTransformationFails() {
             when(transformerRegistry.transform(any(), any())).thenReturn(Result.failure("error"));
             var requestBody = Json.createObjectBuilder()
+                    .add(TYPE, EDC_POLICY_DEFINITION_TYPE_TERM)
                     .add("policy", Json.createObjectBuilder()
                             .add(CONTEXT, "context")
                             .add(TYPE, "Set")
@@ -586,6 +595,7 @@ public abstract class PolicyDefinitionApiControllerTestBase extends RestControll
             when(transformerRegistry.transform(any(), eq(PolicyDefinition.class))).thenReturn(Result.success(policyDefinition));
             when(service.create(any())).thenReturn(ServiceResult.conflict("already exists"));
             var requestBody = Json.createObjectBuilder()
+                    .add(TYPE, EDC_POLICY_DEFINITION_TYPE_TERM)
                     .add("policy", Json.createObjectBuilder()
                             .add(CONTEXT, "context")
                             .add(TYPE, "Set")
@@ -604,6 +614,7 @@ public abstract class PolicyDefinitionApiControllerTestBase extends RestControll
         @Test
         void create_authorizationFailed() {
             var requestBody = Json.createObjectBuilder()
+                    .add(TYPE, EDC_POLICY_DEFINITION_TYPE_TERM)
                     .add("policy", Json.createObjectBuilder()
                             .add(CONTEXT, "context")
                             .add(TYPE, "Set")

--- a/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/TransferProcessApiV5Extension.java
+++ b/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/TransferProcessApiV5Extension.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.connector.controlplane.api.management.transferprocess;
 
 import jakarta.json.Json;
 import org.eclipse.edc.api.auth.spi.AuthorizationService;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.transferprocess.v5.TransferProcessApiV5Controller;
 import org.eclipse.edc.connector.controlplane.services.spi.transferprocess.TransferProcessService;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess;
@@ -99,7 +98,7 @@ public class TransferProcessApiV5Extension implements ServiceExtension {
         authorizationService.addLookupFunction(TransferProcess.class, this::findTransferProcess);
 
         webService.registerResource(ApiContext.MANAGEMENT, new TransferProcessApiV5Controller(context.getMonitor(), authorizationService, participantContextService, service, profileResolver, managementApiTransformerRegistry));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, TransferProcessApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, TransferProcessApiV5Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
     }
 
     private ParticipantResource findTransferProcess(String ownerId, String assetId) {

--- a/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v5/TransferProcessApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v5/TransferProcessApiV5Controller.java
@@ -91,7 +91,7 @@ public class TransferProcessApiV5Controller implements TransferProcessApiV5 {
     @RequiredScope("management-api:transfers:read")
     @Override
     public JsonArray queryTransferProcessesV5(@PathParam("participantContextId") String participantContextId,
-                                              @SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson,
+                                              @SchemaType(value = EDC_QUERY_SPEC_TYPE_TERM, version = "v4") JsonObject querySpecJson,
                                               @Context SecurityContext securityContext) {
 
         authorizationService.authorize(securityContext, participantContextId, participantContextId, ParticipantContext.class)
@@ -162,7 +162,7 @@ public class TransferProcessApiV5Controller implements TransferProcessApiV5 {
     @RequiredScope("management-api:transfers:write")
     @Override
     public JsonObject initiateTransferProcessV5(@PathParam("participantContextId") String participantContextId,
-                                                @SchemaType(TRANSFER_REQUEST_TYPE_TERM) JsonObject request,
+                                                @SchemaType(value = TRANSFER_REQUEST_TYPE_TERM, version = "v4") JsonObject request,
                                                 @Context SecurityContext securityContext) {
 
         authorizationService.authorize(securityContext, participantContextId, participantContextId, ParticipantContext.class)
@@ -195,7 +195,7 @@ public class TransferProcessApiV5Controller implements TransferProcessApiV5 {
     @Override
     public void terminateTransferProcessV5(@PathParam("participantContextId") String participantContextId,
                                            @PathParam("id") String id,
-                                           @SchemaType(TERMINATE_TRANSFER_TYPE_TERM) JsonObject requestBody,
+                                           @SchemaType(value = TERMINATE_TRANSFER_TYPE_TERM, version = "v4") JsonObject requestBody,
                                            @Context SecurityContext securityContext) {
 
 
@@ -216,7 +216,7 @@ public class TransferProcessApiV5Controller implements TransferProcessApiV5 {
     @Override
     public void suspendTransferProcessV5(@PathParam("participantContextId") String participantContextId,
                                          @PathParam("id") String id,
-                                         @SchemaType(SUSPEND_TRANSFER_TYPE_TERM) JsonObject requestBody,
+                                         @SchemaType(value = SUSPEND_TRANSFER_TYPE_TERM, version = "v4") JsonObject requestBody,
                                          @Context SecurityContext securityContext) {
 
         authorizationService.authorize(securityContext, participantContextId, id, TransferProcess.class)

--- a/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/BaseTransferProcessApiControllerTest.java
+++ b/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/BaseTransferProcessApiControllerTest.java
@@ -48,7 +48,12 @@ import java.util.UUID;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.util.Collections.emptyList;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.SuspendTransfer.SUSPEND_TRANSFER_TYPE_TERM;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TerminateTransfer.TERMINATE_TRANSFER_TYPE_TERM;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_TYPE_TERM;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -169,13 +174,12 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
         @Test
         void shouldReturnQueriedTransferProcesses() {
             var querySpec = QuerySpec.none();
-            var expandedRequestBody = Json.createObjectBuilder().build();
             var transferProcess = createTransferProcess().id("id").build();
             var expandedResponseBody = Json.createObjectBuilder().add("id", "id").add("createdAt", 1234).build();
             when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.success(querySpec));
             when(service.search(any())).thenReturn(ServiceResult.success(List.of(transferProcess)));
             when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(expandedResponseBody));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
 
             baseRequest(participantContextId)
                     .body(requestBody)
@@ -187,7 +191,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
                     .body("size()", is(1))
                     .body("[0].id", is("id"))
                     .body("[0].createdAt", is(1234));
-            verify(transformerRegistry).transform(expandedRequestBody, QuerySpec.class);
+            verify(transformerRegistry).transform(requestBody, QuerySpec.class);
             verify(service).search(argThat(s -> s.getOffset() == querySpec.getOffset() &&
                     s.getFilterExpression().stream().anyMatch(c -> c.getOperandLeft().equals("participantContextId") &&
                             c.getOperator().equals("=") &&
@@ -218,7 +222,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
         @Test
         void shouldReturn400_whenQuerySpecTransformFails() {
             when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.failure("error"));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
 
             baseRequest(participantContextId)
                     .body(requestBody)
@@ -234,7 +238,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
             var querySpec = QuerySpec.none();
             when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.success(querySpec));
             when(service.search(any())).thenReturn(ServiceResult.badRequest("error"));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
 
             baseRequest(participantContextId)
                     .body(requestBody)
@@ -252,7 +256,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
             when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.success(querySpec));
             when(service.search(any())).thenReturn(ServiceResult.success(List.of(transferProcess)));
             when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.failure("error"));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
 
             baseRequest(participantContextId)
                     .body(requestBody)
@@ -278,7 +282,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
             when(transformerRegistry.transform(any(), eq(TransferRequest.class))).thenReturn(Result.success(transferRequest));
             when(service.initiateTransfer(isA(ParticipantContext.class), any())).thenReturn(ServiceResult.success(transferProcess));
             when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, TRANSFER_REQUEST_TYPE_TERM).build();
 
             baseRequest(participantContextId)
                     .body(requestBody)
@@ -296,7 +300,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
         @Test
         void shouldReturnBadRequest_whenTransformationFails() {
             when(transformerRegistry.transform(any(), any())).thenReturn(Result.failure("error"));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, TRANSFER_REQUEST_TYPE_TERM).build();
 
             baseRequest(participantContextId)
                     .body(requestBody)
@@ -315,7 +319,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
                     .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build()));
             when(transformerRegistry.transform(any(), eq(TransferRequest.class))).thenReturn(Result.success(transferRequest));
             when(service.initiateTransfer(any(), any())).thenReturn(ServiceResult.conflict("already exists"));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, TRANSFER_REQUEST_TYPE_TERM).build();
 
             baseRequest(participantContextId)
                     .body(requestBody)
@@ -332,18 +336,18 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
 
         @Test
         void shouldTerminate() {
-            var expanded = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, TERMINATE_TRANSFER_TYPE_TERM).build();
             var terminateTransfer = new TerminateTransfer("anyReason");
             when(transformerRegistry.transform(any(), eq(TerminateTransfer.class))).thenReturn(Result.success(terminateTransfer));
             when(service.terminate(any())).thenReturn(ServiceResult.success());
 
             baseRequest(participantContextId)
                     .contentType(JSON)
-                    .body(Json.createObjectBuilder().build())
+                    .body(requestBody)
                     .post("/transferprocesses/id/terminate")
                     .then()
                     .statusCode(204);
-            verify(transformerRegistry).transform(expanded, TerminateTransfer.class);
+            verify(transformerRegistry).transform(requestBody, TerminateTransfer.class);
             verify(service).terminate(isA(TerminateTransferCommand.class));
         }
 
@@ -353,7 +357,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
 
             baseRequest(participantContextId)
                     .contentType(JSON)
-                    .body(Json.createObjectBuilder().build())
+                    .body(Json.createObjectBuilder().add(TYPE, TERMINATE_TRANSFER_TYPE_TERM).build())
                     .post("/transferprocesses/id/terminate")
                     .then()
                     .statusCode(400);
@@ -380,18 +384,18 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
 
         @Test
         void shouldSuspend() {
-            var expanded = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, SUSPEND_TRANSFER_TYPE_TERM).build();
             var suspendTransfer = new SuspendTransfer("anyReason");
             when(transformerRegistry.transform(any(), eq(SuspendTransfer.class))).thenReturn(Result.success(suspendTransfer));
             when(service.suspend(any())).thenReturn(ServiceResult.success());
 
             baseRequest(participantContextId)
                     .contentType(JSON)
-                    .body(Json.createObjectBuilder().build())
+                    .body(requestBody)
                     .post("/transferprocesses/id/suspend")
                     .then()
                     .statusCode(204);
-            verify(transformerRegistry).transform(expanded, SuspendTransfer.class);
+            verify(transformerRegistry).transform(requestBody, SuspendTransfer.class);
             verify(service).suspend(isA(SuspendTransferCommand.class));
         }
 
@@ -401,7 +405,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
 
             baseRequest(participantContextId)
                     .contentType(JSON)
-                    .body(Json.createObjectBuilder().build())
+                    .body(Json.createObjectBuilder().add(TYPE, SUSPEND_TRANSFER_TYPE_TERM).build())
                     .post("/transferprocesses/id/suspend")
                     .then()
                     .statusCode(400);

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/AssetApiExtension.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/AssetApiExtension.java
@@ -16,7 +16,6 @@
 
 package org.eclipse.edc.connector.controlplane.api.management.asset;
 
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.api.validation.DataAddressValidator;
 import org.eclipse.edc.connector.controlplane.api.management.asset.v4.AssetApiV4Controller;
 import org.eclipse.edc.connector.controlplane.api.management.asset.validation.AssetValidator;
@@ -81,7 +80,7 @@ public class AssetApiExtension implements ServiceExtension {
 
         webService.registerResource(ApiContext.MANAGEMENT, new AssetApiV4Controller(assetService,
                 managementTypeTransformerRegistry, monitor, validator, participantContextSupplier));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, AssetApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validator, ManagementApiJsonSchema.V4.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, AssetApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
 
     }
 }

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/v4/AssetApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/v4/AssetApiV4Controller.java
@@ -49,14 +49,14 @@ public class AssetApiV4Controller extends BaseAssetApiController implements Asse
 
     @POST
     @Override
-    public JsonObject createAssetV4(@SchemaType({EDC_ASSET_TYPE_TERM, EDC_CATALOG_ASSET_TYPE_TERM}) JsonObject asset) {
+    public JsonObject createAssetV4(@SchemaType(value = {EDC_ASSET_TYPE_TERM, EDC_CATALOG_ASSET_TYPE_TERM}, version = "v4") JsonObject asset) {
         return createAsset(asset);
     }
 
     @POST
     @Path("/request")
     @Override
-    public JsonArray requestAssetsV4(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson) {
+    public JsonArray requestAssetsV4(@SchemaType(value = EDC_QUERY_SPEC_TYPE_TERM, version = "v4") JsonObject querySpecJson) {
         return requestAssets(querySpecJson);
     }
 
@@ -76,7 +76,7 @@ public class AssetApiV4Controller extends BaseAssetApiController implements Asse
 
     @PUT
     @Override
-    public void updateAssetV4(@SchemaType({EDC_ASSET_TYPE_TERM, EDC_CATALOG_ASSET_TYPE_TERM}) JsonObject asset) {
+    public void updateAssetV4(@SchemaType(value = {EDC_ASSET_TYPE_TERM, EDC_CATALOG_ASSET_TYPE_TERM}, version = "v4") JsonObject asset) {
         updateAsset(asset);
     }
 }

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/BaseAssetApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/BaseAssetApiControllerTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
@@ -42,12 +41,14 @@ import static jakarta.json.Json.createObjectBuilder;
 import static org.eclipse.edc.api.model.IdResponse.ID_RESPONSE_CREATED_AT;
 import static org.eclipse.edc.api.model.IdResponse.ID_RESPONSE_TYPE;
 import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_TYPE;
+import static org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset.EDC_ASSET_TYPE_TERM;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_PREFIX;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -105,7 +106,7 @@ public abstract class BaseAssetApiControllerTest extends RestControllerTestBase 
 
         baseRequest()
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/assets/request")
                 .then()
                 .log().ifError()
@@ -143,7 +144,7 @@ public abstract class BaseAssetApiControllerTest extends RestControllerTestBase 
         when(validator.validate(any(), any())).thenReturn(ValidationResult.success());
 
         baseRequest()
-                .body(Map.of("offset", -1))
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).add("offset", -1).build())
                 .contentType(JSON)
                 .post("/assets/request")
                 .then()
@@ -159,7 +160,7 @@ public abstract class BaseAssetApiControllerTest extends RestControllerTestBase 
 
         baseRequest()
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/assets/request")
                 .then()
                 .statusCode(400);
@@ -187,7 +188,7 @@ public abstract class BaseAssetApiControllerTest extends RestControllerTestBase 
 
         baseRequest()
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/assets/request")
                 .then()
                 .statusCode(400);
@@ -414,7 +415,7 @@ public abstract class BaseAssetApiControllerTest extends RestControllerTestBase 
     private JsonObjectBuilder createAssetJson() {
         return createObjectBuilder()
                 .add(CONTEXT, createContextBuilder().build())
-                .add(TYPE, EDC_ASSET_TYPE)
+                .add(TYPE, EDC_ASSET_TYPE_TERM)
                 .add(ID, TEST_ASSET_ID)
                 .add("properties", createPropertiesBuilder().build());
     }

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/CatalogApiExtension.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/CatalogApiExtension.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.connector.controlplane.api.management.catalog;
 
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.catalog.v4.CatalogApiV4Controller;
 import org.eclipse.edc.connector.controlplane.api.management.catalog.validation.CatalogRequestValidator;
 import org.eclipse.edc.connector.controlplane.api.management.catalog.validation.DatasetRequestValidator;
@@ -85,6 +84,6 @@ public class CatalogApiExtension implements ServiceExtension {
         validatorRegistry.register(DATASET_REQUEST_TYPE, DatasetRequestValidator.instance());
 
         webService.registerResource(ApiContext.MANAGEMENT, new CatalogApiV4Controller(service, managementApiTransformerRegistry, validatorRegistry, participantContextSupplier));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, CatalogApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, CatalogApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
     }
 }

--- a/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v4/CatalogApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/catalog/v4/CatalogApiV4Controller.java
@@ -44,14 +44,14 @@ public class CatalogApiV4Controller extends BaseCatalogApiController implements 
     @POST
     @Path("/request")
     @Override
-    public void requestCatalogV4(@SchemaType(CATALOG_REQUEST_TYPE_TERM) JsonObject request, @Suspended AsyncResponse response) {
+    public void requestCatalogV4(@SchemaType(value = CATALOG_REQUEST_TYPE_TERM, version = "v4") JsonObject request, @Suspended AsyncResponse response) {
         requestCatalog(request, response);
     }
 
     @POST
     @Path("dataset/request")
     @Override
-    public void getDatasetV4(@SchemaType(DATASET_REQUEST_TYPE_TERM) JsonObject request, @Suspended AsyncResponse response) {
+    public void getDatasetV4(@SchemaType(value = DATASET_REQUEST_TYPE_TERM, version = "v4") JsonObject request, @Suspended AsyncResponse response) {
         getDataset(request, response);
     }
 }

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/BaseCatalogApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/BaseCatalogApiControllerTest.java
@@ -42,8 +42,11 @@ import static io.restassured.http.ContentType.JSON;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.connector.controlplane.catalog.spi.CatalogRequest.CATALOG_REQUEST_TYPE_TERM;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_PROTOCOL;
 import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_TYPE;
+import static org.eclipse.edc.connector.controlplane.catalog.spi.DatasetRequest.DATASET_REQUEST_TYPE_TERM;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.response.ResponseStatus.FATAL_ERROR;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -72,7 +75,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(), eq(CatalogRequest.class))).thenReturn(Result.success(request));
         when(service.requestCatalog(any(), any(), any(), any(), any())).thenReturn(completedFuture(StatusResult.success("{}".getBytes())));
-        var requestBody = Json.createObjectBuilder().add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, CATALOG_REQUEST_TYPE_TERM).add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -88,7 +91,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
     @Test
     void requestCatalog_shouldReturnBadRequest_whenValidationFails() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.failure(Violation.violation("error", "path")));
-        var requestBody = Json.createObjectBuilder().add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, CATALOG_REQUEST_TYPE_TERM).add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -105,7 +108,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
     void requestCatalog_shouldReturnBadRequest_whenTransformFails() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(), eq(CatalogRequest.class))).thenReturn(Result.failure("error"));
-        var requestBody = Json.createObjectBuilder().add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, CATALOG_REQUEST_TYPE_TERM).add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -124,7 +127,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
         when(transformerRegistry.transform(any(), eq(CatalogRequest.class))).thenReturn(Result.success(request));
         when(service.requestCatalog(any(), any(), any(), any(), any())).thenReturn(completedFuture(StatusResult.failure(FATAL_ERROR, "error")));
 
-        var requestBody = Json.createObjectBuilder().add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, CATALOG_REQUEST_TYPE_TERM).add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -141,7 +144,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(), eq(CatalogRequest.class))).thenReturn(Result.success(request));
         when(service.requestCatalog(any(), any(), any(), any(), any())).thenReturn(failedFuture(new EdcException("error")));
-        var requestBody = Json.createObjectBuilder().add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, CATALOG_REQUEST_TYPE_TERM).add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -163,7 +166,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(), any())).thenReturn(Result.success(request));
         when(service.requestDataset(any(), any(), any(), any(), any())).thenReturn(CompletableFuture.completedFuture(StatusResult.success("{}".getBytes())));
-        var requestBody = Json.createObjectBuilder().add(DATASET_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, DATASET_REQUEST_TYPE_TERM).add(DATASET_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -181,7 +184,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
     @Test
     void requestDataset_shouldReturnBadRequest_whenValidationFails() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.failure(Violation.violation("error", "path")));
-        var requestBody = Json.createObjectBuilder().add(DATASET_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, DATASET_REQUEST_TYPE_TERM).add(DATASET_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -198,7 +201,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
     void requestDataset_shouldReturnBadRequest_whenTransformFails() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(), eq(DatasetRequest.class))).thenReturn(Result.failure("error"));
-        var requestBody = Json.createObjectBuilder().add(DATASET_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, DATASET_REQUEST_TYPE_TERM).add(DATASET_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -217,7 +220,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
         when(transformerRegistry.transform(any(), eq(DatasetRequest.class))).thenReturn(Result.success(request));
         when(service.requestDataset(any(), any(), any(), any(), any())).thenReturn(completedFuture(StatusResult.failure(FATAL_ERROR, "error")));
 
-        var requestBody = Json.createObjectBuilder().add(DATASET_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, DATASET_REQUEST_TYPE_TERM).add(DATASET_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -234,7 +237,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(), eq(DatasetRequest.class))).thenReturn(Result.success(request));
         when(service.requestDataset(any(), any(), any(), any(), any())).thenReturn(failedFuture(new EdcException("error")));
-        var requestBody = Json.createObjectBuilder().add(DATASET_REQUEST_PROTOCOL, "any").build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, DATASET_REQUEST_TYPE_TERM).add(DATASET_REQUEST_PROTOCOL, "any").build();
 
         given()
                 .port(port)
@@ -252,6 +255,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
         when(transformerRegistry.transform(argThat(o -> o instanceof JsonObject jo && jo.containsKey(CatalogRequest.CATALOG_REQUEST_ADDITIONAL_SCOPES)), eq(CatalogRequest.class))).thenReturn(Result.success(request));
         when(service.requestCatalog(any(), any(), any(), any(), any())).thenReturn(completedFuture(StatusResult.success("{}".getBytes())));
         var requestBody = Json.createObjectBuilder()
+                .add(TYPE, CATALOG_REQUEST_TYPE_TERM)
                 .add(CatalogRequest.CATALOG_REQUEST_PROTOCOL, "any")
                 .add(CatalogRequest.CATALOG_REQUEST_ADDITIONAL_SCOPES, Json.createArrayBuilder(List.of("scope1", "scope2")).build())
                 .build();

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/ContractAgreementApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/ContractAgreementApiExtension.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.edc.connector.controlplane.api.management.contractagreement;
 
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.contractagreement.v4.ContractAgreementApiV4Controller;
 import org.eclipse.edc.connector.controlplane.services.spi.contractagreement.ContractAgreementService;
 import org.eclipse.edc.jsonld.spi.JsonLd;
@@ -70,7 +69,7 @@ public class ContractAgreementApiExtension implements ServiceExtension {
         var managementApiTransformerRegistryV4 = managementApiTransformerRegistry.forContext(MANAGEMENT_API_V_4);
 
         webService.registerResource(ApiContext.MANAGEMENT, new ContractAgreementApiV4Controller(service, managementApiTransformerRegistryV4, monitor, validatorRegistry));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractAgreementApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractAgreementApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
 
     }
 }

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/v4/ContractAgreementApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/v4/ContractAgreementApiV4Controller.java
@@ -43,7 +43,7 @@ public class ContractAgreementApiV4Controller extends BaseContractAgreementApiCo
     @POST
     @Path("/request")
     @Override
-    public JsonArray queryAgreementsV4(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson) {
+    public JsonArray queryAgreementsV4(@SchemaType(value = EDC_QUERY_SPEC_TYPE_TERM, version = "v4") JsonObject querySpecJson) {
         return queryAgreements(querySpecJson);
     }
 

--- a/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/BaseContractAgreementApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-agreement-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractagreement/BaseContractAgreementApiControllerTest.java
@@ -37,9 +37,12 @@ import java.util.List;
 import java.util.UUID;
 
 import static io.restassured.http.ContentType.JSON;
+import static jakarta.json.Json.createObjectBuilder;
 import static java.util.Collections.emptyList;
 import static java.util.UUID.randomUUID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
@@ -70,7 +73,7 @@ public abstract class BaseContractAgreementApiControllerTest extends RestControl
 
         baseRequest()
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/request")
                 .then()
                 .statusCode(200)
@@ -91,7 +94,7 @@ public abstract class BaseContractAgreementApiControllerTest extends RestControl
 
         baseRequest()
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/request")
                 .then()
                 .statusCode(200)
@@ -109,7 +112,7 @@ public abstract class BaseContractAgreementApiControllerTest extends RestControl
 
         baseRequest()
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/request")
                 .then()
                 .statusCode(400);
@@ -126,7 +129,7 @@ public abstract class BaseContractAgreementApiControllerTest extends RestControl
 
         baseRequest()
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/request")
                 .then()
                 .statusCode(200)

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/ContractDefinitionApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/ContractDefinitionApiExtension.java
@@ -17,7 +17,6 @@
 package org.eclipse.edc.connector.controlplane.api.management.contractdefinition;
 
 import jakarta.json.Json;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.v4.ContractDefinitionApiV4Controller;
 import org.eclipse.edc.connector.controlplane.api.management.contractdefinition.validation.ContractDefinitionValidator;
 import org.eclipse.edc.connector.controlplane.services.spi.contractdefinition.ContractDefinitionService;
@@ -88,7 +87,7 @@ public class ContractDefinitionApiExtension implements ServiceExtension {
         var managementApiTransformerRegistry = transformerRegistry.forContext("management-api");
 
         webService.registerResource(ApiContext.MANAGEMENT, new ContractDefinitionApiV4Controller(managementApiTransformerRegistry, service, context.getMonitor(), validatorRegistry, participantContextSupplier));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractDefinitionApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractDefinitionApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
 
     }
 }

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v4/ContractDefinitionApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/v4/ContractDefinitionApiV4Controller.java
@@ -48,7 +48,7 @@ public class ContractDefinitionApiV4Controller extends BaseContractDefinitionApi
     @POST
     @Path("/request")
     @Override
-    public JsonArray queryContractDefinitionsV4(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson) {
+    public JsonArray queryContractDefinitionsV4(@SchemaType(value = EDC_QUERY_SPEC_TYPE_TERM, version = "v4") JsonObject querySpecJson) {
         return queryContractDefinitions(querySpecJson);
     }
 
@@ -61,7 +61,7 @@ public class ContractDefinitionApiV4Controller extends BaseContractDefinitionApi
 
     @POST
     @Override
-    public JsonObject createContractDefinitionV4(@SchemaType(CONTRACT_DEFINITION_TYPE_TERM) JsonObject createObject) {
+    public JsonObject createContractDefinitionV4(@SchemaType(value = CONTRACT_DEFINITION_TYPE_TERM, version = "v4") JsonObject createObject) {
         return createContractDefinition(createObject);
     }
 
@@ -74,7 +74,7 @@ public class ContractDefinitionApiV4Controller extends BaseContractDefinitionApi
 
     @PUT
     @Override
-    public void updateContractDefinitionV4(@SchemaType(CONTRACT_DEFINITION_TYPE_TERM) JsonObject updateObject) {
+    public void updateContractDefinitionV4(@SchemaType(value = CONTRACT_DEFINITION_TYPE_TERM, version = "v4") JsonObject updateObject) {
         updateContractDefinition(updateObject);
     }
 }

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/BaseContractDefinitionApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/BaseContractDefinitionApiControllerTest.java
@@ -35,8 +35,6 @@ import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 
@@ -47,10 +45,11 @@ import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.Co
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_ASSETS_SELECTOR;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_CONTRACTPOLICY_ID;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_TYPE;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition.CONTRACT_DEFINITION_TYPE_TERM;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
-import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.mockito.ArgumentMatchers.any;
@@ -74,9 +73,8 @@ public abstract class BaseContractDefinitionApiControllerTest extends RestContro
             .build();
     protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);
 
-    @ParameterizedTest
-    @ValueSource(strings = {"", "{}"})
-    void queryAllContractDefinitions(String body) {
+    @Test
+    void queryAllContractDefinitions() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(service.search(any())).thenReturn(ServiceResult.success(List.of(createContractDefinition().build())));
         when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.success(QuerySpec.Builder.newInstance().build()));
@@ -84,16 +82,13 @@ public abstract class BaseContractDefinitionApiControllerTest extends RestContro
 
         baseRequest()
                 .contentType(JSON)
-                .body(body)
+                .body(Json.createObjectBuilder().add(TYPE, "QuerySpec").build())
                 .post("/request")
                 .then()
                 .statusCode(200)
                 .body("size()", greaterThan(0));
 
         verify(service).search(eq(QuerySpec.Builder.newInstance().build()));
-        if (!body.isEmpty()) {
-            verify(validatorRegistry).validate(eq(EDC_QUERY_SPEC_TYPE), any());
-        }
     }
 
     @Test
@@ -102,7 +97,7 @@ public abstract class BaseContractDefinitionApiControllerTest extends RestContro
 
         baseRequest()
                 .contentType(JSON)
-                .body(createObjectBuilder().build())
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/request")
                 .then()
                 .statusCode(400);
@@ -118,7 +113,7 @@ public abstract class BaseContractDefinitionApiControllerTest extends RestContro
 
         baseRequest()
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/request")
                 .then()
                 .statusCode(400);
@@ -135,7 +130,7 @@ public abstract class BaseContractDefinitionApiControllerTest extends RestContro
 
         var error = baseRequest()
                 .contentType(JSON)
-                .body("{}")
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/request")
                 .then()
                 .statusCode(400)
@@ -203,7 +198,7 @@ public abstract class BaseContractDefinitionApiControllerTest extends RestContro
     @Test
     void create_shouldReturnBadRequest_whenValidationFails() {
         var requestJson = createObjectBuilder()
-                .add(TYPE, CONTRACT_DEFINITION_TYPE)
+                .add(TYPE, CONTRACT_DEFINITION_TYPE_TERM)
                 .add(CONTRACT_DEFINITION_ACCESSPOLICY_ID, "ap1")
                 .add(CONTRACT_DEFINITION_CONTRACTPOLICY_ID, "cp1")
                 .add(CONTRACT_DEFINITION_ASSETS_SELECTOR, createCriterionBuilder().build())
@@ -241,7 +236,7 @@ public abstract class BaseContractDefinitionApiControllerTest extends RestContro
     @Test
     void create_transformationFails() {
         var requestJson = createObjectBuilder()
-                .add(TYPE, CONTRACT_DEFINITION_TYPE)
+                .add(TYPE, CONTRACT_DEFINITION_TYPE_TERM)
                 .add(CONTRACT_DEFINITION_ACCESSPOLICY_ID, "ap1")
                 .add(CONTRACT_DEFINITION_CONTRACTPOLICY_ID, "cp1")
                 .add(CONTRACT_DEFINITION_ASSETS_SELECTOR, createCriterionBuilder().build())
@@ -381,7 +376,7 @@ public abstract class BaseContractDefinitionApiControllerTest extends RestContro
 
     private JsonObject createExpandedJsonObject() {
         return createObjectBuilder()
-                .add(TYPE, CONTRACT_DEFINITION_TYPE)
+                .add(TYPE, CONTRACT_DEFINITION_TYPE_TERM)
                 .add(ID, "test-id")
                 .add(CONTRACT_DEFINITION_ACCESSPOLICY_ID, "ap1")
                 .add(CONTRACT_DEFINITION_CONTRACTPOLICY_ID, "cp1")

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiExtension.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiExtension.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.controlplane.api.management.contractnegotiation;
 
 import jakarta.json.Json;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.v4.ContractNegotiationApiV4Controller;
 import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.validation.ContractRequestValidator;
 import org.eclipse.edc.connector.controlplane.api.management.contractnegotiation.validation.TerminateNegotiationValidator;
@@ -99,6 +98,6 @@ public class ContractNegotiationApiExtension implements ServiceExtension {
         validatorRegistry.register(V_4_PREFIX + TERMINATE_NEGOTIATION_TYPE, TerminateNegotiationValidator.instanceV4());
 
         webService.registerResource(ApiContext.MANAGEMENT, new ContractNegotiationApiV4Controller(service, managementApiTransformerRegistry, monitor, validatorRegistry, participantContextSupplier));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractNegotiationApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, ContractNegotiationApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
     }
 }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v4/ContractNegotiationApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v4/ContractNegotiationApiV4Controller.java
@@ -56,7 +56,7 @@ public class ContractNegotiationApiV4Controller extends BaseContractNegotiationA
     @POST
     @Path("/request")
     @Override
-    public JsonArray queryNegotiationsV4(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson) {
+    public JsonArray queryNegotiationsV4(@SchemaType(value = EDC_QUERY_SPEC_TYPE_TERM, version = "v4") JsonObject querySpecJson) {
         return queryNegotiations(querySpecJson);
     }
 
@@ -83,14 +83,14 @@ public class ContractNegotiationApiV4Controller extends BaseContractNegotiationA
 
     @POST
     @Override
-    public JsonObject initiateContractNegotiationV4(@SchemaType(CONTRACT_REQUEST_TYPE_TERM) JsonObject requestObject) {
+    public JsonObject initiateContractNegotiationV4(@SchemaType(value = CONTRACT_REQUEST_TYPE_TERM, version = "v4") JsonObject requestObject) {
         return initiateContractNegotiation(requestObject);
     }
 
     @POST
     @Path("/{id}/terminate")
     @Override
-    public void terminateNegotiationV4(@PathParam("id") String id, @SchemaType(TERMINATE_NEGOTIATION_TYPE_TERM) JsonObject terminateNegotiation) {
+    public void terminateNegotiationV4(@PathParam("id") String id, @SchemaType(value = TERMINATE_NEGOTIATION_TYPE_TERM, version = "v4") JsonObject terminateNegotiation) {
         terminateNegotiation(id, terminateNegotiation);
     }
 

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
@@ -45,12 +45,14 @@ import static jakarta.json.Json.createObjectBuilder;
 import static java.lang.String.format;
 import static java.util.UUID.randomUUID;
 import static org.eclipse.edc.api.model.IdResponse.ID_RESPONSE_TYPE;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractRequest.CONTRACT_REQUEST_TYPE_TERM;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.NegotiationState.NEGOTIATION_STATE_TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -105,7 +107,7 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
 
         baseRequest()
                 .contentType(JSON)
-                .body(createObjectBuilder().build())
+                .body(createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build())
                 .post("/request")
                 .then()
                 .statusCode(400);
@@ -123,7 +125,7 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
         )));
         when(transformerRegistry.transform(any(JsonObject.class), eq(QuerySpec.class))).thenReturn(Result.failure("test-failure"));
 
-        var requestBody = createObjectBuilder().build();
+        var requestBody = createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
         baseRequest()
                 .contentType(JSON)
                 .body(requestBody)
@@ -191,7 +193,7 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
         when(transformerRegistry.transform(any(ContractNegotiation.class), eq(JsonObject.class)))
                 .thenReturn(Result.failure("test-failure"));
 
-        var requestBody = createObjectBuilder().build();
+        var requestBody = createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
         baseRequest()
                 .contentType(JSON)
                 .body(requestBody)
@@ -420,7 +422,7 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
 
             baseRequest()
                     .contentType(JSON)
-                    .body(createObjectBuilder().build())
+                    .body(createObjectBuilder().add(TYPE, CONTRACT_REQUEST_TYPE_TERM).build())
                     .post()
                     .then()
                     .statusCode(200)
@@ -454,7 +456,7 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
 
             baseRequest()
                     .contentType(JSON)
-                    .body(createObjectBuilder().build())
+                    .body(createObjectBuilder().add(TYPE, CONTRACT_REQUEST_TYPE_TERM).build())
                     .post()
                     .then()
                     .statusCode(500);
@@ -470,7 +472,7 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
 
             baseRequest()
                     .contentType(JSON)
-                    .body(createObjectBuilder().build())
+                    .body(createObjectBuilder().add(TYPE, CONTRACT_REQUEST_TYPE_TERM).build())
                     .post()
                     .then()
                     .statusCode(400);
@@ -486,7 +488,7 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
 
             baseRequest()
                     .contentType(JSON)
-                    .body(createObjectBuilder().build())
+                    .body(createObjectBuilder().add(TYPE, CONTRACT_REQUEST_TYPE_TERM).build())
                     .post()
                     .then()
                     .statusCode(400);

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v4/ContractNegotiationApiV4ControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/v4/ContractNegotiationApiV4ControllerTest.java
@@ -29,7 +29,9 @@ import org.junit.jupiter.api.Test;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.TerminateNegotiation.TERMINATE_NEGOTIATION_TYPE;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.TerminateNegotiation.TERMINATE_NEGOTIATION_TYPE_TERM;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -54,7 +56,7 @@ class ContractNegotiationApiV4ControllerTest extends BaseContractNegotiationApiC
         when(service.terminate(any())).thenReturn(ServiceResult.success());
 
         baseRequest()
-                .body(Json.createObjectBuilder().add(ID, "id").build())
+                .body(Json.createObjectBuilder().add(TYPE, TERMINATE_NEGOTIATION_TYPE_TERM).add(ID, "id").build())
                 .contentType(JSON)
                 .post("/cn1/terminate")
                 .then()
@@ -69,7 +71,7 @@ class ContractNegotiationApiV4ControllerTest extends BaseContractNegotiationApiC
         when(transformerRegistry.transform(any(JsonObject.class), eq(TerminateNegotiation.class))).thenReturn(Result.failure("error"));
 
         baseRequest()
-                .body(Json.createObjectBuilder().add(ID, "id").build())
+                .body(Json.createObjectBuilder().add(TYPE, TERMINATE_NEGOTIATION_TYPE_TERM).add(ID, "id").build())
                 .contentType(JSON)
                 .post("/cn1/terminate")
                 .then()
@@ -86,7 +88,7 @@ class ContractNegotiationApiV4ControllerTest extends BaseContractNegotiationApiC
         when(service.terminate(any())).thenReturn(ServiceResult.conflict("conflict"));
 
         baseRequest()
-                .body(Json.createObjectBuilder().build())
+                .body(Json.createObjectBuilder().add(TYPE, TERMINATE_NEGOTIATION_TYPE_TERM).build())
                 .contentType(JSON)
                 .post("/cn1/terminate")
                 .then()
@@ -98,7 +100,7 @@ class ContractNegotiationApiV4ControllerTest extends BaseContractNegotiationApiC
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.failure(violation("error", "path")));
 
         baseRequest()
-                .body(Json.createObjectBuilder().add(ID, "id").build())
+                .body(Json.createObjectBuilder().add(TYPE, TERMINATE_NEGOTIATION_TYPE_TERM).add(ID, "id").build())
                 .contentType(JSON)
                 .post("/cn1/terminate")
                 .then()

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/PolicyDefinitionApiExtension.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/PolicyDefinitionApiExtension.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.controlplane.api.management.policy;
 
 import jakarta.json.Json;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.policy.v4.PolicyDefinitionApiV4Controller;
 import org.eclipse.edc.connector.controlplane.api.management.policy.validation.PolicyDefinitionValidator;
 import org.eclipse.edc.connector.controlplane.api.management.policy.validation.PolicyEvaluationPlanRequestValidator;
@@ -92,6 +91,6 @@ public class PolicyDefinitionApiExtension implements ServiceExtension {
 
         var monitor = context.getMonitor();
         webService.registerResource(ApiContext.MANAGEMENT, new PolicyDefinitionApiV4Controller(monitor, managementApiTransformerRegistry, service, validatorRegistry, participantContextSupplier));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, PolicyDefinitionApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, PolicyDefinitionApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
     }
 }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v4/PolicyDefinitionApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/v4/PolicyDefinitionApiV4Controller.java
@@ -50,7 +50,7 @@ public class PolicyDefinitionApiV4Controller extends BasePolicyDefinitionApiCont
     @POST
     @Path("request")
     @Override
-    public JsonArray queryPolicyDefinitionsV4(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson) {
+    public JsonArray queryPolicyDefinitionsV4(@SchemaType(value = EDC_QUERY_SPEC_TYPE_TERM, version = "v4") JsonObject querySpecJson) {
         return queryPolicyDefinitions(querySpecJson);
     }
 
@@ -63,7 +63,7 @@ public class PolicyDefinitionApiV4Controller extends BasePolicyDefinitionApiCont
 
     @POST
     @Override
-    public JsonObject createPolicyDefinitionV4(@SchemaType(EDC_POLICY_DEFINITION_TYPE_TERM) JsonObject request) {
+    public JsonObject createPolicyDefinitionV4(@SchemaType(value = EDC_POLICY_DEFINITION_TYPE_TERM, version = "v4") JsonObject request) {
         return createPolicyDefinition(request);
     }
 
@@ -77,7 +77,7 @@ public class PolicyDefinitionApiV4Controller extends BasePolicyDefinitionApiCont
     @PUT
     @Path("{id}")
     @Override
-    public void updatePolicyDefinitionV4(@PathParam("id") String id, @SchemaType(EDC_POLICY_DEFINITION_TYPE_TERM) JsonObject input) {
+    public void updatePolicyDefinitionV4(@PathParam("id") String id, @SchemaType(value = EDC_POLICY_DEFINITION_TYPE_TERM, version = "v4") JsonObject input) {
         updatePolicyDefinition(id, input);
     }
 
@@ -91,7 +91,7 @@ public class PolicyDefinitionApiV4Controller extends BasePolicyDefinitionApiCont
     @POST
     @Path("{id}/evaluationplan")
     @Override
-    public JsonObject createExecutionPlanV4(@PathParam("id") String id, @SchemaType(EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE_TERM) JsonObject request) {
+    public JsonObject createExecutionPlanV4(@PathParam("id") String id, @SchemaType(value = EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE_TERM, version = "v4") JsonObject request) {
         return createExecutionPlan(id, request);
     }
 }

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/BasePolicyDefinitionApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/BasePolicyDefinitionApiControllerTest.java
@@ -41,9 +41,12 @@ import java.util.List;
 
 import static io.restassured.http.ContentType.JSON;
 import static org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_TYPE;
+import static org.eclipse.edc.connector.controlplane.policy.spi.PolicyDefinition.EDC_POLICY_DEFINITION_TYPE_TERM;
+import static org.eclipse.edc.connector.controlplane.policy.spi.PolicyEvaluationPlanRequest.EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE_TERM;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -81,6 +84,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
         when(transformerRegistry.transform(any(IdResponse.class), eq(JsonObject.class))).thenReturn(Result.success(response));
 
         var requestBody = Json.createObjectBuilder()
+                .add(TYPE, EDC_POLICY_DEFINITION_TYPE_TERM)
                 .add("policy", Json.createObjectBuilder()
                         .add(CONTEXT, "context")
                         .add(TYPE, "Set")
@@ -106,6 +110,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
     void create_shouldReturnBadRequest_whenValidationFails() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.failure(violation("failure", "failure path")));
         var requestBody = Json.createObjectBuilder()
+                .add(TYPE, EDC_POLICY_DEFINITION_TYPE_TERM)
                 .add("policy", Json.createObjectBuilder()
                         .add(CONTEXT, "context")
                         .add(TYPE, "Set")
@@ -128,6 +133,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(), any())).thenReturn(Result.failure("error"));
         var requestBody = Json.createObjectBuilder()
+                .add(TYPE, EDC_POLICY_DEFINITION_TYPE_TERM)
                 .add("policy", Json.createObjectBuilder()
                         .add(CONTEXT, "context")
                         .add(TYPE, "Set")
@@ -151,6 +157,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
         when(transformerRegistry.transform(any(), eq(PolicyDefinition.class))).thenReturn(Result.success(policyDefinition));
         when(service.create(any())).thenReturn(ServiceResult.conflict("already exists"));
         var requestBody = Json.createObjectBuilder()
+                .add(TYPE, EDC_POLICY_DEFINITION_TYPE_TERM)
                 .add("policy", Json.createObjectBuilder()
                         .add(CONTEXT, "context")
                         .add(TYPE, "Set")
@@ -196,6 +203,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
         when(transformerRegistry.transform(any(), eq(PolicyDefinition.class))).thenReturn(Result.success(policyDefinition));
         when(service.update(any())).thenReturn(ServiceResult.success(policyDefinition));
         var requestBody = Json.createObjectBuilder()
+                .add(TYPE, EDC_POLICY_DEFINITION_TYPE_TERM)
                 .add("policy", Json.createObjectBuilder()
                         .add(CONTEXT, "context")
                         .add(TYPE, "Set")
@@ -217,6 +225,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
     void update_shouldReturnBadRequest_whenValidationFails() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.failure(violation("failure", "failure path")));
         var requestBody = Json.createObjectBuilder()
+                .add(TYPE, EDC_POLICY_DEFINITION_TYPE_TERM)
                 .add("policy", Json.createObjectBuilder()
                         .add(CONTEXT, "context")
                         .add(TYPE, "Set")
@@ -237,6 +246,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(), any())).thenReturn(Result.failure("error"));
         var requestBody = Json.createObjectBuilder()
+                .add(TYPE, EDC_POLICY_DEFINITION_TYPE_TERM)
                 .add("policy", Json.createObjectBuilder()
                         .add(CONTEXT, "context")
                         .add(TYPE, "Set")
@@ -259,6 +269,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
         when(transformerRegistry.transform(any(), eq(PolicyDefinition.class))).thenReturn(Result.success(policyDefinition));
         when(service.update(any())).thenReturn(ServiceResult.notFound("not found"));
         var requestBody = Json.createObjectBuilder()
+                .add(TYPE, EDC_POLICY_DEFINITION_TYPE_TERM)
                 .add("policy", Json.createObjectBuilder()
                         .add(CONTEXT, "context")
                         .add(TYPE, "Set")
@@ -324,7 +335,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
         when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.success(querySpec));
         when(service.search(any())).thenReturn(ServiceResult.success(List.of(policyDefinition)));
         when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(expandedResponseBody));
-        var requestBody = Json.createObjectBuilder().build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
 
         baseRequest()
                 .body(requestBody)
@@ -346,7 +357,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
     @Test
     void search_shouldBadRequest_whenValidationFails() {
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.failure(violation("failure", "failure path")));
-        var requestBody = Json.createObjectBuilder().build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
 
         baseRequest()
                 .body(requestBody)
@@ -362,6 +373,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
     @Test
     void search_shouldReturn400_whenInvalidQuery() {
         var requestBody = Json.createObjectBuilder()
+                .add(TYPE, EDC_QUERY_SPEC_TYPE_TERM)
                 .add("offset", -1)
                 .build();
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
@@ -382,7 +394,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
 
     @Test
     void search_shouldReturnBadRequest_whenQuerySpecTransformFails() {
-        var requestBody = Json.createObjectBuilder().build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.failure("error"));
 
@@ -402,7 +414,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.success(querySpec));
         when(service.search(any())).thenReturn(ServiceResult.badRequest("error"));
-        var requestBody = Json.createObjectBuilder().build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
 
         baseRequest()
                 .body(requestBody)
@@ -421,7 +433,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
         when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.success(querySpec));
         when(service.search(any())).thenReturn(ServiceResult.success(List.of(policyDefinition)));
         when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.failure("error"));
-        var requestBody = Json.createObjectBuilder().build();
+        var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
 
         baseRequest()
                 .body(requestBody)
@@ -505,7 +517,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
         var policyDefinition = PolicyDefinition.Builder.newInstance().policy(Policy.Builder.newInstance().build()).build();
         var plan = PolicyEvaluationPlan.Builder.newInstance().build();
         var response = Json.createObjectBuilder().build();
-        var body = Json.createObjectBuilder().add("policyScope", policyScope).build();
+        var body = Json.createObjectBuilder().add(TYPE, EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE_TERM).add("policyScope", policyScope).build();
 
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(service.findById(any())).thenReturn(policyDefinition);
@@ -529,7 +541,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
     void createEvaluationPlan_fails_whenPolicyNotFound() {
 
         var policyScope = "scope";
-        var body = Json.createObjectBuilder().add("policyScope", policyScope).build();
+        var body = Json.createObjectBuilder().add(TYPE, EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE_TERM).add("policyScope", policyScope).build();
 
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
         when(service.findById(any())).thenReturn(null);
@@ -548,7 +560,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
     void createEvaluationPlan_fails_whenRequestValidation() {
 
         var policyScope = "scope";
-        var body = Json.createObjectBuilder().add("policyScope", policyScope).build();
+        var body = Json.createObjectBuilder().add(TYPE, EDC_POLICY_EVALUATION_PLAN_REQUEST_TYPE_TERM).add("policyScope", policyScope).build();
 
         when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.failure(violation("failure", "failure path")));
         when(service.findById(any())).thenReturn(null);

--- a/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/SecretsApiExtension.java
+++ b/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/SecretsApiExtension.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.api.management.secret;
 
 import jakarta.json.Json;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.api.management.secret.transform.JsonObjectFromSecretTransformer;
 import org.eclipse.edc.connector.api.management.secret.transform.JsonObjectToSecretTransformer;
 import org.eclipse.edc.connector.api.management.secret.v4.SecretsApiV4Controller;
@@ -78,7 +77,7 @@ public class SecretsApiExtension implements ServiceExtension {
         managementApiTransformerRegistry.register(new JsonObjectToSecretTransformer());
 
         webService.registerResource(ApiContext.MANAGEMENT, new SecretsApiV4Controller(secretService, managementApiTransformerRegistry, validator));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, SecretsApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validator, ManagementApiJsonSchema.V4.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, SecretsApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
 
     }
 

--- a/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/v4/SecretsApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/secrets-api/src/main/java/org/eclipse/edc/connector/api/management/secret/v4/SecretsApiV4Controller.java
@@ -43,7 +43,7 @@ public class SecretsApiV4Controller extends BaseSecretsApiController implements 
 
     @POST
     @Override
-    public JsonObject createSecretV4(@SchemaType(EDC_SECRET_TYPE_TERM) JsonObject secretJson) {
+    public JsonObject createSecretV4(@SchemaType(value = EDC_SECRET_TYPE_TERM, version = "v4") JsonObject secretJson) {
         return createSecret(secretJson);
     }
 
@@ -63,7 +63,7 @@ public class SecretsApiV4Controller extends BaseSecretsApiController implements 
 
     @PUT
     @Override
-    public void updateSecretV4(@SchemaType(EDC_SECRET_TYPE_TERM) JsonObject secretJson) {
+    public void updateSecretV4(@SchemaType(value = EDC_SECRET_TYPE_TERM, version = "v4") JsonObject secretJson) {
         updateSecret(secretJson);
     }
 }

--- a/extensions/control-plane/api/management-api/secrets-api/src/test/java/org/eclipse/edc/connector/api/management/secret/BaseSecretsApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/secrets-api/src/test/java/org/eclipse/edc/connector/api/management/secret/BaseSecretsApiControllerTest.java
@@ -41,6 +41,7 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VOCAB;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
 import static org.eclipse.edc.spi.constants.CoreConstants.EDC_PREFIX;
 import static org.eclipse.edc.spi.types.domain.secret.Secret.EDC_SECRET_TYPE;
+import static org.eclipse.edc.spi.types.domain.secret.Secret.EDC_SECRET_TYPE_TERM;
 import static org.eclipse.edc.spi.types.domain.secret.Secret.EDC_SECRET_VALUE;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.hamcrest.Matchers.greaterThan;
@@ -270,7 +271,7 @@ public abstract class BaseSecretsApiControllerTest extends RestControllerTestBas
     private JsonObjectBuilder createSecretJson() {
         return createObjectBuilder()
                 .add(CONTEXT, createContextBuilder().build())
-                .add(TYPE, EDC_SECRET_TYPE)
+                .add(TYPE, EDC_SECRET_TYPE_TERM)
                 .add(ID, TEST_SECRET_ID)
                 .add(EDC_SECRET_VALUE, TEST_SECRET_VALUE);
     }

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/TransferProcessApiExtension.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/TransferProcessApiExtension.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.connector.controlplane.api.management.transferprocess;
 
 import jakarta.json.Json;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.connector.controlplane.api.management.transferprocess.v4.TransferProcessApiV4Controller;
 import org.eclipse.edc.connector.controlplane.api.management.transferprocess.validation.TerminateTransferValidator;
 import org.eclipse.edc.connector.controlplane.api.management.transferprocess.validation.TransferRequestValidator;
@@ -91,6 +90,6 @@ public class TransferProcessApiExtension implements ServiceExtension {
         validatorRegistry.register(TERMINATE_TRANSFER_TYPE, TerminateTransferValidator.instance());
 
         webService.registerResource(ApiContext.MANAGEMENT, new TransferProcessApiV4Controller(context.getMonitor(), service, managementApiTransformerRegistry, validatorRegistry, participantContextSupplier));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, TransferProcessApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, TransferProcessApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, MANAGEMENT_SCOPE_V4));
     }
 }

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v4/TransferProcessApiV4Controller.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/v4/TransferProcessApiV4Controller.java
@@ -49,7 +49,7 @@ public class TransferProcessApiV4Controller extends BaseTransferProcessApiContro
     @POST
     @Path("request")
     @Override
-    public JsonArray queryTransferProcessesV4(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson) {
+    public JsonArray queryTransferProcessesV4(@SchemaType(value = EDC_QUERY_SPEC_TYPE_TERM, version = "v4") JsonObject querySpecJson) {
         return queryTransferProcesses(querySpecJson);
     }
 
@@ -69,21 +69,21 @@ public class TransferProcessApiV4Controller extends BaseTransferProcessApiContro
 
     @POST
     @Override
-    public JsonObject initiateTransferProcessV4(@SchemaType(TRANSFER_REQUEST_TYPE_TERM) JsonObject transferRequest) {
+    public JsonObject initiateTransferProcessV4(@SchemaType(value = TRANSFER_REQUEST_TYPE_TERM, version = "v4") JsonObject transferRequest) {
         return initiateTransferProcess(transferRequest);
     }
 
     @POST
     @Path("/{id}/terminate")
     @Override
-    public void terminateTransferProcessV4(@PathParam("id") String id, @SchemaType(TERMINATE_TRANSFER_TYPE_TERM) JsonObject terminateTransfer) {
+    public void terminateTransferProcessV4(@PathParam("id") String id, @SchemaType(value = TERMINATE_TRANSFER_TYPE_TERM, version = "v4") JsonObject terminateTransfer) {
         terminateTransferProcess(id, terminateTransfer);
     }
 
     @POST
     @Path("/{id}/suspend")
     @Override
-    public void suspendTransferProcessV4(@PathParam("id") String id, @SchemaType(SUSPEND_TRANSFER_TYPE_TERM) JsonObject suspendTransfer) {
+    public void suspendTransferProcessV4(@PathParam("id") String id, @SchemaType(value = SUSPEND_TRANSFER_TYPE_TERM, version = "v4") JsonObject suspendTransfer) {
         suspendTransferProcess(id, suspendTransfer);
     }
 

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/BaseTransferProcessApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/BaseTransferProcessApiControllerTest.java
@@ -46,10 +46,15 @@ import java.util.UUID;
 import static io.restassured.http.ContentType.JSON;
 import static java.util.Collections.emptyList;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.SuspendTransfer.SUSPEND_TRANSFER_TYPE;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.SuspendTransfer.SUSPEND_TRANSFER_TYPE_TERM;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TerminateTransfer.TERMINATE_TRANSFER_TYPE;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TerminateTransfer.TERMINATE_TRANSFER_TYPE_TERM;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_TYPE;
+import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferRequest.TRANSFER_REQUEST_TYPE_TERM;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE;
+import static org.eclipse.edc.spi.query.QuerySpec.EDC_QUERY_SPEC_TYPE_TERM;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -160,14 +165,13 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
         @Test
         void shouldReturnQueriedTransferProcesses() {
             var querySpec = QuerySpec.none();
-            var expandedRequestBody = Json.createObjectBuilder().build();
             var transferProcess = createTransferProcess().id("id").build();
             var expandedResponseBody = Json.createObjectBuilder().add("id", "id").add("createdAt", 1234).build();
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.success(querySpec));
             when(service.search(any())).thenReturn(ServiceResult.success(List.of(transferProcess)));
             when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(expandedResponseBody));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
 
             baseRequest()
                     .body(requestBody)
@@ -179,7 +183,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
                     .body("size()", is(1))
                     .body("[0].id", is("id"))
                     .body("[0].createdAt", is(1234));
-            verify(transformerRegistry).transform(expandedRequestBody, QuerySpec.class);
+            verify(transformerRegistry).transform(requestBody, QuerySpec.class);
             verify(service).search(querySpec);
             verify(transformerRegistry).transform(transferProcess, JsonObject.class);
         }
@@ -204,7 +208,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
         @Test
         void shouldReturnBadRequest_whenValidationFails() {
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.failure(violation("error", "path")));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
 
             baseRequest()
                     .body(requestBody)
@@ -221,7 +225,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
         void shouldReturn400_whenQuerySpecTransformFails() {
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.failure("error"));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
 
             baseRequest()
                     .body(requestBody)
@@ -238,7 +242,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.success(querySpec));
             when(service.search(any())).thenReturn(ServiceResult.badRequest("error"));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
 
             baseRequest()
                     .body(requestBody)
@@ -257,7 +261,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
             when(transformerRegistry.transform(any(), eq(QuerySpec.class))).thenReturn(Result.success(querySpec));
             when(service.search(any())).thenReturn(ServiceResult.success(List.of(transferProcess)));
             when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.failure("error"));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, EDC_QUERY_SPEC_TYPE_TERM).build();
 
             baseRequest()
                     .body(requestBody)
@@ -282,7 +286,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
             when(transformerRegistry.transform(any(), eq(TransferRequest.class))).thenReturn(Result.success(transferRequest));
             when(service.initiateTransfer(any(), any())).thenReturn(ServiceResult.success(transferProcess));
             when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, TRANSFER_REQUEST_TYPE_TERM).build();
 
             baseRequest()
                     .body(requestBody)
@@ -300,7 +304,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
         @Test
         void shouldReturnBadRequest_whenValidationFails() {
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.failure(violation("error", "path")));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, TRANSFER_REQUEST_TYPE_TERM).build();
 
             baseRequest()
                     .body(requestBody)
@@ -318,7 +322,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
         void shouldReturnBadRequest_whenTransformationFails() {
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(transformerRegistry.transform(any(), any())).thenReturn(Result.failure("error"));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, TRANSFER_REQUEST_TYPE_TERM).build();
 
             baseRequest()
                     .body(requestBody)
@@ -336,7 +340,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(transformerRegistry.transform(any(), eq(TransferRequest.class))).thenReturn(Result.success(transferRequest));
             when(service.initiateTransfer(any(), any())).thenReturn(ServiceResult.conflict("already exists"));
-            var requestBody = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, TRANSFER_REQUEST_TYPE_TERM).build();
 
             baseRequest()
                     .body(requestBody)
@@ -353,7 +357,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
 
         @Test
         void shouldTerminate() {
-            var expanded = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, TERMINATE_TRANSFER_TYPE_TERM).build();
             var terminateTransfer = new TerminateTransfer("anyReason");
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(transformerRegistry.transform(any(), eq(TerminateTransfer.class))).thenReturn(Result.success(terminateTransfer));
@@ -361,11 +365,11 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
 
             baseRequest()
                     .contentType(JSON)
-                    .body(Json.createObjectBuilder().build())
+                    .body(requestBody)
                     .post("/id/terminate")
                     .then()
                     .statusCode(204);
-            verify(transformerRegistry).transform(expanded, TerminateTransfer.class);
+            verify(transformerRegistry).transform(requestBody, TerminateTransfer.class);
             verify(service).terminate(isA(TerminateTransferCommand.class));
         }
 
@@ -375,7 +379,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
 
             baseRequest()
                     .contentType(JSON)
-                    .body(Json.createObjectBuilder().build())
+                    .body(Json.createObjectBuilder().add(TYPE, TERMINATE_TRANSFER_TYPE_TERM).build())
                     .post("/id/terminate")
                     .then()
                     .statusCode(400);
@@ -391,7 +395,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
 
             baseRequest()
                     .contentType(JSON)
-                    .body(Json.createObjectBuilder().build())
+                    .body(Json.createObjectBuilder().add(TYPE, TERMINATE_TRANSFER_TYPE_TERM).build())
                     .post("/id/terminate")
                     .then()
                     .statusCode(400);
@@ -419,7 +423,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
 
         @Test
         void shouldSuspend() {
-            var expanded = Json.createObjectBuilder().build();
+            var requestBody = Json.createObjectBuilder().add(TYPE, SUSPEND_TRANSFER_TYPE_TERM).build();
             var suspendTransfer = new SuspendTransfer("anyReason");
             when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
             when(transformerRegistry.transform(any(), eq(SuspendTransfer.class))).thenReturn(Result.success(suspendTransfer));
@@ -427,11 +431,11 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
 
             baseRequest()
                     .contentType(JSON)
-                    .body(Json.createObjectBuilder().build())
+                    .body(requestBody)
                     .post("/id/suspend")
                     .then()
                     .statusCode(204);
-            verify(transformerRegistry).transform(expanded, SuspendTransfer.class);
+            verify(transformerRegistry).transform(requestBody, SuspendTransfer.class);
             verify(service).suspend(isA(SuspendTransferCommand.class));
         }
 
@@ -441,7 +445,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
 
             baseRequest()
                     .contentType(JSON)
-                    .body(Json.createObjectBuilder().build())
+                    .body(Json.createObjectBuilder().add(TYPE, SUSPEND_TRANSFER_TYPE_TERM).build())
                     .post("/id/suspend")
                     .then()
                     .statusCode(400);
@@ -457,7 +461,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
 
             baseRequest()
                     .contentType(JSON)
-                    .body(Json.createObjectBuilder().build())
+                    .body(Json.createObjectBuilder().add(TYPE, SUSPEND_TRANSFER_TYPE_TERM).build())
                     .post("/id/suspend")
                     .then()
                     .statusCode(400);

--- a/extensions/federated-catalog/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiExtension.java
+++ b/extensions/federated-catalog/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiExtension.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.catalog.api.query;
 
 import jakarta.json.Json;
-import org.eclipse.edc.api.management.schema.ManagementApiJsonSchema;
 import org.eclipse.edc.catalog.api.query.v4.CatalogsApiV4Controller;
 import org.eclipse.edc.catalog.spi.QueryService;
 import org.eclipse.edc.jsonld.spi.JsonLd;
@@ -83,6 +82,6 @@ public class FederatedCatalogApiExtension implements ServiceExtension {
         jsonLd.registerContext(EDC_DSPACE_CONTEXT, FEDERATED_CATALOG_SCOPE_V4);
 
         webService.registerResource(ApiContext.MANAGEMENT, new CatalogsApiV4Controller(queryService, managementApiTransformerRegistry));
-        webService.registerDynamicResource(ApiContext.MANAGEMENT, CatalogsApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, FEDERATED_CATALOG_SCOPE_V4, validatorRegistry, ManagementApiJsonSchema.V4.version()));
+        webService.registerDynamicResource(ApiContext.MANAGEMENT, CatalogsApiV4Controller.class, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, FEDERATED_CATALOG_SCOPE_V4));
     }
 }

--- a/extensions/federated-catalog/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/v4/CatalogsApiV4Controller.java
+++ b/extensions/federated-catalog/api/federated-catalog-api/src/main/java/org/eclipse/edc/catalog/api/query/v4/CatalogsApiV4Controller.java
@@ -42,7 +42,7 @@ public class CatalogsApiV4Controller extends BaseCatalogsApiController implement
     @Override
     @POST
     @Path("/request")
-    public JsonArray requestCatalogsV4(@SchemaType(EDC_QUERY_SPEC_TYPE_TERM) JsonObject querySpecJson, @DefaultValue("false") @QueryParam("flatten") boolean flatten) {
+    public JsonArray requestCatalogsV4(@SchemaType(value = EDC_QUERY_SPEC_TYPE_TERM, version = "v4") JsonObject querySpecJson, @DefaultValue("false") @QueryParam("flatten") boolean flatten) {
         return requestCatalogs(querySpecJson, flatten);
     }
 }

--- a/extensions/federated-catalog/api/federated-catalog-api/src/test/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiControllerTest.java
+++ b/extensions/federated-catalog/api/federated-catalog-api/src/test/java/org/eclipse/edc/catalog/api/query/FederatedCatalogApiControllerTest.java
@@ -42,6 +42,7 @@ import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.catalog.api.query.TestUtil.buildCatalog;
 import static org.eclipse.edc.catalog.api.query.TestUtil.createCatalog;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.eclipse.edc.protocol.dsp.spi.type.Dsp2025Constants.DSP_NAMESPACE_V_2025_1;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 import static org.hamcrest.CoreMatchers.is;
@@ -63,7 +64,7 @@ class FederatedCatalogApiControllerTest extends RestControllerTestBase {
 
         baseRequest()
                 .contentType(JSON)
-                .body("{}")
+                .body(Json.createObjectBuilder().add(TYPE, "QuerySpec").build())
                 .post(PATH)
                 .then()
                 .log().ifValidationFails()
@@ -79,7 +80,7 @@ class FederatedCatalogApiControllerTest extends RestControllerTestBase {
 
         baseRequest()
                 .contentType(JSON)
-                .body("{}")
+                .body(Json.createObjectBuilder().add(TYPE, "QuerySpec").build())
                 .post(PATH)
                 .then()
                 .log().ifValidationFails()
@@ -94,7 +95,7 @@ class FederatedCatalogApiControllerTest extends RestControllerTestBase {
 
         baseRequest()
                 .contentType(JSON)
-                .body("{}")
+                .body(Json.createObjectBuilder().add(TYPE, "QuerySpec").build())
                 .post(PATH)
                 .then()
                 .statusCode(500);
@@ -114,7 +115,7 @@ class FederatedCatalogApiControllerTest extends RestControllerTestBase {
 
         var response = baseRequest()
                 .contentType(JSON)
-                .body("{}")
+                .body(Json.createObjectBuilder().add(TYPE, "QuerySpec").build())
                 .post(PATH + "?flatten=true")
                 .then()
                 .log().ifValidationFails()

--- a/spi/core-spi/src/main/java/org/eclipse/edc/web/spi/validation/SchemaType.java
+++ b/spi/core-spi/src/main/java/org/eclipse/edc/web/spi/validation/SchemaType.java
@@ -30,4 +30,9 @@ public @interface SchemaType {
      */
     String[] value();
 
+    /**
+     * The schema version to validate against. Must always be set explicitly.
+     */
+    String version();
+
 }


### PR DESCRIPTION
## What this PR changes/adds

Avoids double deserialization for `JsonObject` request bodies, by moving the deserialization logic into a `MessageBodyReader`

## Why it does that

avoid duplication and unnecessary computation

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5926 

_Please be sure to take a look at the [contributing guidelines](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/#submitting-a-pull-request) and our [etiquette for pull requests](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/pr-etiquette/)._
