### PR TITLE
fix: conversion of JsonObject to Constraint

### DIFF
--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/to/JsonObjectToConstraintTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/to/JsonObjectToConstraintTransformer.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.connector.controlplane.transform.odrl.to;
 
+import jakarta.json.JsonArray;
 import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
@@ -130,27 +131,11 @@ public class JsonObjectToConstraintTransformer extends AbstractJsonLdTransformer
      * @return the extracted value
      */
     private Object extractComplexValue(JsonValue root) {
-        switch (root.getValueType()) {
-            case ARRAY -> {
-                var array = root.asJsonArray();
-                if (array.size() != 1) {
-                    // not a single element array, return as-is
-                    return array;
-                }
-                // single element array, extract and return it
+        if (root instanceof JsonArray array) {
+            if (array.size() == 1) {
                 return extractComplexValue(array.get(0));
             }
-            case OBJECT -> {
-                var valueProp = root.asJsonObject().get(VALUE);
-                if (valueProp != null) {
-                    // object has a value type, extract and return it
-                    return extractValue(valueProp);
-                }
-            }
-            default -> {
-                // extract the value directly
-                return extractValue(root);
-            }
+            return array.stream().map(this::extractComplexValue).toList();
         }
 
         return extractValue(root);
@@ -161,6 +146,12 @@ public class JsonObjectToConstraintTransformer extends AbstractJsonLdTransformer
      */
     private Object extractValue(JsonValue value) {
         switch (value.getValueType()) {
+            case OBJECT -> {
+                var nestedValue = value.asJsonObject().get(VALUE);
+                if (nestedValue != null) {
+                    return extractValue(nestedValue);
+                }
+            }
             case STRING -> {
                 return ((JsonString) value).getString();
             }
@@ -177,6 +168,7 @@ public class JsonObjectToConstraintTransformer extends AbstractJsonLdTransformer
                 return value;
             }
         }
+        return value;
     }
 
 }

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/to/JsonObjectToAtomicConstraintComplexTypeTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/to/JsonObjectToAtomicConstraintComplexTypeTest.java
@@ -31,6 +31,7 @@ import java.math.BigDecimal;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.CONTEXT;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.VALUE;
@@ -74,11 +75,9 @@ class JsonObjectToAtomicConstraintComplexTypeTest {
                 .extracting(AtomicConstraint::getRightExpression)
                 .asInstanceOf(type(LiteralExpression.class))
                 .extracting(LiteralExpression::getValue)
-                .asInstanceOf(type(JsonArray.class))
+                .asInstanceOf(list(String.class))
                 .satisfies(array -> {
-                    assertThat(array.size()).isEqualTo(2);
-                    assertThat(array.get(0)).asInstanceOf(type(JsonObject.class)).extracting(v -> v.getJsonString(VALUE).getString()).isEqualTo("value1");
-                    assertThat(array.get(1)).asInstanceOf(type(JsonObject.class)).extracting(v -> v.getJsonString(VALUE).getString()).isEqualTo("value2");
+                    assertThat(array).hasSize(2).extracting(String::new).containsExactly("value1", "value2");
                 });
     }
 

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/to/JsonObjectToConstraintTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/odrl/to/JsonObjectToConstraintTransformerTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -95,6 +96,22 @@ class JsonObjectToConstraintTransformerTest {
             assertThat(((LiteralExpression) atomicConstraint.getRightExpression()).getValue()).isEqualTo(right);
         });
         verify(context).transform(id("gteq").build(), Operator.class);
+    }
+
+    @Test
+    void atomicConstraint_rightOperandAsArray() {
+        when(context.transform(any(), eq(Operator.class))).thenReturn(Operator.GEQ);
+        var constraint = jsonFactory.createObjectBuilder()
+                .add(ODRL_LEFT_OPERAND_ATTRIBUTE, jsonFactory.createArrayBuilder().add(id("leftOperand")))
+                .add(ODRL_OPERATOR_ATTRIBUTE, jsonFactory.createArrayBuilder().add(id("gteq")))
+                .add(ODRL_RIGHT_OPERAND_ATTRIBUTE, jsonFactory.createArrayBuilder().add(value("right1")).add(value("right2")))
+                .build();
+
+        var result = transformer.transform(TestJsonLd.expand(constraint), context);
+
+        assertThat(result).isNotNull().asInstanceOf(type(AtomicConstraint.class)).satisfies(atomicConstraint -> {
+            assertThat(((LiteralExpression) atomicConstraint.getRightExpression()).getValue()).isEqualTo(List.of("right1", "right2"));
+        });
     }
 
     @Test

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/PolicyDefinitionApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/PolicyDefinitionApiV5EndToEndTest.java
@@ -57,6 +57,7 @@ import static org.eclipse.edc.test.e2e.managementapi.v5.TestFunction.jsonLdConte
 import static org.eclipse.edc.test.e2e.managementapi.v5.TestFunction.participantContext;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.matchesRegex;
@@ -160,7 +161,9 @@ public class PolicyDefinitionApiV5EndToEndTest {
                     .contentType(JSON)
                     .body(ID, is(id))
                     .body(CONTEXT, contains(jsonLdContextArray()))
-                    .body("policy.permission[0].constraint[0].rightOperand", hasSize(2));
+                    .body("policy.permission[0].constraint[0].rightOperand", hasSize(2))
+                    .body("policy.permission[0].constraint[0].rightOperand", hasItem("value"))
+                    .body("policy.permission[0].constraint[0].rightOperand", hasItem("another"));
         }
 
         @Test


### PR DESCRIPTION
## What this PR changes/adds

Add missing unwrapping of JsonValue types also when the input is a JsonArray.

## Why it does that

Avoid weird serialized types when Constraing.rightOperand is an array

## Further notes
**THIS IS A BREAKING CHANGE**: until 0.18.0, when a `rightOperand` of a `Constraint` type in a `PolicyDefinition` contained a `List`, it would got stored into database as something like:
```json
    "rightOperand": {
        "value":[{
            "@value":{"valueType":"STRING","chars":"item1","string":"item2"}
        },{
            "@value":{"valueType":"STRING","chars":"item2","string":"item2"}
        }]   
    }
``` 

this because the incoming `JsonArray` from the API's json-ld was not unwrapped and the type was stored as it was.
So, if in your control-plane do you have PolicyDefinitions with a multi-value `rightOperand`, you should migrate every one of those into:
```json
    "rightOperand": {
        "value":["item1", "item2"]
    }
```

It could become tricky to write an automatic script to do that, so our advice would be to update the affected policies with an API call passing the same bodies that were used to create them.

Please also note that if you adapted your policy functions to workaround this bug, you'll need to update them as well.

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5792 
Related to #5934 

_Please be sure to take a look at the [contributing guidelines](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/#submitting-a-pull-request) and our [etiquette for pull requests](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/pr-etiquette/)._
