### PR TITLE
feat: implement retry

### DIFF
--- a/core/common/lib/core-lib/src/main/java/org/eclipse/edc/nats/tasks/subscriber/AbstractTaskSubscriber.java
+++ b/core/common/lib/core-lib/src/main/java/org/eclipse/edc/nats/tasks/subscriber/AbstractTaskSubscriber.java
@@ -50,7 +50,7 @@ public abstract class AbstractTaskSubscriber<P extends ProcessTaskPayload> exten
         try {
             var task = mapperSupplier.get().readValue(message.getData(), Task.class);
             if (target.isAssignableFrom(task.getPayload().getClass())) {
-                return transactionContext.execute(() -> handleTask(task));
+                return transactionContext.execute(() -> handleTask(message, task));
             } else {
                 return StatusResult.failure(ResponseStatus.FATAL_ERROR, "Invalid task payload type");
             }
@@ -60,23 +60,27 @@ public abstract class AbstractTaskSubscriber<P extends ProcessTaskPayload> exten
     }
 
     @SuppressWarnings("unchecked")
-    private @NotNull StatusResult<Void> handleTask(Task task) {
+    private @NotNull StatusResult<Void> handleTask(Message message, Task task) {
         var persistedTask = taskService.findById(task.getId());
         if (persistedTask == null) {
+            // The task is published within the producer's transaction, before it commits, so a fast delivery can
+            // arrive before the task is visible in the store. Retry until it becomes visible, bounded by the NATS
+            // delivery count (which exists even though the task does not) so a task that never commits cannot be
+            // redelivered forever.
+            if (message.metaData().deliveredCount() >= maxRetries) {
+                monitor.severe("Task " + task.getId() + " not found after " + maxRetries + " deliveries. Dropping message.");
+                return StatusResult.success();
+            }
             return StatusResult.failure(ResponseStatus.ERROR_RETRY, "Task not found: " + task.getId());
         }
+
         var result = handlePayload((P) task.getPayload());
         if (result.succeeded() || result.fatalError()) {
             taskService.delete(task.getId());
-        } else {
-            if (persistedTask.getRetryCount() >= maxRetries) {
-                monitor.severe("Task " + persistedTask.getId() + " reached max retry count of " + maxRetries + ". Dropping task. Last error: " + result.getFailureDetail());
-                taskService.delete(persistedTask.getId());
-                return StatusResult.success();
-            }
-            //increment retry count
-            taskService.update(task.toBuilder().retryCount(task.getRetryCount() + 1).at(clock.millis()).build());
         }
+        // On a retryable (ERROR_RETRY) failure the message is nak'd and redelivered. The retry/give-up decision is
+        // owned by the processor (bounded by edc.<entity>.send.retry.limit), which terminates the entity on
+        // exhaustion; the subscriber deliberately does not cap business retries here.
         return result;
     }
 

--- a/core/control-plane/control-plane-transfer-task-executor/src/main/java/org/eclipse/edc/controlplane/transfer/process/tasks/executor/TransferProcessTaskExecutorImpl.java
+++ b/core/control-plane/control-plane-transfer-task-executor/src/main/java/org/eclipse/edc/controlplane/transfer/process/tasks/executor/TransferProcessTaskExecutorImpl.java
@@ -145,29 +145,29 @@ public class TransferProcessTaskExecutorImpl implements TransferProcessTaskExecu
                 }
             });
         } else {
-            return invokeProcessor(process, transferProcessors::processProviderInitial).onSuccess(v -> {
+            return terminateOnFatalError(process, invokeProcessor(process, transferProcessors::processProviderInitial).onSuccess(v -> {
                 if (process.getState() == STARTING.code()) {
                     var task = baseBuilder(SendTransferStart.Builder.newInstance(), process).build();
                     storeTask(task);
                 }
-            });
+            }));
         }
     }
 
     private StatusResult<Void> handleSendStartMessage(TransferProcess process) {
-        return invokeProcessor(process, transferProcessors::processStarting);
+        return invokeProcessorTerminatingOnFatalError(process, transferProcessors::processStarting);
     }
 
     private StatusResult<Void> handleSignalStartedDataflow(TransferProcess process) {
-        return invokeProcessor(process, transferProcessors::processStartupRequested);
+        return invokeProcessorTerminatingOnFatalError(process, transferProcessors::processStartupRequested);
     }
 
     private StatusResult<Void> handleSuspendDataflow(TransferProcess process) {
-        return invokeProcessor(process, transferProcessors::processSuspending);
+        return invokeProcessorTerminatingOnFatalError(process, transferProcessors::processSuspending);
     }
 
     private StatusResult<Void> handleResumeDataflow(TransferProcess process) {
-        return invokeProcessor(process, transferProcessors::processResuming);
+        return invokeProcessorTerminatingOnFatalError(process, transferProcessors::processResuming);
     }
 
     private StatusResult<Void> handleTerminateDataflow(TransferProcess process) {
@@ -175,7 +175,7 @@ public class TransferProcessTaskExecutorImpl implements TransferProcessTaskExecu
     }
 
     private StatusResult<Void> handleCompleteDataflow(TransferProcess process) {
-        return invokeProcessor(process, transferProcessors::processCompleting);
+        return invokeProcessorTerminatingOnFatalError(process, transferProcessors::processCompleting);
     }
 
     private StatusResult<Void> handleSendRequest(TransferProcess process) {
@@ -196,6 +196,19 @@ public class TransferProcessTaskExecutorImpl implements TransferProcessTaskExecu
         } catch (Exception e) {
             return StatusResult.failure(FATAL_ERROR, "Failed to invoke processor: %s".formatted(e.getMessage()));
         }
+    }
+
+    private StatusResult<Void> invokeProcessorTerminatingOnFatalError(TransferProcess process, Function<TransferProcess, CompletableFuture<StatusResult<Void>>> processor) {
+        return terminateOnFatalError(process, invokeProcessor(process, processor));
+    }
+
+    private StatusResult<Void> terminateOnFatalError(TransferProcess process, StatusResult<Void> result) {
+        return result.onFailure(f -> {
+            if (f.isFatal()) {
+                var task = baseBuilder(TerminateDataFlow.Builder.newInstance(), process).build();
+                storeTask(task);
+            }
+        });
     }
 
     protected <T extends ProcessTaskPayload, B extends ProcessTaskPayload.Builder<T, B>> B baseBuilder(B builder, TransferProcess transferProcess) {

--- a/core/control-plane/control-plane-transfer-task-executor/src/test/java/org/eclipse/edc/controlplane/transfer/process/tasks/executor/TransferProcessTaskExecutorImplTest.java
+++ b/core/control-plane/control-plane-transfer-task-executor/src/test/java/org/eclipse/edc/controlplane/transfer/process/tasks/executor/TransferProcessTaskExecutorImplTest.java
@@ -29,6 +29,7 @@ import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcess
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates;
 import org.eclipse.edc.connector.controlplane.transfer.spi.types.protocol.TransferProcessAck;
 import org.eclipse.edc.controlplane.tasks.ProcessTaskPayload;
+import org.eclipse.edc.controlplane.tasks.Task;
 import org.eclipse.edc.controlplane.tasks.TaskService;
 import org.eclipse.edc.controlplane.transfer.spi.TransferProcessTaskExecutor;
 import org.eclipse.edc.controlplane.transfer.spi.tasks.CompleteDataFlow;
@@ -83,15 +84,17 @@ import static org.eclipse.edc.connector.controlplane.transfer.spi.types.Transfer
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATED;
 import static org.eclipse.edc.connector.controlplane.transfer.spi.types.TransferProcessStates.TERMINATING;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class TransferProcessTaskExecutorImplTest {
-
+    
     private final TransferProcessObservable observable = mock();
     private final DataFlowController dataFlowController = mock();
     private final TransferProcessStore transferStore = mock();
@@ -262,6 +265,61 @@ class TransferProcessTaskExecutorImplTest {
         assertThat(result.failed()).isTrue();
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(FatalTerminationProvider.class)
+    void handle_shouldStoreTerminateDataFlowTask_whenProcessorFailsFatally(TransferProcessTaskPayload payload) {
+        when(policyArchive.findPolicyForContract(any())).thenReturn(Policy.Builder.newInstance().build());
+        when(messageDispatcher.dispatch(any(), any(), any())).thenReturn(completedFuture(StatusResult.fatalError("boom")));
+        when(dataFlowController.start(any(), any())).thenReturn(StatusResult.fatalError("boom"));
+        when(dataFlowController.started(any())).thenReturn(StatusResult.fatalError("boom"));
+        when(dataFlowController.resume(any())).thenReturn(StatusResult.fatalError("boom"));
+        when(dataFlowController.suspend(any())).thenReturn(StatusResult.fatalError("boom"));
+        when(dataFlowController.completed(any())).thenReturn(StatusResult.fatalError("boom"));
+
+        var process = TransferProcess.Builder.newInstance()
+                .id(payload.getProcessId())
+                .type(TransferProcess.Type.valueOf(payload.getProcessType()))
+                .state(TransferProcessStates.from(payload.getProcessState()).code())
+                .contractId("contractId")
+                .build();
+        when(transferStore.findById(payload.getProcessId())).thenReturn(process);
+
+        var result = executor.handle(payload);
+
+        assertThat(result.failed()).isTrue();
+
+        var captor = ArgumentCaptor.forClass(Task.class);
+        verify(taskService).create(captor.capture());
+        assertThat(captor.getValue().getPayload())
+                .isInstanceOfSatisfying(TerminateDataFlow.class,
+                        p -> assertThat(p.getProcessId()).isEqualTo(payload.getProcessId()));
+    }
+
+    @Test
+    void handle_shouldNotStoreTerminateDataFlowTask_whenProcessorFailsNonFatally() {
+        var task = SignalDataflowStarted.Builder.newInstance()
+                .processId("transfer-123")
+                .processState(REQUESTED.code())
+                .processType(CONSUMER.name())
+                .build();
+
+        var process = TransferProcess.Builder.newInstance()
+                .id("transfer-123")
+                .type(CONSUMER)
+                .state(REQUESTED.code())
+                .contractId("contractId")
+                .build();
+        when(transferStore.findById("transfer-123")).thenReturn(process);
+        // a retryable failure yields a non-fatal error
+        when(dataFlowController.started(any())).thenReturn(StatusResult.failure(ERROR_RETRY, "temporary"));
+
+        var result = executor.handle(task);
+
+        assertThat(result.failed()).isTrue();
+        assertThat(result.fatalError()).isFalse();
+        verify(taskService, never()).create(any());
+    }
+
     @Test
     void handle_shouldTransitionWhenHandlerSucceeds() {
         var transferProcess = createTransferProcess("transfer-123", INITIAL);
@@ -333,6 +391,29 @@ class TransferProcessTaskExecutorImplTest {
                     arguments(baseBuilder(CompleteDataFlow.Builder.newInstance(), id, COMPLETING, PROVIDER).build(), COMPLETED)
             );
 
+        }
+    }
+
+    public static class FatalTerminationProvider implements ArgumentsProvider {
+
+        protected <T extends ProcessTaskPayload, B extends ProcessTaskPayload.Builder<T, B>> B baseBuilder(B builder, String id, TransferProcessStates state, TransferProcess.Type type) {
+            return builder.processId(id)
+                    .processState(state.code())
+                    .processType(type.name());
+        }
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+
+            var id = UUID.randomUUID().toString();
+            return Stream.of(
+                    arguments(baseBuilder(PrepareTransfer.Builder.newInstance(), id, INITIAL, PROVIDER).build()),
+                    arguments(baseBuilder(SendTransferStart.Builder.newInstance(), id, STARTING, PROVIDER).build()),
+                    arguments(baseBuilder(SignalDataflowStarted.Builder.newInstance(), id, REQUESTED, CONSUMER).build()),
+                    arguments(baseBuilder(SuspendDataFlow.Builder.newInstance(), id, SUSPENDING, CONSUMER).build()),
+                    arguments(baseBuilder(ResumeDataFlow.Builder.newInstance(), id, RESUMING, CONSUMER).build()),
+                    arguments(baseBuilder(CompleteDataFlow.Builder.newInstance(), id, COMPLETING, CONSUMER).build())
+            );
         }
     }
 }

--- a/extensions/control-plane/tasks/nats/subscriber/negotiation-tasks-subscriber-nats/src/main/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/subscriber/NatsContractNegotiationSubscriberExtension.java
+++ b/extensions/control-plane/tasks/nats/subscriber/negotiation-tasks-subscriber-nats/src/main/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/subscriber/NatsContractNegotiationSubscriberExtension.java
@@ -129,7 +129,11 @@ public class NatsContractNegotiationSubscriberExtension implements ServiceExtens
             Integer batchSize,
             @Setting(key = "edc.nats.cn.subscriber.max-wait", description = "The max waiting time for messages (ms)", defaultValue = "100")
             Integer maxWait,
-            @Setting(key = "edc.nats.cn.subscriber.max-retries", description = "Max retries for task execution failure on transient errors", defaultValue = "3")
+            @Setting(key = "edc.nats.cn.subscriber.max-retries",
+                    description = "Max number of message deliveries while the referenced task is not yet visible in the store " +
+                            "(e.g. published before its transaction committed), after which the message is dropped. It does not cap " +
+                            "processor/business retries, which are bounded by edc.negotiation.send.retry.limit.",
+                    defaultValue = "3")
             Integer maxRetries
     ) {
     }

--- a/extensions/control-plane/tasks/nats/subscriber/negotiation-tasks-subscriber-nats/src/test/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/subscriber/NatsContractNegotiationTaskSubscriberTest.java
+++ b/extensions/control-plane/tasks/nats/subscriber/negotiation-tasks-subscriber-nats/src/test/java/org/eclipse/edc/virtual/controlplane/contract/negotiation/subscriber/NatsContractNegotiationTaskSubscriberTest.java
@@ -68,7 +68,9 @@ import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -141,25 +143,42 @@ public class NatsContractNegotiationTaskSubscriberTest {
     }
 
     @Test
-    void handleRetryMessage_withLimit() throws JsonProcessingException {
+    void handleRetryMessage_businessRetryIsNotCappedBySubscriber() throws JsonProcessingException {
         var payload = baseBuilder(RequestNegotiation.Builder.newInstance(), UUID.randomUUID().toString(), INITIAL, CONSUMER).build();
         var task = Task.Builder.newInstance().at(System.currentTimeMillis())
                 .payload(payload)
                 .build();
 
-        when(taskService.findById(any())).thenReturn(task)
-                .thenReturn(task.toBuilder().retryCount(task.getRetryCount() + 1).build())
-                .thenReturn(task.toBuilder().retryCount(task.getRetryCount() + 2).build());
-
+        when(taskService.findById(any())).thenReturn(task);
         when(taskManager.handle(any())).thenReturn(StatusResult.failure(ERROR_RETRY));
         subscriber.start();
 
         NATS_EXTENSION.publish("negotiations.provider." + payload.name(), MAPPER.writeValueAsBytes(task));
 
+        // a retryable failure is redelivered without a subscriber-side cap: the processor owns the give-up decision
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() ->
+                verify(taskManager, atLeast(3)).handle(refEq(payload)));
+        verify(taskService, never()).delete(any());
+        verify(taskService, never()).update(any());
+    }
+
+    @Test
+    void handleMissingTask_isRetried_thenDroppedAfterMaxDeliveries() throws JsonProcessingException {
+        var payload = baseBuilder(RequestNegotiation.Builder.newInstance(), UUID.randomUUID().toString(), INITIAL, CONSUMER).build();
+        var task = Task.Builder.newInstance().at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        // task not yet visible (published before its transaction committed): retry, bounded by delivery count
+        when(taskService.findById(any())).thenReturn(null);
+        subscriber.start();
+
+        NATS_EXTENSION.publish("negotiations.provider." + payload.name(), MAPPER.writeValueAsBytes(task));
+
+        // maxRetries == 2: delivered twice (nak, then dropped); the executor is never invoked while the task is missing
         await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
-            verify(taskManager, times(3)).handle(refEq(payload));
-            verify(taskService).delete(task.getId());
-            verify(taskService, times(2)).update(any());
+            verify(taskService, times(2)).findById(any());
+            verify(taskManager, never()).handle(any());
         });
     }
 

--- a/extensions/control-plane/tasks/nats/subscriber/transfer-tasks-subscriber-nats/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/subscriber/nats/NatsTransferProcessTaskSubscriberExtension.java
+++ b/extensions/control-plane/tasks/nats/subscriber/transfer-tasks-subscriber-nats/src/main/java/org/eclipse/edc/virtual/controlplane/transfer/subscriber/nats/NatsTransferProcessTaskSubscriberExtension.java
@@ -129,7 +129,11 @@ public class NatsTransferProcessTaskSubscriberExtension implements ServiceExtens
             Integer batchSize,
             @Setting(key = "edc.nats.tp.subscriber.max-wait", description = "The max waiting time for messages (ms)", defaultValue = "100")
             Integer maxWait,
-            @Setting(key = "edc.nats.tp.subscriber.max-retries", description = "Max retries for task execution failure on transient errors", defaultValue = "3")
+            @Setting(key = "edc.nats.tp.subscriber.max-retries",
+                    description = "Max number of message deliveries while the referenced task is not yet visible in the store " +
+                            "(e.g. published before its transaction committed), after which the message is dropped. It does not cap " +
+                            "processor/business retries, which are bounded by edc.transfer.send.retry.limit.",
+                    defaultValue = "3")
             Integer maxRetries
 
     ) {

--- a/extensions/control-plane/tasks/nats/subscriber/transfer-tasks-subscriber-nats/src/test/java/org/eclipse/edc/virtual/controlplane/transfer/subscriber/nats/NatsTransferProcessSubscriberTest.java
+++ b/extensions/control-plane/tasks/nats/subscriber/transfer-tasks-subscriber-nats/src/test/java/org/eclipse/edc/virtual/controlplane/transfer/subscriber/nats/NatsTransferProcessSubscriberTest.java
@@ -72,7 +72,9 @@ import static org.eclipse.edc.spi.response.ResponseStatus.ERROR_RETRY;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -149,25 +151,42 @@ class NatsTransferProcessSubscriberTest {
     }
 
     @Test
-    void handleRetryMessage_withLimit() throws JsonProcessingException {
+    void handleRetryMessage_businessRetryIsNotCappedBySubscriber() throws JsonProcessingException {
         var payload = baseBuilder(PrepareTransfer.Builder.newInstance(), UUID.randomUUID().toString(), INITIAL, CONSUMER).build();
         var task = Task.Builder.newInstance().at(System.currentTimeMillis())
                 .payload(payload)
                 .build();
 
-        when(taskService.findById(any())).thenReturn(task)
-                .thenReturn(task.toBuilder().retryCount(task.getRetryCount() + 1).build())
-                .thenReturn(task.toBuilder().retryCount(task.getRetryCount() + 2).build());
-
+        when(taskService.findById(any())).thenReturn(task);
         when(taskManager.handle(any())).thenReturn(StatusResult.failure(ERROR_RETRY));
         subscriber.start();
 
         NATS_EXTENSION.publish("transfers.provider." + payload.name(), MAPPER.writeValueAsBytes(task));
 
+        // a retryable failure is redelivered without a subscriber-side cap: the processor owns the give-up decision
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() ->
+                verify(taskManager, atLeast(3)).handle(refEq(payload)));
+        verify(taskService, never()).delete(any());
+        verify(taskService, never()).update(any());
+    }
+
+    @Test
+    void handleMissingTask_isRetried_thenDroppedAfterMaxDeliveries() throws JsonProcessingException {
+        var payload = baseBuilder(PrepareTransfer.Builder.newInstance(), UUID.randomUUID().toString(), INITIAL, CONSUMER).build();
+        var task = Task.Builder.newInstance().at(System.currentTimeMillis())
+                .payload(payload)
+                .build();
+
+        // task not yet visible (published before its transaction committed): retry, bounded by delivery count
+        when(taskService.findById(any())).thenReturn(null);
+        subscriber.start();
+
+        NATS_EXTENSION.publish("transfers.provider." + payload.name(), MAPPER.writeValueAsBytes(task));
+
+        // maxRetries == 2: delivered twice (nak, then dropped); the executor is never invoked while the task is missing
         await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
-            verify(taskManager, times(3)).handle(refEq(payload));
-            verify(taskService).delete(task.getId());
-            verify(taskService, times(2)).update(any());
+            verify(taskService, times(2)).findById(any());
+            verify(taskManager, never()).handle(any());
         });
     }
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/negotiation/VirtualNegotiationRetryEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/negotiation/VirtualNegotiationRetryEndToEndTest.java
@@ -1,0 +1,185 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.negotiation;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import org.eclipse.edc.api.authentication.OauthServerEndToEndExtension;
+import org.eclipse.edc.connector.controlplane.contract.spi.types.negotiation.ContractNegotiationStates;
+import org.eclipse.edc.connector.controlplane.test.system.utils.Participants;
+import org.eclipse.edc.connector.controlplane.test.system.utils.client.ManagementApiClientV5;
+import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.AssetDto;
+import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.PermissionDto;
+import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.PolicyDefinitionDto;
+import org.eclipse.edc.connector.controlplane.test.system.utils.client.api.model.PolicyDto;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.junit.extensions.ComponentRuntimeContext;
+import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.nats.testfixtures.NatsEndToEndExtension;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
+import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
+import org.eclipse.edc.test.e2e.Runtimes;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Diagnostic E2E test for GH issue #5610 ("Externalize state machine retrial decision").
+ * <p>
+ * In the virtual, NATS-driven control plane a state transition is executed by a task subscriber that redelivers the
+ * message on transient failures. The classic {@code RetryProcessor} decides when to give up based on the entity's
+ * {@code stateCount} vs {@code edc.negotiation.send.retry.limit}, while the NATS subscriber has its own, independent
+ * ceiling ({@code edc.nats.cn.subscriber.max-retries}). This test verifies that the entity {@code stateCount}-based
+ * retry limit actually drives a negotiation to {@code TERMINATED} when the counter-party keeps failing over NATS.
+ * <p>
+ * A retryable failure is produced by pointing the consumer at a fake provider that always answers HTTP 503 (the DSP
+ * dispatcher maps 5xx to {@code ERROR_RETRY}; 4xx and connection errors map to {@code FATAL_ERROR}). The NATS
+ * {@code max-retries} is set high and {@code send.retry.limit} low so the {@code stateCount} ceiling is the operative
+ * one and the task-redelivery ceiling cannot mask the outcome.
+ */
+@PostgresqlIntegrationTest
+class VirtualNegotiationRetryEndToEndTest {
+
+    static final String PROVIDER_CONTEXT = "provider";
+    static final String CONSUMER_CONTEXT = "consumer";
+    static final String PROVIDER_ID = "provider-id";
+    static final String CONSUMER_ID = "consumer-id";
+
+    // value of edc.negotiation.send.retry.limit applied to the runtime below
+    static final int NEGOTIATION_SEND_RETRY_LIMIT = 5;
+
+    @Order(0)
+    @RegisterExtension
+    static final OauthServerEndToEndExtension AUTH_SERVER_EXTENSION = OauthServerEndToEndExtension.Builder.newInstance().build();
+
+    @Order(0)
+    @RegisterExtension
+    static final NatsEndToEndExtension NATS_EXTENSION = new NatsEndToEndExtension();
+
+    @Order(0)
+    @RegisterExtension
+    static final PostgresqlEndToEndExtension POSTGRESQL_EXTENSION = new PostgresqlEndToEndExtension();
+
+    @Order(0)
+    @RegisterExtension
+    static final WireMockExtension FAKE_PROVIDER = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    @Order(1)
+    @RegisterExtension
+    static final BeforeAllCallback SETUP = context ->
+            POSTGRESQL_EXTENSION.createDatabase(Runtimes.ControlPlane.NAME.toLowerCase());
+
+    @Order(2)
+    @RegisterExtension
+    static final RuntimeExtension CONTROL_PLANE = ComponentRuntimeExtension.Builder.newInstance()
+            .name(Runtimes.ControlPlane.NAME)
+            .modules(Runtimes.ControlPlane.VIRTUAL_MODULES)
+            .modules(Runtimes.ControlPlane.VIRTUAL_SQL_MODULES)
+            .modules(Runtimes.ControlPlane.VIRTUAL_NATS_MODULES)
+            .modules(Runtimes.ControlPlane.IAM_MOCK)
+            .endpoints(Runtimes.ControlPlane.ENDPOINTS.build())
+            .configurationProvider(VirtualNegotiationRetryEndToEndTest::config)
+            .configurationProvider(VirtualNegotiationRetryEndToEndTest::retryConfig)
+            .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(Runtimes.ControlPlane.NAME.toLowerCase()))
+            .configurationProvider(NATS_EXTENSION::configFor)
+            .configurationProvider(AUTH_SERVER_EXTENSION::getConfig)
+            .paramProvider(ManagementApiClientV5.class, ctx -> ManagementApiClientV5.forContext(ctx, AUTH_SERVER_EXTENSION.getAuthServer()))
+            .paramProvider(Participants.class, VirtualNegotiationRetryEndToEndTest::participants)
+            .build();
+
+    @BeforeAll
+    static void beforeAll(ManagementApiClientV5 connectorClient, Participants participants) {
+        connectorClient.createParticipant(participants.consumer().contextId(), participants.consumer().id(), participants.consumer().config());
+        connectorClient.createParticipant(participants.provider().contextId(), participants.provider().id(), participants.provider().config());
+    }
+
+    private static Config config() {
+        return ConfigFactory.fromMap(Map.of(
+                "edc.iam.oauth2.jwks.url", "https://example.com/jwks",
+                "edc.iam.oauth2.issuer", "test-issuer",
+                "web.http.protocol.virtual", "true",
+                "edc.dataspace.enable.profiles.all", "true"
+        ));
+    }
+
+    private static Config retryConfig() {
+        return ConfigFactory.fromMap(Map.of(
+                // do not retry http requests
+                "edc.core.retry.retries.max", "0",
+                // make the entity stateCount ceiling the operative one (default is 7)...
+                "edc.negotiation.send.retry.limit", String.valueOf(NEGOTIATION_SEND_RETRY_LIMIT),
+                "edc.negotiation.send.retry.base-delay.ms", "100",
+                "edc.negotiation.state-machine.iteration-wait-millis", "50"
+        ));
+    }
+
+    private static Participants participants(ComponentRuntimeContext ctx) {
+        var protocolEndpoint = ctx.getEndpoint("protocol");
+        var signalingEndpoint = ctx.getEndpoint("signaling");
+        return new Participants(
+                new Participants.Participant(PROVIDER_CONTEXT, PROVIDER_ID, protocolEndpoint, signalingEndpoint),
+                new Participants.Participant(CONSUMER_CONTEXT, CONSUMER_ID, protocolEndpoint, signalingEndpoint)
+        );
+    }
+
+    private static String setup(ManagementApiClientV5 connectorClient, Participants.Participant provider) {
+        var policy = new PolicyDto(List.of(new PermissionDto()));
+        var policyDef = new PolicyDefinitionDto(policy);
+        return connectorClient.setupResources(provider.contextId(), new AssetDto(), policyDef, policyDef);
+    }
+
+    @Test
+    void contractNegotiation_shouldTerminate_afterRetryLimit_whenCounterPartyKeepsFailing(ManagementApiClientV5 connectorClient, Participants participants) {
+        // the fake provider answers 503 to every DSP request -> ERROR_RETRY (retryable) on the consumer side
+        FAKE_PROVIDER.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(503).withBody("{}")));
+
+        var consumer = participants.consumer();
+        var provider = participants.provider();
+
+        // set up a real offer on the provider so we have a valid offer to send...
+        var assetId = setup(connectorClient, provider);
+        var dataset = connectorClient.fetchDataset(consumer.contextId(), consumer.profile(), assetId, provider.getProtocolEndpoint(), provider.id());
+        var offer = dataset.offers().stream().findFirst().orElseThrow();
+
+        // ...but direct the negotiation at the failing (503) endpoint so processRequesting keeps failing
+        var negotiationId = connectorClient.initContractNegotiation(consumer.contextId(), consumer.profile(), assetId, offer, FAKE_PROVIDER.baseUrl(), provider.id());
+
+        // the stateCount-based retry limit must eventually drive the negotiation to TERMINATED over NATS
+        connectorClient.waitForContractNegotiationState(consumer.contextId(), negotiationId, ContractNegotiationStates.TERMINATED.name());
+
+        assertThat(connectorClient.getNegotiationError(consumer.contextId(), negotiationId))
+                .contains("Failed to request contract to provider");
+
+        // the request is dispatched once per attempt; RetryProcessor terminates when stateCount (starts at 1 in
+        // REQUESTING) exceeds the limit, so the counter-party is hit exactly (limit + 1) times. The catalog fetch
+        // above targets the real provider, not this stub, so every recorded request is a ContractRequestMessage.
+        FAKE_PROVIDER.verify(NEGOTIATION_SEND_RETRY_LIMIT + 1, anyRequestedFor(anyUrl()));
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

It not necessary to have a custom retry. The processors already handle that via entity state count. I've added only a test for asserting that and repurpose the max-retries only to task not found scenario

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5610 

_Please be sure to take a look at the [contributing guidelines](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/#submitting-a-pull-request) and our [etiquette for pull requests](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/pr-etiquette/)._
