### PR TITLE
fix: race condition in participant context config merge

### DIFF
--- a/core/common/lib/core-lib/src/main/java/org/eclipse/edc/sql/statement/SqlExecuteStatement.java
+++ b/core/common/lib/core-lib/src/main/java/org/eclipse/edc/sql/statement/SqlExecuteStatement.java
@@ -105,6 +105,22 @@ public class SqlExecuteStatement {
     }
 
     /**
+     * Gives a SQL insert statement that does nothing if a row with the same id already exists, based on the
+     * "ON CONFLICT" semantic.
+     *
+     * @param tableName the table name.
+     * @param idColumn  the id column.
+     * @return sql insert statement.
+     */
+    public String insertIntoIgnoreConflict(String tableName, String idColumn) {
+        if (columnEntries.isEmpty()) {
+            throw new IllegalArgumentException(format("Cannot create INSERT statement on %s because no columns are registered", tableName));
+        }
+
+        return insertStatement(tableName) + " ON CONFLICT (" + idColumn + ") DO NOTHING;";
+    }
+
+    /**
      * Gives a SQL update statement.
      *
      * @param tableName   the table name.

--- a/core/common/lib/core-lib/src/test/java/org/eclipse/edc/sql/statement/SqlExecuteStatementTest.java
+++ b/core/common/lib/core-lib/src/test/java/org/eclipse/edc/sql/statement/SqlExecuteStatementTest.java
@@ -106,6 +106,28 @@ class SqlExecuteStatementTest {
     }
 
     @Nested
+    class InsertIgnoreConflict {
+
+        @Test
+        void shouldThrowException_whenNoColumnSpecified() {
+            assertThatThrownBy(() -> SqlExecuteStatement.newInstance("::json").insertIntoIgnoreConflict("table_name", "id"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void shouldReturnStatement() {
+            var statement = SqlExecuteStatement.newInstance("::json")
+                    .column("id")
+                    .column("column_name")
+                    .jsonColumn("json_column_name")
+                    .insertIntoIgnoreConflict("table_name", "id");
+
+            assertThat(statement).isEqualToIgnoringCase("insert into table_name (id, column_name, json_column_name)" +
+                    " values (?, ?, ?::json) on conflict (id) do nothing;");
+        }
+    }
+
+    @Nested
     class Upsert {
 
         @Test

--- a/core/common/participant-context-config-core/src/main/java/org/eclipse/edc/participantcontext/config/defaults/store/InMemoryParticipantContextConfigStore.java
+++ b/core/common/participant-context-config-core/src/main/java/org/eclipse/edc/participantcontext/config/defaults/store/InMemoryParticipantContextConfigStore.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.participantcontext.spi.config.model.ParticipantContextCon
 import org.eclipse.edc.participantcontext.spi.config.store.ParticipantContextConfigStore;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -27,11 +28,27 @@ public class InMemoryParticipantContextConfigStore implements ParticipantContext
 
     @Override
     public void save(ParticipantContextConfiguration config) {
-        store.put(config.getParticipantContextId(), config);
+        store.put(config.getParticipantContextId(), copy(config));
+    }
+
+    @Override
+    public ParticipantContextConfiguration merge(ParticipantContextConfiguration patch) {
+        // compute() performs the remapping atomically, so concurrent merges cannot lose entries
+        return store.compute(patch.getParticipantContextId(), (id, existing) -> patch.mergeOnto(existing));
     }
 
     @Override
     public @Nullable ParticipantContextConfiguration get(String participantContextId) {
         return store.get(participantContextId);
+    }
+
+    /**
+     * Copies the entry maps so that callers cannot mutate stored state through the reference they passed in.
+     */
+    private ParticipantContextConfiguration copy(ParticipantContextConfiguration config) {
+        return config.toBuilder()
+                .entries(new HashMap<>(config.getEntries()))
+                .privateEntries(new HashMap<>(config.getPrivateEntries()))
+                .build();
     }
 }

--- a/core/common/participant-context-config-core/src/main/java/org/eclipse/edc/participantcontext/config/service/ParticipantContextConfigServiceImpl.java
+++ b/core/common/participant-context-config-core/src/main/java/org/eclipse/edc/participantcontext/config/service/ParticipantContextConfigServiceImpl.java
@@ -58,44 +58,21 @@ public class ParticipantContextConfigServiceImpl implements ParticipantContextCo
     @Override
     public ServiceResult<Void> merge(ParticipantContextConfiguration config) {
         return transactionContext.execute(() -> {
-            var existing = configStore.get(config.getParticipantContextId());
+            var now = clock.millis();
+            // the patch is handed to the store as-is: applying it has to happen atomically inside the store, otherwise
+            // concurrent merges would read the same base and clobber each other's entries
             return ServiceResult.from(encryptEntries(config))
-                    .map(encryptedPatch -> {
-                        var base = existing != null
-                                ? existing
-                                : ParticipantContextConfiguration.Builder.newInstance()
-                                    .participantContextId(config.getParticipantContextId())
-                                    .createdAt(clock.millis())
-                                    .build();
-                        return base.toBuilder()
-                                .entries(mergePatch(base.getEntries(), encryptedPatch.getEntries()))
-                                .privateEntries(mergePatch(base.getPrivateEntries(), encryptedPatch.getPrivateEntries()))
-                                .lastModified(clock.millis())
-                                .build();
-                    })
-                    .onSuccess(configStore::save)
+                    .map(encryptedPatch -> encryptedPatch.toBuilder()
+                            .createdAt(now) // only takes effect if no configuration exists yet
+                            .lastModified(now)
+                            .build())
+                    .onSuccess(configStore::merge)
                     .mapEmpty();
         });
     }
 
     private static boolean hasNullValue(Map<String, String> map) {
         return map.values().stream().anyMatch(value -> value == null);
-    }
-
-    /**
-     * Applies a JSON Merge Patch (RFC 7396) of {@code patch} onto {@code base}: a null value removes the key, any
-     * other value adds or overwrites it.
-     */
-    private static Map<String, String> mergePatch(Map<String, String> base, Map<String, String> patch) {
-        var merged = new HashMap<>(base);
-        patch.forEach((key, value) -> {
-            if (value == null) {
-                merged.remove(key);
-            } else {
-                merged.put(key, value);
-            }
-        });
-        return merged;
     }
 
     private Result<ParticipantContextConfiguration> encryptEntries(ParticipantContextConfiguration config) {

--- a/core/common/participant-context-config-core/src/test/java/org/eclipse/edc/participantcontext/config/defaults/store/InMemoryParticipantContextConfigStoreTest.java
+++ b/core/common/participant-context-config-core/src/test/java/org/eclipse/edc/participantcontext/config/defaults/store/InMemoryParticipantContextConfigStoreTest.java
@@ -14,15 +14,57 @@
 
 package org.eclipse.edc.participantcontext.config.defaults.store;
 
+import org.eclipse.edc.participantcontext.spi.config.model.ParticipantContextConfiguration;
 import org.eclipse.edc.participantcontext.spi.config.store.ParticipantContextConfigStore;
 import org.eclipse.edc.participantcontext.spi.config.store.ParticipantContextConfigStoreTestBase;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class InMemoryParticipantContextConfigStoreTest extends ParticipantContextConfigStoreTestBase {
-    
+
+    private static final int THREADS = 8;
+    private static final int MERGES_PER_THREAD = 50;
+
     private final InMemoryParticipantContextConfigStore store = new InMemoryParticipantContextConfigStore();
 
     @Override
     protected ParticipantContextConfigStore getStore() {
         return store;
+    }
+
+    @Test
+    void merge_concurrently_shouldNotLoseEntries() throws Exception {
+        var barrier = new CyclicBarrier(THREADS);
+        var executor = Executors.newFixedThreadPool(THREADS);
+
+        try {
+            var tasks = IntStream.range(0, THREADS).mapToObj(thread -> (Callable<Void>) () -> {
+                barrier.await(30, TimeUnit.SECONDS);
+                for (var i = 0; i < MERGES_PER_THREAD; i++) {
+                    store.merge(ParticipantContextConfiguration.Builder.newInstance()
+                            .participantContextId("participant1")
+                            .entries(Map.of("t%d-%d".formatted(thread, i), "value"))
+                            .build());
+                }
+                return null;
+            }).toList();
+
+            for (var future : executor.invokeAll(tasks, 60, TimeUnit.SECONDS)) {
+                future.get();
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(store.get("participant1")).isNotNull()
+                .satisfies(cfg -> assertThat(cfg.getEntries()).hasSize(THREADS * MERGES_PER_THREAD));
     }
 }

--- a/core/common/participant-context-config-core/src/test/java/org/eclipse/edc/participantcontext/config/service/ParticipantContextConfigServiceImplTest.java
+++ b/core/common/participant-context-config-core/src/test/java/org/eclipse/edc/participantcontext/config/service/ParticipantContextConfigServiceImplTest.java
@@ -70,17 +70,8 @@ public class ParticipantContextConfigServiceImplTest {
     }
 
     @Test
-    void merge() {
+    void merge_shouldDelegateEncryptedPatchToStore() {
         when(registry.encrypt(anyString(), anyString())).then(a -> Result.success("enc(" + a.getArgument(1) + ")"));
-
-        var existing = ParticipantContextConfiguration.Builder.newInstance()
-                .participantContextId("participantContext")
-                .createdAt(1000)
-                .lastModified(1000)
-                .entries(new HashMap<>(Map.of("key", "value", "keep", "kept")))
-                .privateEntries(new HashMap<>(Map.of("secret", "enc(existing)")))
-                .build();
-        when(store.get("participantContext")).thenReturn(existing);
 
         var patch = ParticipantContextConfiguration.Builder.newInstance()
                 .participantContextId("participantContext")
@@ -91,51 +82,35 @@ public class ParticipantContextConfigServiceImplTest {
         var result = service.merge(patch);
         assertThat(result).isSucceeded();
 
-        verify(store).save(argThat(saved ->
-                saved.getParticipantContextId().equals("participantContext") &&
-                        saved.getCreatedAt() == 1000 &&
-                        saved.getLastModified() == 5000 &&
-                        saved.getEntries().equals(Map.of("key", "updated", "keep", "kept", "new", "added")) &&
-                        saved.getPrivateEntries().equals(Map.of("secret", "enc(existing)", "newSecret", "enc(plain)"))));
-        // only the patch's private entry is encrypted, existing ones are left untouched
+        // the patch must reach the store unmerged: applying it is the store's job, so that it can do so atomically
+        verify(store).merge(argThat(applied ->
+                applied.getParticipantContextId().equals("participantContext") &&
+                        applied.getCreatedAt() == 5000 &&
+                        applied.getLastModified() == 5000 &&
+                        applied.getEntries().equals(Map.of("key", "updated", "new", "added")) &&
+                        applied.getPrivateEntries().equals(Map.of("newSecret", "enc(plain)"))));
         verify(registry).encrypt(anyString(), anyString());
     }
 
     @Test
-    void merge_whenNotFound_shouldCreate() {
+    void merge_shouldNotReadTheStore() {
         when(registry.encrypt(anyString(), anyString())).then(a -> Result.success("enc(" + a.getArgument(1) + ")"));
-        when(store.get("participantContext")).thenReturn(null);
 
         var patch = ParticipantContextConfiguration.Builder.newInstance()
                 .participantContextId("participantContext")
                 .entries(Map.of("key", "value"))
-                .privateEntries(Map.of("secret", "plain"))
                 .build();
 
-        var result = service.merge(patch);
-        assertThat(result).isSucceeded();
+        assertThat(service.merge(patch)).isSucceeded();
 
-        verify(store).save(argThat(saved ->
-                saved.getParticipantContextId().equals("participantContext") &&
-                        saved.getCreatedAt() == 5000 &&
-                        saved.getLastModified() == 5000 &&
-                        saved.getEntries().equals(Map.of("key", "value")) &&
-                        saved.getPrivateEntries().equals(Map.of("secret", "enc(plain)"))));
-        verify(registry).encrypt(anyString(), anyString());
+        // a read-modify-write here would race with concurrent merges and lose entries
+        verify(store, never()).get(any());
+        verify(store, never()).save(any());
     }
 
     @Test
-    void merge_shouldRemoveEntry_whenValueIsNull() {
+    void merge_shouldNotEncryptNullValues() {
         when(registry.encrypt(anyString(), anyString())).then(a -> Result.success("enc(" + a.getArgument(1) + ")"));
-
-        var existing = ParticipantContextConfiguration.Builder.newInstance()
-                .participantContextId("participantContext")
-                .createdAt(1000)
-                .lastModified(1000)
-                .entries(new HashMap<>(Map.of("key", "value", "keep", "kept")))
-                .privateEntries(new HashMap<>(Map.of("secret", "enc(existing)", "keepSecret", "enc(kept)")))
-                .build();
-        when(store.get("participantContext")).thenReturn(existing);
 
         var entries = new HashMap<String, String>();
         entries.put("key", null);
@@ -150,34 +125,24 @@ public class ParticipantContextConfigServiceImplTest {
         var result = service.merge(patch);
         assertThat(result).isSucceeded();
 
-        verify(store).save(argThat(saved ->
-                saved.getEntries().equals(Map.of("keep", "kept")) &&
-                        saved.getPrivateEntries().equals(Map.of("keepSecret", "enc(kept)"))));
-        // null values are removal signals and must never be encrypted
+        // null values are removal signals and must reach the store verbatim, never encrypted
+        verify(store).merge(argThat(applied ->
+                applied.getEntries().containsKey("key") && applied.getEntries().get("key") == null &&
+                        applied.getPrivateEntries().containsKey("secret") && applied.getPrivateEntries().get("secret") == null));
         verify(registry, never()).encrypt(anyString(), any());
     }
 
     @Test
-    void merge_whenKeyAbsent_nullIsNoop() {
-        when(registry.encrypt(anyString(), anyString())).then(a -> Result.success("enc(" + a.getArgument(1) + ")"));
+    void merge_shouldFail_whenEncryptionFails() {
+        when(registry.encrypt(anyString(), anyString())).thenReturn(Result.failure("boom"));
 
-        var existing = ParticipantContextConfiguration.Builder.newInstance()
-                .participantContextId("participantContext")
-                .entries(new HashMap<>(Map.of("keep", "kept")))
-                .build();
-        when(store.get("participantContext")).thenReturn(existing);
-
-        var entries = new HashMap<String, String>();
-        entries.put("missing", null);
         var patch = ParticipantContextConfiguration.Builder.newInstance()
                 .participantContextId("participantContext")
-                .entries(entries)
+                .privateEntries(Map.of("secret", "plain"))
                 .build();
 
-        var result = service.merge(patch);
-        assertThat(result).isSucceeded();
-
-        verify(store).save(argThat(saved -> saved.getEntries().equals(Map.of("keep", "kept"))));
+        assertThat(service.merge(patch)).isFailed().detail().contains("Failed to encrypt entries");
+        verify(store, never()).merge(any());
     }
 
     @Test

--- a/core/common/participant-context-connector-classic-core/src/main/java/org/eclipse/edc/participantcontext/connector/config/store/SingleParticipantContextConfigStore.java
+++ b/core/common/participant-context-connector-classic-core/src/main/java/org/eclipse/edc/participantcontext/connector/config/store/SingleParticipantContextConfigStore.java
@@ -32,6 +32,11 @@ public class SingleParticipantContextConfigStore implements ParticipantContextCo
     }
 
     @Override
+    public ParticipantContextConfiguration merge(ParticipantContextConfiguration patch) {
+        throw new UnsupportedOperationException("SingleParticipantContextConfigStore is read-only");
+    }
+
+    @Override
     public @Nullable ParticipantContextConfiguration get(String participantContextId) {
         if (this.config.getParticipantContextId().equals(participantContextId)) {
             return config;

--- a/core/common/participant-context-connector-classic-core/src/test/java/org/eclipse/edc/participantcontext/config/store/SingleParticipantContextConfigStoreTest.java
+++ b/core/common/participant-context-connector-classic-core/src/test/java/org/eclipse/edc/participantcontext/config/store/SingleParticipantContextConfigStoreTest.java
@@ -55,6 +55,55 @@ public class SingleParticipantContextConfigStoreTest extends ParticipantContextC
         super.update();
     }
 
+    // SingleParticipantContextConfigStore is read-only
+    @Override
+    @Disabled
+    protected void merge_whenNotExisting_shouldCreate() {
+        super.merge_whenNotExisting_shouldCreate();
+    }
+
+    // SingleParticipantContextConfigStore is read-only
+    @Override
+    @Disabled
+    protected void merge_shouldAddAndOverwriteEntries() {
+        super.merge_shouldAddAndOverwriteEntries();
+    }
+
+    // SingleParticipantContextConfigStore is read-only
+    @Override
+    @Disabled
+    protected void merge_shouldRemoveEntry_whenValueIsNull() {
+        super.merge_shouldRemoveEntry_whenValueIsNull();
+    }
+
+    // SingleParticipantContextConfigStore is read-only
+    @Override
+    @Disabled
+    protected void merge_whenKeyAbsent_nullIsNoop() {
+        super.merge_whenKeyAbsent_nullIsNoop();
+    }
+
+    // SingleParticipantContextConfigStore is read-only
+    @Override
+    @Disabled
+    protected void merge_shouldNotTouchPrivateEntries_whenPatchingEntriesOnly() {
+        super.merge_shouldNotTouchPrivateEntries_whenPatchingEntriesOnly();
+    }
+
+    // SingleParticipantContextConfigStore is read-only
+    @Override
+    @Disabled
+    protected void merge_shouldPreserveCreatedAt_andUpdateLastModified() {
+        super.merge_shouldPreserveCreatedAt_andUpdateLastModified();
+    }
+
+    // SingleParticipantContextConfigStore is read-only
+    @Override
+    @Disabled
+    protected void merge_shouldReturnMergedConfiguration() {
+        super.merge_shouldReturnMergedConfiguration();
+    }
+
     @Test
     void get() {
         assertThat(getStore().get(PARTICIPANT_CONTEXT_ID))
@@ -68,6 +117,13 @@ public class SingleParticipantContextConfigStoreTest extends ParticipantContextC
     void save_unsupported() {
 
         assertThatThrownBy(() -> getStore().save(config))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void merge_unsupported() {
+
+        assertThatThrownBy(() -> getStore().merge(config))
                 .isInstanceOf(UnsupportedOperationException.class);
     }
 

--- a/extensions/control-plane/store/sql/participantcontext-config-store-sql/build.gradle.kts
+++ b/extensions/control-plane/store/sql/participantcontext-config-store-sql/build.gradle.kts
@@ -25,5 +25,8 @@ dependencies {
     testImplementation(project(":core:common:junit"))
     testImplementation(testFixtures(project(":spi:control-plane-spi")))
     testImplementation(testFixtures(project(":extensions:common:sql:sql-test-fixtures")))
+    // needed by SqlParticipantContextConfigStoreConcurrencyTest: the standard test fixture wires a
+    // NoopTransactionContext over autocommit connections, under which SELECT ... FOR UPDATE holds no lock
+    testImplementation(project(":extensions:common:transaction:transaction-local"))
     testImplementation(libs.postgres)
 }

--- a/extensions/control-plane/store/sql/participantcontext-config-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/config/BaseSqlDialectStatementsConfig.java
+++ b/extensions/control-plane/store/sql/participantcontext-config-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/config/BaseSqlDialectStatementsConfig.java
@@ -37,4 +37,29 @@ public class BaseSqlDialectStatementsConfig implements ParticipantContextConfigS
 
     }
 
+    @Override
+    public String getInsertIfAbsentTemplate() {
+        return executeStatement()
+                .column(getIdColumn())
+                .column(getCreateTimestampColumn())
+                .column(getLastModifiedTimestampColumn())
+                .jsonColumn(getEntriesColumn())
+                .jsonColumn(getPrivateEntriesColumn())
+                .insertIntoIgnoreConflict(getParticipantContextConfigTable(), getIdColumn());
+    }
+
+    @Override
+    public String getFindByIdForUpdateTemplate() {
+        return format("SELECT * FROM %s WHERE %s = ? FOR UPDATE", getParticipantContextConfigTable(), getIdColumn());
+    }
+
+    @Override
+    public String getUpdateEntriesTemplate() {
+        return executeStatement()
+                .column(getLastModifiedTimestampColumn())
+                .jsonColumn(getEntriesColumn())
+                .jsonColumn(getPrivateEntriesColumn())
+                .update(getParticipantContextConfigTable(), getIdColumn());
+    }
+
 }

--- a/extensions/control-plane/store/sql/participantcontext-config-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/config/ParticipantContextConfigStoreStatements.java
+++ b/extensions/control-plane/store/sql/participantcontext-config-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/config/ParticipantContextConfigStoreStatements.java
@@ -50,4 +50,21 @@ public interface ParticipantContextConfigStoreStatements extends SqlStatements {
 
     String getFindByIdTemplate();
 
+    /**
+     * Creates an empty configuration row if none exists yet, so that it can subsequently be locked for update.
+     */
+    String getInsertIfAbsentTemplate();
+
+    /**
+     * Selects a configuration by id, taking an exclusive row lock that is held until the enclosing transaction
+     * completes. Must be executed within a transaction.
+     */
+    String getFindByIdForUpdateTemplate();
+
+    /**
+     * Updates the entries and the last-modified timestamp of an existing configuration. Leaves the creation
+     * timestamp untouched.
+     */
+    String getUpdateEntriesTemplate();
+
 }

--- a/extensions/control-plane/store/sql/participantcontext-config-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/config/SqlParticipantContextConfigStore.java
+++ b/extensions/control-plane/store/sql/participantcontext-config-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/config/SqlParticipantContextConfigStore.java
@@ -30,9 +30,16 @@ import java.util.Map;
 
 
 /**
- * SQL-based {@link Config} store intended for use with PostgreSQL
+ * SQL-based {@link Config} store intended for use with PostgreSQL.
+ * <p>
+ * Note that {@link #merge(ParticipantContextConfiguration)} guards the read-modify-write with a {@code SELECT ... FOR
+ * UPDATE} row lock, which is only held for the duration of the enclosing transaction. It therefore requires a real
+ * {@link TransactionContext}: under a {@code NoopTransactionContext} with a non-enlisted {@code DataSource} every
+ * statement auto-commits, the lock is released immediately, and concurrent merges can lose entries.
  */
 public class SqlParticipantContextConfigStore extends AbstractSqlStore implements ParticipantContextConfigStore {
+
+    private static final String EMPTY_JSON_OBJECT = "{}";
 
     private final ParticipantContextConfigStoreStatements statements;
 
@@ -60,6 +67,46 @@ public class SqlParticipantContextConfigStore extends AbstractSqlStore implement
                         toJson(config.getPrivateEntries())
                 );
 
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
+    @Override
+    public ParticipantContextConfiguration merge(ParticipantContextConfiguration patch) {
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                // materialize an empty row if none exists yet, so that the subsequent lock always has a row to take
+                queryExecutor.execute(connection, statements.getInsertIfAbsentTemplate(),
+                        patch.getParticipantContextId(),
+                        patch.getCreatedAt(),
+                        patch.getLastModified(),
+                        EMPTY_JSON_OBJECT,
+                        EMPTY_JSON_OBJECT
+                );
+
+                // take an exclusive row lock, held until the enclosing transaction completes. Under READ COMMITTED a
+                // blocked reader re-reads the latest committed row once the lock is granted, which is what makes the
+                // read-modify-write below safe against concurrent merges.
+                var existing = queryExecutor.single(connection, false, this::mapResultSet,
+                        statements.getFindByIdForUpdateTemplate(), patch.getParticipantContextId());
+
+                if (existing == null) {
+                    throw new EdcPersistenceException("Configuration for participant context '%s' vanished while merging"
+                            .formatted(patch.getParticipantContextId()));
+                }
+
+                var merged = patch.mergeOnto(existing);
+
+                queryExecutor.execute(connection, statements.getUpdateEntriesTemplate(),
+                        merged.getLastModified(),
+                        toJson(merged.getEntries()),
+                        toJson(merged.getPrivateEntries()),
+                        merged.getParticipantContextId()
+                );
+
+                return merged;
             } catch (SQLException e) {
                 throw new EdcPersistenceException(e);
             }

--- a/extensions/control-plane/store/sql/participantcontext-config-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/participantcontext/config/SqlParticipantContextConfigStoreConcurrencyTest.java
+++ b/extensions/control-plane/store/sql/participantcontext-config-store-sql/src/test/java/org/eclipse/edc/connector/store/sql/participantcontext/config/SqlParticipantContextConfigStoreConcurrencyTest.java
@@ -1,0 +1,171 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.connector.store.sql.participantcontext.config;
+
+import org.eclipse.edc.connector.store.sql.participantcontext.config.schema.postgres.PostgresDialectStatementsConfig;
+import org.eclipse.edc.json.JacksonTypeManager;
+import org.eclipse.edc.junit.annotations.ComponentTest;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
+import org.eclipse.edc.participantcontext.spi.config.model.ParticipantContextConfiguration;
+import org.eclipse.edc.spi.monitor.ConsoleMonitor;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
+import org.eclipse.edc.transaction.local.LocalDataSourceRegistry;
+import org.eclipse.edc.transaction.local.LocalTransactionContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that concurrent {@link SqlParticipantContextConfigStore#merge} invocations do not lose entries.
+ * <p>
+ * This cannot live in {@code ParticipantContextConfigStoreTestBase}, nor reuse the transaction context of
+ * {@link PostgresqlStoreSetupExtension}: that fixture wires a {@code NoopTransactionContext} over a
+ * {@code DefaultDataSourceRegistry}, so every connection auto-commits and the {@code SELECT ... FOR UPDATE} row lock
+ * would be released at statement end. The production pair is assembled here instead.
+ */
+@ComponentTest
+@ExtendWith(PostgresqlStoreSetupExtension.class)
+class SqlParticipantContextConfigStoreConcurrencyTest {
+
+    private static final String PARTICIPANT_CONTEXT_ID = "participant1";
+    private static final int THREADS = 8;
+    private static final int MERGES_PER_THREAD = 50;
+
+    private final ParticipantContextConfigStoreStatements statements = new PostgresDialectStatementsConfig();
+
+    private LocalTransactionContext transactionContext;
+    private SqlParticipantContextConfigStore store;
+
+    @BeforeEach
+    void setup(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) {
+        transactionContext = new LocalTransactionContext(new ConsoleMonitor());
+        var registry = new LocalDataSourceRegistry(transactionContext);
+        // DefaultDataSourceRegistry.resolve() hands back the raw DataSource, which the local registry then enlists
+        registry.register(extension.getDatasourceName(), extension.getDataSourceRegistry().resolve(extension.getDatasourceName()));
+
+        store = new SqlParticipantContextConfigStore(registry, extension.getDatasourceName(), transactionContext,
+                new JacksonTypeManager().getMapper(), queryExecutor, statements);
+
+        extension.runQuery(TestUtils.getResourceFileContentAsString("participant-context-config-schema.sql"));
+    }
+
+    @AfterEach
+    void tearDown(PostgresqlStoreSetupExtension extension) {
+        extension.runQuery("DROP TABLE " + statements.getParticipantContextConfigTable() + " CASCADE");
+    }
+
+    @Test
+    void merge_concurrently_shouldNotLoseEntries() throws Exception {
+        // a barrier placed between the read and the write would deadlock the fixed implementation, since the losing
+        // thread blocks inside the SELECT ... FOR UPDATE. Synchronise the start instead and rely on volume.
+        var barrier = new CyclicBarrier(THREADS);
+        var executor = Executors.newFixedThreadPool(THREADS);
+
+        try {
+            var tasks = IntStream.range(0, THREADS).mapToObj(thread -> (Callable<Void>) () -> {
+                barrier.await(30, TimeUnit.SECONDS);
+                for (var i = 0; i < MERGES_PER_THREAD; i++) {
+                    var key = "t%d-%d".formatted(thread, i);
+                    transactionContext.execute(() -> store.merge(patch(Map.of(key, "value"))));
+                }
+                return null;
+            }).toList();
+
+            for (var future : executor.invokeAll(tasks, 120, TimeUnit.SECONDS)) {
+                future.get();
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        var expectedKeys = IntStream.range(0, THREADS)
+                .boxed()
+                .flatMap(t -> IntStream.range(0, MERGES_PER_THREAD).mapToObj(i -> "t%d-%d".formatted(t, i)))
+                .toList();
+
+        assertThat(transactionContext.execute(() -> store.get(PARTICIPANT_CONTEXT_ID)))
+                .isNotNull()
+                .satisfies(cfg -> assertThat(cfg.getEntries())
+                        .hasSize(THREADS * MERGES_PER_THREAD)
+                        .containsKeys(expectedKeys.toArray(String[]::new)));
+    }
+
+    @Test
+    void merge_shouldBlockConcurrentMerge_untilTransactionCompletes() throws Exception {
+        var merged = new CountDownLatch(1);
+        var release = new CountDownLatch(1);
+        var secondCompleted = new CountDownLatch(1);
+        var executor = Executors.newFixedThreadPool(2);
+
+        try {
+            executor.submit(() -> transactionContext.execute(() -> {
+                store.merge(patch(Map.of("first", "value")));
+                merged.countDown();
+                awaitUninterruptibly(release);
+            }));
+
+            assertThat(merged.await(30, TimeUnit.SECONDS)).isTrue();
+
+            executor.submit(() -> {
+                transactionContext.execute(() -> store.merge(patch(Map.of("second", "value"))));
+                secondCompleted.countDown();
+            });
+
+            // the second merge must be waiting on the row lock held by the still-open first transaction
+            assertThat(secondCompleted.await(1, TimeUnit.SECONDS)).isFalse();
+
+            release.countDown();
+            assertThat(secondCompleted.await(30, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            release.countDown();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(30, TimeUnit.SECONDS)).isTrue();
+        }
+
+        assertThat(transactionContext.execute(() -> store.get(PARTICIPANT_CONTEXT_ID)))
+                .isNotNull()
+                .satisfies(cfg -> assertThat(cfg.getEntries()).containsOnlyKeys("first", "second"));
+    }
+
+    private ParticipantContextConfiguration patch(Map<String, String> entries) {
+        return ParticipantContextConfiguration.Builder.newInstance()
+                .participantContextId(PARTICIPANT_CONTEXT_ID)
+                .entries(entries)
+                .build();
+    }
+
+    private void awaitUninterruptibly(CountDownLatch latch) {
+        try {
+            if (!latch.await(30, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("timed out waiting for latch");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/spi/control-plane-spi/src/main/java/org/eclipse/edc/participantcontext/spi/config/model/ParticipantContextConfiguration.java
+++ b/spi/control-plane-spi/src/main/java/org/eclipse/edc/participantcontext/spi/config/model/ParticipantContextConfiguration.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.participantcontext.spi.config.model;
 
 import org.eclipse.edc.participantcontext.spi.types.ParticipantResource;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Clock;
 import java.util.HashMap;
@@ -60,6 +61,40 @@ public class ParticipantContextConfiguration implements ParticipantResource {
 
     public long getLastModified() {
         return lastModified;
+    }
+
+    /**
+     * Applies this configuration as a JSON Merge Patch (RFC 7396) on top of {@code base}, returning a new instance.
+     * A {@code null} entry value removes the key, any other value adds or overwrites it.
+     * <p>
+     * The result keeps {@code base}'s creation timestamp when {@code base} is non-null, and always takes this
+     * instance's {@code lastModified}. The returned instance owns fresh entry maps, so it never aliases the maps
+     * of either input.
+     *
+     * @param base the configuration to patch, or null if none exists yet
+     * @return the merged configuration
+     */
+    public ParticipantContextConfiguration mergeOnto(@Nullable ParticipantContextConfiguration base) {
+        return Builder.newInstance()
+                .participantContextId(participantContextId)
+                .clock(clock)
+                .createdAt(base != null ? base.getCreatedAt() : createdAt)
+                .lastModified(lastModified)
+                .entries(mergePatch(base != null ? base.getEntries() : Map.of(), entries))
+                .privateEntries(mergePatch(base != null ? base.getPrivateEntries() : Map.of(), privateEntries))
+                .build();
+    }
+
+    private static Map<String, String> mergePatch(Map<String, String> base, Map<String, String> patch) {
+        var merged = new HashMap<>(base);
+        patch.forEach((key, value) -> {
+            if (value == null) {
+                merged.remove(key);
+            } else {
+                merged.put(key, value);
+            }
+        });
+        return merged;
     }
 
     public Builder toBuilder() {

--- a/spi/control-plane-spi/src/main/java/org/eclipse/edc/participantcontext/spi/config/store/ParticipantContextConfigStore.java
+++ b/spi/control-plane-spi/src/main/java/org/eclipse/edc/participantcontext/spi/config/store/ParticipantContextConfigStore.java
@@ -30,6 +30,23 @@ public interface ParticipantContextConfigStore {
     void save(ParticipantContextConfiguration config);
 
     /**
+     * Atomically applies a JSON Merge Patch (RFC 7396) to the configuration of a participant context: an entry with a
+     * {@code null} value removes the key, any other value adds or overwrites it. If no configuration exists yet, one is
+     * created from the patch, using the patch's {@code createdAt} timestamp.
+     * <p>
+     * Implementations MUST guarantee that the read-modify-write is atomic with respect to concurrent {@link #merge} and
+     * {@link #save} invocations, including from other runtime instances sharing the same backing store. Persistent
+     * implementations typically rely on the ambient {@link org.eclipse.edc.transaction.spi.TransactionContext} to hold
+     * row locks until commit, so invoking this method outside a transactional context does not guarantee atomicity.
+     * <p>
+     * Values are stored verbatim: any encryption of private entries must have been applied by the caller beforehand.
+     *
+     * @param patch the merge patch to apply, its participant context id identifies the target configuration
+     * @return the resulting configuration after the patch has been applied
+     */
+    ParticipantContextConfiguration merge(ParticipantContextConfiguration patch);
+
+    /**
      * Retrieves the configuration for a given participant context.
      *
      * @param participantContextId the participant context identifier

--- a/spi/control-plane-spi/src/test/java/org/eclipse/edc/participantcontext/spi/config/model/ParticipantContextConfigurationTest.java
+++ b/spi/control-plane-spi/src/test/java/org/eclipse/edc/participantcontext/spi/config/model/ParticipantContextConfigurationTest.java
@@ -1,0 +1,124 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.participantcontext.spi.config.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ParticipantContextConfigurationTest {
+
+    @Test
+    void mergeOnto_shouldAddAndOverwriteEntries() {
+        var base = config(Map.of("a", "1", "b", "2"), Map.of("s1", "x"), 1000, 1000);
+        var patch = config(Map.of("b", "9", "c", "3"), Map.of("s2", "y"), 4000, 5000);
+
+        var merged = patch.mergeOnto(base);
+
+        assertThat(merged.getEntries()).containsExactlyInAnyOrderEntriesOf(Map.of("a", "1", "b", "9", "c", "3"));
+        assertThat(merged.getPrivateEntries()).containsExactlyInAnyOrderEntriesOf(Map.of("s1", "x", "s2", "y"));
+    }
+
+    @Test
+    void mergeOnto_shouldRemoveEntry_whenValueIsNull() {
+        var base = config(Map.of("a", "1", "b", "2"), Map.of("s1", "x", "s2", "y"), 1000, 1000);
+
+        var entries = new HashMap<String, String>();
+        entries.put("b", null);
+        var privateEntries = new HashMap<String, String>();
+        privateEntries.put("s1", null);
+        var patch = config(entries, privateEntries, 4000, 5000);
+
+        var merged = patch.mergeOnto(base);
+
+        assertThat(merged.getEntries()).containsExactlyInAnyOrderEntriesOf(Map.of("a", "1"));
+        assertThat(merged.getPrivateEntries()).containsExactlyInAnyOrderEntriesOf(Map.of("s2", "y"));
+    }
+
+    @Test
+    void mergeOnto_whenKeyAbsent_nullIsNoop() {
+        var base = config(Map.of("a", "1"), Map.of(), 1000, 1000);
+
+        var entries = new HashMap<String, String>();
+        entries.put("missing", null);
+        var merged = config(entries, Map.of(), 4000, 5000).mergeOnto(base);
+
+        assertThat(merged.getEntries()).containsExactlyInAnyOrderEntriesOf(Map.of("a", "1"));
+    }
+
+    @Test
+    void mergeOnto_shouldMergeEntriesAndPrivateEntriesIndependently() {
+        var base = config(Map.of("a", "1"), Map.of("s1", "x"), 1000, 1000);
+
+        var merged = config(Map.of("b", "2"), Map.of(), 4000, 5000).mergeOnto(base);
+
+        // patching only the public entries must not wipe the private ones
+        assertThat(merged.getEntries()).containsExactlyInAnyOrderEntriesOf(Map.of("a", "1", "b", "2"));
+        assertThat(merged.getPrivateEntries()).containsExactlyInAnyOrderEntriesOf(Map.of("s1", "x"));
+    }
+
+    @Test
+    void mergeOnto_whenBaseIsNull_shouldCreateFromPatch() {
+        var patch = config(Map.of("a", "1"), Map.of("s1", "x"), 4000, 5000);
+
+        var merged = patch.mergeOnto(null);
+
+        assertThat(merged.getParticipantContextId()).isEqualTo("participant1");
+        assertThat(merged.getCreatedAt()).isEqualTo(4000);
+        assertThat(merged.getLastModified()).isEqualTo(5000);
+        assertThat(merged.getEntries()).containsExactlyInAnyOrderEntriesOf(Map.of("a", "1"));
+        assertThat(merged.getPrivateEntries()).containsExactlyInAnyOrderEntriesOf(Map.of("s1", "x"));
+    }
+
+    @Test
+    void mergeOnto_shouldKeepBaseCreatedAt_andTakePatchLastModified() {
+        var base = config(Map.of(), Map.of(), 1000, 2000);
+
+        var merged = config(Map.of(), Map.of(), 4000, 5000).mergeOnto(base);
+
+        assertThat(merged.getCreatedAt()).isEqualTo(1000);
+        assertThat(merged.getLastModified()).isEqualTo(5000);
+    }
+
+    @Test
+    void mergeOnto_shouldNotAliasTheInputMaps() {
+        var base = config(new HashMap<>(Map.of("a", "1")), new HashMap<>(Map.of("s1", "x")), 1000, 1000);
+        var patch = config(new HashMap<>(Map.of("b", "2")), new HashMap<>(Map.of("s2", "y")), 4000, 5000);
+
+        var merged = patch.mergeOnto(base);
+
+        assertThat(merged.getEntries()).isNotSameAs(base.getEntries()).isNotSameAs(patch.getEntries());
+        assertThat(merged.getPrivateEntries()).isNotSameAs(base.getPrivateEntries()).isNotSameAs(patch.getPrivateEntries());
+
+        // mutating the result must leave both inputs untouched
+        merged.getEntries().put("c", "3");
+        assertThat(base.getEntries()).doesNotContainKey("c");
+        assertThat(patch.getEntries()).doesNotContainKey("c");
+    }
+
+    private ParticipantContextConfiguration config(Map<String, String> entries, Map<String, String> privateEntries,
+                                                   long createdAt, long lastModified) {
+        return ParticipantContextConfiguration.Builder.newInstance()
+                .participantContextId("participant1")
+                .createdAt(createdAt)
+                .lastModified(lastModified)
+                .entries(entries)
+                .privateEntries(privateEntries)
+                .build();
+    }
+}

--- a/spi/control-plane-spi/src/testFixtures/java/org/eclipse/edc/participantcontext/spi/config/store/ParticipantContextConfigStoreTestBase.java
+++ b/spi/control-plane-spi/src/testFixtures/java/org/eclipse/edc/participantcontext/spi/config/store/ParticipantContextConfigStoreTestBase.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.participantcontext.spi.config.store;
 import org.eclipse.edc.participantcontext.spi.config.model.ParticipantContextConfiguration;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,8 +36,8 @@ public abstract class ParticipantContextConfigStoreTestBase {
         assertThat(getStore().get("participant1"))
                 .isNotNull()
                 .satisfies(cfg -> {
-                    assertThat(cfg.getEntries()).containsAllEntriesOf(cfg.getEntries());
-                    assertThat(cfg.getPrivateEntries()).containsAllEntriesOf(cfg.getPrivateEntries());
+                    assertThat(cfg.getEntries()).containsAllEntriesOf(config.getEntries());
+                    assertThat(cfg.getPrivateEntries()).containsAllEntriesOf(config.getPrivateEntries());
                 });
 
     }
@@ -62,9 +63,126 @@ public abstract class ParticipantContextConfigStoreTestBase {
         assertThat(getStore().get("participant1"))
                 .isNotNull()
                 .satisfies(cfg -> {
-                    assertThat(newConfig.getEntries()).containsAllEntriesOf(cfg.getEntries());
+                    assertThat(cfg.getEntries()).containsAllEntriesOf(newConfig.getEntries());
                 });
 
+    }
+
+    @Test
+    protected void merge_whenNotExisting_shouldCreate() {
+        var patch = ParticipantContextConfiguration.Builder.newInstance()
+                .participantContextId("participant1")
+                .createdAt(1000)
+                .lastModified(1000)
+                .entries(Map.of("key1", "value1"))
+                .privateEntries(Map.of("sensitive1", "supersecret"))
+                .build();
+
+        var merged = getStore().merge(patch);
+
+        assertThat(merged.getEntries()).containsExactlyInAnyOrderEntriesOf(Map.of("key1", "value1"));
+        assertThat(merged.getCreatedAt()).isEqualTo(1000);
+        assertThat(getStore().get("participant1"))
+                .isNotNull()
+                .satisfies(cfg -> {
+                    assertThat(cfg.getEntries()).containsExactlyInAnyOrderEntriesOf(Map.of("key1", "value1"));
+                    assertThat(cfg.getPrivateEntries()).containsExactlyInAnyOrderEntriesOf(Map.of("sensitive1", "supersecret"));
+                    assertThat(cfg.getCreatedAt()).isEqualTo(1000);
+                });
+    }
+
+    @Test
+    protected void merge_shouldAddAndOverwriteEntries() {
+        getStore().save(config());
+
+        getStore().merge(patch(Map.of("key1", "updated", "key4", "value4"), Map.of()));
+
+        assertThat(getStore().get("participant1")).isNotNull()
+                .satisfies(cfg -> assertThat(cfg.getEntries()).containsExactlyInAnyOrderEntriesOf(
+                        Map.of("key1", "updated", "key2", "2", "key3", "value3", "key4", "value4")));
+    }
+
+    @Test
+    protected void merge_shouldRemoveEntry_whenValueIsNull() {
+        getStore().save(config());
+
+        var entries = new HashMap<String, String>();
+        entries.put("key1", null);
+        var privateEntries = new HashMap<String, String>();
+        privateEntries.put("sensitive1", null);
+        getStore().merge(patch(entries, privateEntries));
+
+        assertThat(getStore().get("participant1")).isNotNull()
+                .satisfies(cfg -> {
+                    assertThat(cfg.getEntries()).containsExactlyInAnyOrderEntriesOf(Map.of("key2", "2", "key3", "value3"));
+                    assertThat(cfg.getPrivateEntries()).containsExactlyInAnyOrderEntriesOf(Map.of("sensitive2", "5"));
+                });
+    }
+
+    @Test
+    protected void merge_whenKeyAbsent_nullIsNoop() {
+        getStore().save(config());
+
+        var entries = new HashMap<String, String>();
+        entries.put("missing", null);
+        getStore().merge(patch(entries, Map.of()));
+
+        assertThat(getStore().get("participant1")).isNotNull()
+                .satisfies(cfg -> assertThat(cfg.getEntries()).containsExactlyInAnyOrderEntriesOf(
+                        Map.of("key1", "value1", "key2", "2", "key3", "value3")));
+    }
+
+    @Test
+    protected void merge_shouldNotTouchPrivateEntries_whenPatchingEntriesOnly() {
+        getStore().save(config());
+
+        getStore().merge(patch(Map.of("key4", "value4"), Map.of()));
+
+        assertThat(getStore().get("participant1")).isNotNull()
+                .satisfies(cfg -> assertThat(cfg.getPrivateEntries()).containsExactlyInAnyOrderEntriesOf(
+                        Map.of("sensitive1", "supersecret", "sensitive2", "5")));
+    }
+
+    @Test
+    protected void merge_shouldPreserveCreatedAt_andUpdateLastModified() {
+        getStore().save(ParticipantContextConfiguration.Builder.newInstance()
+                .participantContextId("participant1")
+                .createdAt(1000)
+                .lastModified(1000)
+                .entries(Map.of("key1", "value1"))
+                .build());
+
+        getStore().merge(patch(Map.of("key2", "value2"), Map.of()));
+
+        assertThat(getStore().get("participant1")).isNotNull()
+                .satisfies(cfg -> {
+                    assertThat(cfg.getCreatedAt()).isEqualTo(1000);
+                    assertThat(cfg.getLastModified()).isEqualTo(9000);
+                });
+    }
+
+    @Test
+    protected void merge_shouldReturnMergedConfiguration() {
+        getStore().save(config());
+
+        var merged = getStore().merge(patch(Map.of("key4", "value4"), Map.of()));
+
+        assertThat(getStore().get("participant1")).isNotNull()
+                .satisfies(cfg -> {
+                    assertThat(cfg.getEntries()).containsExactlyInAnyOrderEntriesOf(merged.getEntries());
+                    assertThat(cfg.getPrivateEntries()).containsExactlyInAnyOrderEntriesOf(merged.getPrivateEntries());
+                    assertThat(cfg.getLastModified()).isEqualTo(merged.getLastModified());
+                });
+    }
+
+    private ParticipantContextConfiguration patch(Map<String, String> entries, Map<String, String> privateEntries) {
+        return ParticipantContextConfiguration.Builder.newInstance()
+                .participantContextId("participant1")
+                .createdAt(8000)
+                .lastModified(9000)
+                .entries(entries)
+                .privateEntries(privateEntries)
+                .build();
     }
 
     private ParticipantContextConfiguration config() {


### PR DESCRIPTION
## What this PR changes/adds

fix race condition in participant context config merge:

`merge` becomes an atomic operation on `ParticipantContextConfigStore` instead of a
service-level compose:

- **SQL**: `INSERT ... ON CONFLICT DO NOTHING` to materialise the row, `SELECT ... FOR UPDATE`
  to lock it for the enclosing transaction, merge, `UPDATE`. No schema change.
- **In-memory**: `ConcurrentHashMap.compute`.
- **Single (classic)**: throws, matching its read-only `save`.

RFC 7396 semantics move to `ParticipantContextConfiguration.mergeOnto(base)` so all
implementations share one definition. `merge` is abstract rather than `default` — a fallback
to `get`/`save` would ship the same bug to any store that didn't override it.

`save` (PUT, full replace) is unchanged: last-writer-wins is the defined semantics there.

## Why it does that

`PATCH /v5beta/participants/{id}/config` could silently lose entries when two requests
arrived concurrently. `ParticipantContextConfigServiceImpl.merge()` did a read-modify-write
across two store calls (`get` → merge in Java → `save`), and the SQL `save` replaces both
JSON columns wholesale. Both calls already shared one transaction, but Postgres' default
READ COMMITTED does not prevent lost updates on read-then-write, so the later commit
overwrote the earlier one's keys. The in-memory store had the same defect.


## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/#submitting-a-pull-request) and our [etiquette for pull requests](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/pr-etiquette/)._
