### PR TITLE
fix(sql): handle SQL NULL as null not 0

### DIFF
--- a/extensions/common/store/sql/jti-validation-store-sql/src/main/java/org/eclipse/edc/jtivalidation/store/sql/SqlJtiValidationStore.java
+++ b/extensions/common/store/sql/jti-validation-store-sql/src/main/java/org/eclipse/edc/jtivalidation/store/sql/SqlJtiValidationStore.java
@@ -113,7 +113,8 @@ public class SqlJtiValidationStore extends AbstractSqlStore implements JtiValida
 
     private JtiValidationEntry mapResultSet(ResultSet resultSet) throws Exception {
         var expiresAt = resultSet.getLong(statements.getExpirationTimeColumn());
-
-        return new JtiValidationEntry(resultSet.getString(statements.getTokenIdColumn()), expiresAt);
+        var wasNull = resultSet.wasNull();
+        return new JtiValidationEntry(resultSet.getString(statements.getTokenIdColumn()),
+                wasNull ? null : expiresAt);
     }
 }

--- a/spi/core-spi/src/testFixtures/java/org/eclipse/edc/jwt/validation/jti/JtiValidationStoreTestBase.java
+++ b/spi/core-spi/src/testFixtures/java/org/eclipse/edc/jwt/validation/jti/JtiValidationStoreTestBase.java
@@ -58,6 +58,20 @@ public abstract class JtiValidationStoreTestBase {
     }
 
     @Test
+    void findById_noExpiresAt() {
+        var entry = new JtiValidationEntry("test-id", null);
+        var store = getStore();
+        store.storeEntry(entry);
+
+        var found = store.findById("test-id", false);
+        assertThat(found).isNotNull();
+        assertThat(found.expirationTimestamp()).isNull();
+        assertThat(found.expirationTimestampAsInstant()).isNull();
+        assertThat(found.isExpired()).isFalse();
+
+    }
+
+    @Test
     void findById_notFound() {
         assertThat(getStore().findById("test-id")).isNull();
     }


### PR DESCRIPTION
## What this PR changes/adds

this fix treats the SQL NULL value as proper Java `null`, instead of 0.

## Why it does that

if a jti validation entry does not have an expiry set, it would interpret a SQL NULL as '0', which is epoch 0 (01.0.1970), thus treating is as expired.

this is needed for fixing some tests in IDentityHub

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/#submitting-a-pull-request) and our [etiquette for pull requests](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/pr-etiquette/)._
