### PR TITLE
fix: rightOperand serialization for list types

### DIFF
--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
@@ -41,6 +41,7 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.Optional;
 
 import static jakarta.json.stream.JsonCollectors.toJsonArray;
@@ -99,10 +100,10 @@ public class JsonObjectFromPolicyTransformer extends AbstractJsonLdTransformer<P
     /**
      * Walks the policy object model, transforming it to a JsonObject.
      */
-    private static class Visitor implements Policy.Visitor<JsonObject>, Rule.Visitor<JsonObject>, Constraint.Visitor<JsonObject>, Expression.Visitor<JsonObject> {
+    private static class Visitor implements Policy.Visitor<JsonObject>, Rule.Visitor<JsonObject>, Constraint.Visitor<JsonObject>, Expression.Visitor<JsonArray> {
         private final JsonBuilderFactory jsonFactory;
         private final ParticipantIdMapper participantIdMapper;
-        private TransformerConfig config;
+        private final TransformerConfig config;
 
 
         Visitor(JsonBuilderFactory jsonFactory, ParticipantIdMapper participantIdMapper, TransformerConfig config) {
@@ -140,10 +141,25 @@ public class JsonObjectFromPolicyTransformer extends AbstractJsonLdTransformer<P
         }
 
         @Override
-        public JsonObject visitLiteralExpression(LiteralExpression expression) {
-            return jsonFactory.createObjectBuilder()
-                    .add(VALUE, Json.createValue(expression.getValue().toString()))
+        public JsonArray visitLiteralExpression(LiteralExpression expression) {
+            if (expression.getValue() instanceof Collection<?> collection) {
+                return collection.stream()
+                        .map(this::toJsonValue)
+                        .map(value -> jsonFactory.createObjectBuilder().add(VALUE, value).build())
+                        .collect(toJsonArray());
+            }
+
+            return jsonFactory.createArrayBuilder()
+                    .add(jsonFactory.createObjectBuilder().add(VALUE, toJsonValue(expression.getValue())))
                     .build();
+        }
+
+        private JsonValue toJsonValue(Object value) {
+            if (value instanceof Number number) {
+                return Json.createValue(number);
+            }
+
+            return Json.createValue(value.toString());
         }
 
         @Override

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformerTest.java
@@ -47,6 +47,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
@@ -191,7 +192,7 @@ class JsonObjectFromPolicyTransformerTest {
                 .isEqualTo(((LiteralExpression) constraint.getLeftExpression()).getValue());
         assertThat(constraintJson.getJsonArray(ODRL_OPERATOR_ATTRIBUTE).getJsonObject(0).getString(ID))
                 .isEqualTo(constraint.getOperator().getOdrlRepresentation());
-        assertThat(constraintJson.getJsonObject(ODRL_RIGHT_OPERAND_ATTRIBUTE).getJsonString(VALUE).getString())
+        assertThat(constraintJson.getJsonArray(ODRL_RIGHT_OPERAND_ATTRIBUTE).getJsonObject(0).getJsonString(VALUE).getString())
                 .isEqualTo(((LiteralExpression) constraint.getRightExpression()).getValue());
 
         verify(context, never()).reportProblem(anyString());
@@ -231,7 +232,7 @@ class JsonObjectFromPolicyTransformerTest {
                 .isEqualTo(((LiteralExpression) constraint.getLeftExpression()).getValue());
         assertThat(constraintJson.getJsonArray(ODRL_OPERATOR_ATTRIBUTE).getJsonObject(0).getString(ID))
                 .isEqualTo(constraint.getOperator().getOdrlRepresentation());
-        assertThat(constraintJson.getJsonObject(ODRL_RIGHT_OPERAND_ATTRIBUTE).getJsonString(VALUE).getString())
+        assertThat(constraintJson.getJsonArray(ODRL_RIGHT_OPERAND_ATTRIBUTE).getJsonObject(0).getJsonString(VALUE).getString())
                 .isEqualTo(((LiteralExpression) constraint.getRightExpression()).getValue());
 
         var dutyJson = permissionJson.getJsonArray(ODRL_DUTY_ATTRIBUTE).get(0).asJsonObject();
@@ -263,7 +264,7 @@ class JsonObjectFromPolicyTransformerTest {
                 .isEqualTo(((LiteralExpression) constraint.getLeftExpression()).getValue());
         assertThat(constraintJson.getJsonArray(ODRL_OPERATOR_ATTRIBUTE).getJsonObject(0).getString(ID))
                 .isEqualTo(constraint.getOperator().getOdrlRepresentation());
-        assertThat(constraintJson.getJsonObject(ODRL_RIGHT_OPERAND_ATTRIBUTE).getJsonString(VALUE).getString())
+        assertThat(constraintJson.getJsonArray(ODRL_RIGHT_OPERAND_ATTRIBUTE).getJsonObject(0).getJsonString(VALUE).getString())
                 .isEqualTo(((LiteralExpression) constraint.getRightExpression()).getValue());
 
         assertThat(prohibitionJson.getJsonArray(ODRL_REMEDY_ATTRIBUTE)).hasSize(1).first()
@@ -299,7 +300,7 @@ class JsonObjectFromPolicyTransformerTest {
                 .isEqualTo(((LiteralExpression) constraint.getLeftExpression()).getValue());
         assertThat(constraintJson.getJsonArray(ODRL_OPERATOR_ATTRIBUTE).getJsonObject(0).getString(ID))
                 .isEqualTo(constraint.getOperator().getOdrlRepresentation());
-        assertThat(constraintJson.getJsonObject(ODRL_RIGHT_OPERAND_ATTRIBUTE).getJsonString(VALUE).getString())
+        assertThat(constraintJson.getJsonArray(ODRL_RIGHT_OPERAND_ATTRIBUTE).getJsonObject(0).getJsonString(VALUE).getString())
                 .isEqualTo(((LiteralExpression) constraint.getRightExpression()).getValue());
 
         var consequencesJson = dutyJson.getJsonArray(ODRL_CONSEQUENCE_ATTRIBUTE);
@@ -425,6 +426,68 @@ class JsonObjectFromPolicyTransformerTest {
 
         assertThat(result).isNotNull();
         assertThat(result.getString(TYPE)).isEqualTo(expectedType);
+    }
+
+    @Test
+    void shouldTransformRightOperandCollectionStrings() {
+        var constraint = AtomicConstraint.Builder.newInstance()
+                .leftExpression(new LiteralExpression("left"))
+                .operator(Operator.EQ)
+                .rightExpression(new LiteralExpression(List.of("right1", "right2")))
+                .build();
+        var policy = Policy.Builder.newInstance()
+                .permission(Permission.Builder.newInstance()
+                        .action(Action.Builder.newInstance().type("use").constraint(constraint).build())
+                        .build())
+                .build();
+
+        var result = transformer.transform(policy, context);
+
+        assertThat(result)
+                .extracting(it -> it.get(ODRL_PERMISSION_ATTRIBUTE))
+                .extracting(it -> it.asJsonArray())
+                .asInstanceOf(list(JsonObject.class))
+                .first()
+                .extracting(it -> it.getJsonObject(ODRL_ACTION_ATTRIBUTE))
+                .extracting(it -> it.getJsonObject(ODRL_REFINEMENT_ATTRIBUTE))
+                .extracting(it -> it.getJsonArray(ODRL_RIGHT_OPERAND_ATTRIBUTE))
+                .asInstanceOf(list(JsonObject.class))
+                .hasSize(2)
+                .extracting(it -> it.getString(VALUE))
+                .containsExactly("right1", "right2");
+
+        verify(context, never()).reportProblem(anyString());
+    }
+
+    @Test
+    void shouldTransformRightOperandCollectionInts() {
+        var constraint = AtomicConstraint.Builder.newInstance()
+                .leftExpression(new LiteralExpression("left"))
+                .operator(Operator.EQ)
+                .rightExpression(new LiteralExpression(List.of(3, 5)))
+                .build();
+        var policy = Policy.Builder.newInstance()
+                .permission(Permission.Builder.newInstance()
+                        .action(Action.Builder.newInstance().type("use").constraint(constraint).build())
+                        .build())
+                .build();
+
+        var result = transformer.transform(policy, context);
+
+        assertThat(result)
+                .extracting(it -> it.get(ODRL_PERMISSION_ATTRIBUTE))
+                .extracting(JsonValue::asJsonArray)
+                .asInstanceOf(list(JsonObject.class))
+                .first()
+                .extracting(it -> it.getJsonObject(ODRL_ACTION_ATTRIBUTE))
+                .extracting(it -> it.getJsonObject(ODRL_REFINEMENT_ATTRIBUTE))
+                .extracting(it -> it.getJsonArray(ODRL_RIGHT_OPERAND_ATTRIBUTE))
+                .asInstanceOf(list(JsonObject.class))
+                .hasSize(2)
+                .extracting(it -> it.getInt(VALUE))
+                .containsExactly(3, 5);
+
+        verify(context, never()).reportProblem(anyString());
     }
 
     private Action getAction() {

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/PolicyDefinitionApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/PolicyDefinitionApiV5EndToEndTest.java
@@ -57,6 +57,7 @@ import static org.eclipse.edc.test.e2e.managementapi.v5.TestFunction.jsonLdConte
 import static org.eclipse.edc.test.e2e.managementapi.v5.TestFunction.participantContext;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.Matchers.notNullValue;
@@ -118,6 +119,48 @@ public class PolicyDefinitionApiV5EndToEndTest {
                     .body("policy.permission[0].constraint[0].rightOperand", is("contractAgreement+0s"))
                     .body("policy.prohibition[0].action", is("use"))
                     .body("policy.obligation[0].action", is("use"));
+        }
+
+        @Test
+        void create_rightOperandAsList(ManagementEndToEndV5TestContext context) {
+            var policy = createObjectBuilder()
+                    .add(TYPE, "Set")
+                    .add("permission", createArrayBuilder()
+                            .add(createObjectBuilder()
+                                    .add("action", "use")
+                                    .add("constraint", createArrayBuilder().add(createObjectBuilder()
+                                                    .add("leftOperand", "inForceDate")
+                                                    .add("operator", "isPartOf")
+                                                    .add("rightOperand", createArrayBuilder().add("value").add("another")))
+                                            .build()))
+                            .build())
+                    .build();
+
+            var requestBody = createObjectBuilder()
+                    .add(CONTEXT, jsonLdContext())
+                    .add(TYPE, "PolicyDefinition")
+                    .add("policy", policy)
+                    .build();
+
+            var id = context.baseRequest(participantTokenJwt)
+                    .body(requestBody.toString())
+                    .contentType(JSON)
+                    .post("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/policydefinitions")
+                    .then()
+                    .log().ifValidationFails()
+                    .contentType(JSON)
+                    .statusCode(200)
+                    .extract().jsonPath().getString(ID);
+
+            context.baseRequest(participantTokenJwt)
+                    .get("/v5beta/participants/" + PARTICIPANT_CONTEXT_ID + "/policydefinitions/" + id)
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .contentType(JSON)
+                    .body(ID, is(id))
+                    .body(CONTEXT, contains(jsonLdContextArray()))
+                    .body("policy.permission[0].constraint[0].rightOperand", hasSize(2));
         }
 
         @Test


### PR DESCRIPTION
## What this PR changes/adds

Correctly serializes `List` values of `rightOperand`.

## Why it does that

Currently it serializes everything as the result of the `toString` method

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5792 

_Please be sure to take a look at the [contributing guidelines](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/#submitting-a-pull-request) and our [etiquette for pull requests](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/pr-etiquette/)._
