### PR TITLE
feat: add error handling on negotiation tasks

### DIFF
--- a/core/control-plane/control-plane-contract-task-executor/src/main/java/org/eclipse/edc/controlplane/contract/negotiation/tasks/executor/ContractNegotiationTaskExecutorImpl.java
+++ b/core/control-plane/control-plane-contract-task-executor/src/main/java/org/eclipse/edc/controlplane/contract/negotiation/tasks/executor/ContractNegotiationTaskExecutorImpl.java
@@ -132,11 +132,11 @@ public class ContractNegotiationTaskExecutorImpl implements ContractNegotiationT
     }
 
     protected StatusResult<Void> handleSendAccept(ContractNegotiation negotiation) {
-        return invokeProcessor(negotiation, negotiationProcessors::processAccepting);
+        return invokeProcessorTerminatingOnFatalError(negotiation, negotiationProcessors::processAccepting);
     }
 
     private StatusResult<Void> handleSendOffer(ContractNegotiation negotiation) {
-        return invokeProcessor(negotiation, negotiationProcessors::processOffering);
+        return invokeProcessorTerminatingOnFatalError(negotiation, negotiationProcessors::processOffering);
     }
 
     protected StatusResult<Void> handleSendTermination(ContractNegotiation negotiation) {
@@ -156,7 +156,7 @@ public class ContractNegotiationTaskExecutorImpl implements ContractNegotiationT
     }
 
     protected StatusResult<Void> handleSendVerification(ContractNegotiation negotiation) {
-        return invokeProcessor(negotiation, negotiationProcessors::processVerifying);
+        return invokeProcessorTerminatingOnFatalError(negotiation, negotiationProcessors::processVerifying);
     }
 
     private StatusResult<Void> handleAgree(ContractNegotiation negotiation) {
@@ -168,7 +168,7 @@ public class ContractNegotiationTaskExecutorImpl implements ContractNegotiationT
     }
 
     protected StatusResult<Void> handleSendAgreement(ContractNegotiation negotiation) {
-        return invokeProcessor(negotiation, negotiationProcessors::processAgreeing);
+        return invokeProcessorTerminatingOnFatalError(negotiation, negotiationProcessors::processAgreeing);
     }
 
     private StatusResult<Void> handleVerify(ContractNegotiation negotiation) {
@@ -188,7 +188,17 @@ public class ContractNegotiationTaskExecutorImpl implements ContractNegotiationT
     }
 
     private StatusResult<Void> handleSendFinalize(ContractNegotiation negotiation) {
-        return invokeProcessor(negotiation, negotiationProcessors::processFinalizing);
+        return invokeProcessorTerminatingOnFatalError(negotiation, negotiationProcessors::processFinalizing);
+    }
+
+    private StatusResult<Void> invokeProcessorTerminatingOnFatalError(ContractNegotiation negotiation, Function<ContractNegotiation, CompletableFuture<StatusResult<Void>>> processor) {
+        return invokeProcessor(negotiation, processor).onFailure(f -> {
+            if (f.isFatal()) {
+                var task = baseBuilder(SendTerminateNegotiation.Builder.newInstance(), negotiation)
+                        .build();
+                storeTask(task);
+            }
+        });
     }
 
     private StatusResult<Void> invokeProcessor(ContractNegotiation negotiation, Function<ContractNegotiation, CompletableFuture<StatusResult<Void>>> processor) {

--- a/core/control-plane/control-plane-contract-task-executor/src/test/java/org/eclipse/edc/controlplane/contract/negotiation/tasks/executor/ContractNegotiationTaskExecutorImplTest.java
+++ b/core/control-plane/control-plane-contract-task-executor/src/test/java/org/eclipse/edc/controlplane/contract/negotiation/tasks/executor/ContractNegotiationTaskExecutorImplTest.java
@@ -29,12 +29,16 @@ import org.eclipse.edc.controlplane.contract.spi.negotiation.tasks.AgreeNegotiat
 import org.eclipse.edc.controlplane.contract.spi.negotiation.tasks.ContractNegotiationTaskPayload;
 import org.eclipse.edc.controlplane.contract.spi.negotiation.tasks.FinalizeNegotiation;
 import org.eclipse.edc.controlplane.contract.spi.negotiation.tasks.RequestNegotiation;
+import org.eclipse.edc.controlplane.contract.spi.negotiation.tasks.SendAccept;
 import org.eclipse.edc.controlplane.contract.spi.negotiation.tasks.SendAgreement;
 import org.eclipse.edc.controlplane.contract.spi.negotiation.tasks.SendFinalizeNegotiation;
+import org.eclipse.edc.controlplane.contract.spi.negotiation.tasks.SendOffer;
 import org.eclipse.edc.controlplane.contract.spi.negotiation.tasks.SendRequestNegotiation;
+import org.eclipse.edc.controlplane.contract.spi.negotiation.tasks.SendTerminateNegotiation;
 import org.eclipse.edc.controlplane.contract.spi.negotiation.tasks.SendVerificationNegotiation;
 import org.eclipse.edc.controlplane.contract.spi.negotiation.tasks.VerifyNegotiation;
 import org.eclipse.edc.controlplane.tasks.ProcessTaskPayload;
+import org.eclipse.edc.controlplane.tasks.Task;
 import org.eclipse.edc.controlplane.tasks.TaskService;
 import org.eclipse.edc.participantcontext.spi.identity.ParticipantIdentityResolver;
 import org.eclipse.edc.policy.model.Policy;
@@ -62,15 +66,18 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.CONSUMER;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiation.Type.PROVIDER;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.ACCEPTING;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.AGREED;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.AGREEING;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZED;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.FINALIZING;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.INITIAL;
+import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.OFFERING;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTED;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.REQUESTING;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.VERIFIED;
 import static org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates.VERIFYING;
+import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -223,6 +230,51 @@ class ContractNegotiationTaskExecutorImplTest {
         assertThat(result.succeeded()).isTrue();
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(FatalTerminationProvider.class)
+    void handle_shouldStoreTerminationTask_whenSendProcessorFailsFatally(ContractNegotiationTaskPayload payload) {
+        var negotiation = createContractNegotiation(payload.getProcessId(),
+                ContractNegotiationStates.from(payload.getProcessState()),
+                ContractNegotiation.Type.valueOf(payload.getProcessType()));
+
+        when(negotiationStore.findById(payload.getProcessId())).thenReturn(negotiation);
+        // a fatal dispatch failure makes the processor return a fatal error
+        when(messageDispatcher.dispatch(any(), any(), any())).thenReturn(completedFuture(StatusResult.fatalError("boom")));
+
+        var result = executor.handle(payload);
+
+        assertThat(result.failed()).isTrue();
+
+        var captor = ArgumentCaptor.forClass(Task.class);
+        verify(taskService).create(captor.capture());
+        assertThat(captor.getValue().getPayload())
+                .isInstanceOfSatisfying(SendTerminateNegotiation.class, p -> {
+                    assertThat(p.getProcessId()).isEqualTo(payload.getProcessId());
+                    assertThat(p.getProcessType()).isEqualTo(payload.getProcessType());
+                });
+    }
+
+    @Test
+    void handleSendAgreement_shouldNotStoreTerminationTask_whenProcessorFailsWithNonFatalError() {
+        var negotiation = createContractNegotiation("negotiation-123", AGREEING, PROVIDER);
+
+        var task = SendAgreement.Builder.newInstance()
+                .processId("negotiation-123")
+                .processState(AGREEING.code())
+                .processType(PROVIDER.name())
+                .build();
+
+        when(negotiationStore.findById("negotiation-123")).thenReturn(negotiation);
+        // a retryable dispatch failure yields a non-fatal error
+        when(messageDispatcher.dispatch(any(), any(), any())).thenReturn(completedFuture(StatusResult.failure(ERROR_RETRY, "temporary failure")));
+
+        var result = executor.handle(task);
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.fatalError()).isFalse();
+        verify(taskService, never()).create(any());
+    }
+
     @Test
     void handle_shouldTransitionToTerminatedOnFatalError() {
         var negotiation = createContractNegotiation("negotiation-123", REQUESTING);
@@ -241,7 +293,7 @@ class ContractNegotiationTaskExecutorImplTest {
         assertThat(result.succeeded()).isTrue();
         verify(negotiationStore).save(any());
     }
-
+    
     private ContractNegotiation createContractNegotiation(String id, ContractNegotiationStates state) {
         return createContractNegotiation(id, state, CONSUMER);
     }
@@ -290,6 +342,27 @@ class ContractNegotiationTaskExecutorImplTest {
                     arguments(baseBuilder(SendAgreement.Builder.newInstance(), "id", AGREEING, PROVIDER).build(), AGREED),
                     arguments(baseBuilder(FinalizeNegotiation.Builder.newInstance(), "id", VERIFIED, PROVIDER).build(), FINALIZING),
                     arguments(baseBuilder(SendFinalizeNegotiation.Builder.newInstance(), "id", FINALIZING, PROVIDER).build(), FINALIZED)
+            );
+        }
+    }
+
+    public static class FatalTerminationProvider implements ArgumentsProvider {
+
+        protected <T extends ProcessTaskPayload, B extends ProcessTaskPayload.Builder<T, B>> B baseBuilder(B builder, String id, ContractNegotiationStates state, ContractNegotiation.Type type) {
+            return builder.processId(id)
+                    .processState(state.code())
+                    .processType(type.name());
+        }
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+
+            return Stream.of(
+                    arguments(baseBuilder(SendAgreement.Builder.newInstance(), "id", AGREEING, PROVIDER).build()),
+                    arguments(baseBuilder(SendAccept.Builder.newInstance(), "id", ACCEPTING, CONSUMER).build()),
+                    arguments(baseBuilder(SendOffer.Builder.newInstance(), "id", OFFERING, PROVIDER).build()),
+                    arguments(baseBuilder(SendVerificationNegotiation.Builder.newInstance(), "id", VERIFYING, CONSUMER).build()),
+                    arguments(baseBuilder(SendFinalizeNegotiation.Builder.newInstance(), "id", FINALIZING, PROVIDER).build())
             );
         }
     }

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/ManagementApiClientV5.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/client/ManagementApiClientV5.java
@@ -169,7 +169,7 @@ public class ManagementApiClientV5 {
         }
     }
 
-    private DatasetDto fetchDataset(String participantContext, String profile, String assetId, String providerAddress, String providerId) {
+    public DatasetDto fetchDataset(String participantContext, String profile, String assetId, String providerAddress, String providerId) {
         return catalogs.getDataset(participantContext, new DatasetRequestDto(assetId, profile, providerAddress, providerId));
     }
 

--- a/spi/core-spi/src/main/java/org/eclipse/edc/spi/response/ResponseFailure.java
+++ b/spi/core-spi/src/main/java/org/eclipse/edc/spi/response/ResponseFailure.java
@@ -32,4 +32,8 @@ public class ResponseFailure extends Failure {
     public ResponseStatus status() {
         return status;
     }
+
+    public boolean isFatal() {
+        return status == ResponseStatus.FATAL_ERROR;
+    }
 }

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/negotiation/ContractNegotiationEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/negotiation/ContractNegotiationEndToEndTest.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -190,6 +191,30 @@ class ContractNegotiationEndToEndTest {
 
             var contractNegotiationId = consumer.initContractNegotiation(provider.asCounterParty(), assetId);
 
+
+            await().untilAsserted(() -> {
+                var state = consumer.getContractNegotiationState(contractNegotiationId);
+                assertThat(state).isEqualTo(TERMINATED.name());
+            });
+        }
+
+        @Test
+        void contractNegotiation_policyMismatch_failure(@Runtime(PROVIDER_NAME) ManagementApiClientV4 provider,
+                                                        @Runtime(CONSUMER_NAME) ManagementApiClientV4 consumer,
+                                                        @Runtime(PROVIDER_NAME) CelPolicyExpressionService expressionService) {
+            var assetId = UUID.randomUUID().toString();
+            createResourcesOnProvider(provider, assetId, httpSourceDataAddress());
+
+            var dataset = consumer.getDatasetForAsset(provider.asCounterParty(), assetId);
+            var policy = dataset.getJsonArray("hasPolicy").get(0).asJsonObject();
+
+            var faultyPolicy = createObjectBuilder(policy)
+                    .add("action", "access")
+                    .add("permission", createArrayBuilder())
+                    .add("assigner", provider.getParticipantId())
+                    .add("target", assetId)
+                    .build();
+            var contractNegotiationId = consumer.initContractNegotiation(provider.asCounterParty(), faultyPolicy);
 
             await().untilAsserted(() -> {
                 var state = consumer.getContractNegotiationState(contractNegotiationId);

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualDcpTransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualDcpTransferPullEndToEndTest.java
@@ -18,11 +18,9 @@ import org.eclipse.edc.api.authentication.OauthServerEndToEndExtension;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
 import org.eclipse.edc.connector.controlplane.test.system.utils.Participants;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.ManagementApiClientV5;
-import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.AssetDto;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.AtomicConstraintDto;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.CelExpressionDto;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.PermissionDto;
-import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.PolicyDefinitionDto;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.PolicyDto;
 import org.eclipse.edc.iam.decentralizedclaims.spi.credentialservice.CredentialService;
 import org.eclipse.edc.iam.decentralizedclaims.spi.credentialservice.CredentialServiceEndToEndExtension;
@@ -235,12 +233,7 @@ class VirtualDcpTransferPullEndToEndTest {
 
         }
 
-        private String setup(ManagementApiClientV5 connectorClient, Participants.Participant provider, PolicyDto policy) {
-            var asset = new AssetDto();
-            var policyDef = new PolicyDefinitionDto(policy);
 
-            return connectorClient.setupResources(provider.contextId(), asset, policyDef, policyDef);
-        }
     }
 
     @Nested

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualTransferEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualTransferEndToEndTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.test.e2e.transfer;
 
 import org.eclipse.edc.api.authentication.OauthServerEndToEndExtension;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
 import org.eclipse.edc.connector.controlplane.test.system.utils.Participants;
 import org.eclipse.edc.connector.controlplane.test.system.utils.client.ManagementApiClientV5;
 import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
@@ -30,6 +31,7 @@ import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
 import org.eclipse.edc.test.e2e.Runtimes;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -126,6 +128,21 @@ class VirtualTransferEndToEndTest {
                 .configurationProvider(Runtimes.SignalingDataPlane::config)
                 .paramProvider(DataPlaneSignalingTestClient.class, DataPlaneSignalingTestClient::new)
                 .build();
+
+
+        @Test
+        void contractNegotiation_policyMismatch_failure(ManagementApiClientV5 connectorClient, Participants participants) {
+            var providerAddress = participants.provider().getProtocolEndpoint();
+            var assetId = setup(connectorClient, participants.provider());
+            var dataset = connectorClient.fetchDataset(participants.consumer().contextId(), participants.consumer().profile(), assetId, providerAddress, participants.provider().id());
+            var offer = dataset.offers().stream().findFirst().get();
+            var permission = offer.getPermissions().stream().findFirst().get();
+            offer.getPermissions().add(permission);
+            var negotiationId = connectorClient.initContractNegotiation(participants.consumer().contextId(), participants.consumer().profile(), assetId, offer, providerAddress, participants.provider().id());
+
+            connectorClient.waitForContractNegotiationState(participants.consumer().contextId(), negotiationId, ContractNegotiationStates.TERMINATED.name());
+
+        }
 
     }
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualTransferEndToEndTestBase.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/transfer/VirtualTransferEndToEndTestBase.java
@@ -252,13 +252,18 @@ public abstract class VirtualTransferEndToEndTestBase {
 
     }
 
-    private String setup(ManagementApiClientV5 connectorClient, Participants.Participant provider) {
-        var asset = new AssetDto();
-
+    protected String setup(ManagementApiClientV5 connectorClient, Participants.Participant provider) {
         var permissions = List.of(new PermissionDto());
-        var policyDef = new PolicyDefinitionDto(new PolicyDto(permissions));
+        var policy = new PolicyDto(permissions);
+
+        return setup(connectorClient, provider, policy);
+
+    }
+
+    protected String setup(ManagementApiClientV5 connectorClient, Participants.Participant provider, PolicyDto policy) {
+        var asset = new AssetDto();
+        var policyDef = new PolicyDefinitionDto(policy);
 
         return connectorClient.setupResources(provider.contextId(), asset, policyDef, policyDef);
-
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

add error handling on negotiation tasks if some fatal error occur on sending the messages.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/#submitting-a-pull-request) and our [etiquette for pull requests](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/pr-etiquette/)._
