### PR TITLE
refactor: simplify ParticipantContext hierarchy

### DIFF
--- a/core/catalog-crawler/catalog-crawler-core/src/main/java/org/eclipse/edc/catalog/crawler/cache/query/PagingCatalogFetcher.java
+++ b/core/catalog-crawler/catalog-crawler-core/src/main/java/org/eclipse/edc/catalog/crawler/cache/query/PagingCatalogFetcher.java
@@ -83,7 +83,7 @@ public class PagingCatalogFetcher {
                 .querySpec(QuerySpec.Builder.newInstance().range(range).build())
                 .build();
 
-        var participantResult  = participantContextSupplier.get().map(ParticipantContext::getParticipantContextId);
+        var participantResult  = participantContextSupplier.get().map(ParticipantContext::getId);
         if (participantResult.failed()) {
             return failedFuture(new EdcException(participantResult.getFailureDetail()));
         }

--- a/core/catalog-crawler/catalog-crawler-core/src/test/java/org/eclipse/edc/catalog/crawler/cache/query/DspCatalogRequestActionTest.java
+++ b/core/catalog-crawler/catalog-crawler-core/src/test/java/org/eclipse/edc/catalog/crawler/cache/query/DspCatalogRequestActionTest.java
@@ -50,7 +50,7 @@ class DspCatalogRequestActionTest {
     private final TypeTransformerRegistry typeTransformerRegistry = new TypeTransformerRegistryImpl(mock());
     private final ObjectMapper objectMapper = createObjectMapper();
     private final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(
-            ParticipantContext.Builder.newInstance().participantContextId("participantContext").identity("identity").build());
+            ParticipantContext.Builder.newInstance().id("participantContext").identity("identity").build());
     private final DspCatalogRequestAction action = new DspCatalogRequestAction(messageDispatcher, participantContextSupplier,
             mock(), objectMapper, typeTransformerRegistry, new TitaniumJsonLd(mock()));
 

--- a/core/catalog-crawler/catalog-crawler-core/src/test/java/org/eclipse/edc/catalog/crawler/cache/query/PagingCatalogFetcherTest.java
+++ b/core/catalog-crawler/catalog-crawler-core/src/test/java/org/eclipse/edc/catalog/crawler/cache/query/PagingCatalogFetcherTest.java
@@ -54,7 +54,7 @@ class PagingCatalogFetcherTest {
     private final ProtocolRemoteMessageDispatcher messageDispatcherMock = mock();
     private final ObjectMapper objectMapper = createObjectMapper();
     private final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(
-            ParticipantContext.Builder.newInstance().participantContextId("participantContext").identity("identity").build());
+            ParticipantContext.Builder.newInstance().id("participantContext").identity("identity").build());
     private final TypeTransformerRegistry typeTransformerRegistry = new TypeTransformerRegistryImpl(mock());
     private PagingCatalogFetcher fetcher;
 

--- a/core/common/lib/core-lib/src/main/java/org/eclipse/edc/boot/vault/InMemoryVault.java
+++ b/core/common/lib/core-lib/src/main/java/org/eclipse/edc/boot/vault/InMemoryVault.java
@@ -93,6 +93,6 @@ public class InMemoryVault implements Vault {
     private @NotNull String getPartition() {
         return Optional.ofNullable(participantContextSupplier)
                 .map(Supplier::get).filter(ServiceResult::succeeded).map(ServiceResult::getContent)
-                .map(ParticipantContext::getParticipantContextId).orElse(DEFAULT_PARTITION);
+                .map(ParticipantContext::getId).orElse(DEFAULT_PARTITION);
     }
 }

--- a/core/common/lib/core-lib/src/test/java/org/eclipse/edc/api/authentication/filter/ServicePrincipalAuthenticationFilterTest.java
+++ b/core/common/lib/core-lib/src/test/java/org/eclipse/edc/api/authentication/filter/ServicePrincipalAuthenticationFilterTest.java
@@ -47,7 +47,7 @@ class ServicePrincipalAuthenticationFilterTest {
                 .thenAnswer(i ->
                         ServiceResult.success(ParticipantContext.Builder.newInstance()
                                 .identity(i.getArgument(0))
-                                .participantContextId(i.getArgument(0))
+                                .id(i.getArgument(0))
                                 .build()));
     }
 

--- a/core/common/lib/core-lib/src/test/java/org/eclipse/edc/boot/vault/InMemoryVaultTest.java
+++ b/core/common/lib/core-lib/src/test/java/org/eclipse/edc/boot/vault/InMemoryVaultTest.java
@@ -87,7 +87,7 @@ class InMemoryVaultTest {
     @Nested
     class WithParticipantContextSupplier {
         private final ParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(
-                ParticipantContext.Builder.newInstance().participantContextId("participantContextId").identity("identity").build()
+                ParticipantContext.Builder.newInstance().id("participantContextId").identity("identity").build()
         );
         private final InMemoryVault vault = new InMemoryVault(mock(Monitor.class), participantContextSupplier);
 

--- a/core/common/participant-context-connector-classic-core/src/main/java/org/eclipse/edc/participantcontext/connector/ClassicParticipantContextDefaultServicesExtension.java
+++ b/core/common/participant-context-connector-classic-core/src/main/java/org/eclipse/edc/participantcontext/connector/ClassicParticipantContextDefaultServicesExtension.java
@@ -52,7 +52,7 @@ public class ClassicParticipantContextDefaultServicesExtension implements Servic
     @Provider(isDefault = true)
     public SingleParticipantContextSupplier participantContextSupplier() {
         var contextId = participantContextId != null ? participantContextId : participantId;
-        var participantContext = ParticipantContext.Builder.newInstance().participantContextId(contextId)
+        var participantContext = ParticipantContext.Builder.newInstance().id(contextId)
                 .identity(participantId).build();
         return () -> ServiceResult.success(participantContext);
     }

--- a/core/common/participant-context-connector-classic-core/src/main/java/org/eclipse/edc/participantcontext/connector/ClassicParticipantContextServicesExtension.java
+++ b/core/common/participant-context-connector-classic-core/src/main/java/org/eclipse/edc/participantcontext/connector/ClassicParticipantContextServicesExtension.java
@@ -54,7 +54,7 @@ public class ClassicParticipantContextServicesExtension implements ServiceExtens
 
     private void initializeParticipantContext() {
         var contextId = participantContextId != null ? participantContextId : participantId;
-        var participantContext = ParticipantContext.Builder.newInstance().participantContextId(contextId)
+        var participantContext = ParticipantContext.Builder.newInstance().id(contextId)
                 .identity(participantId).build();
 
         if (participantContextStore.findById(contextId).failed()) {

--- a/core/common/participant-context-connector-classic-core/src/test/java/org/eclipse/edc/participantcontext/ClassicParticipantContextDefaultServicesExtensionTest.java
+++ b/core/common/participant-context-connector-classic-core/src/test/java/org/eclipse/edc/participantcontext/ClassicParticipantContextDefaultServicesExtensionTest.java
@@ -39,7 +39,7 @@ public class ClassicParticipantContextDefaultServicesExtensionTest {
         var extension = factory.constructInstance(ClassicParticipantContextDefaultServicesExtension.class);
 
         var supplier = extension.participantContextSupplier();
-        assertThat(supplier.get().getContent()).extracting(ParticipantContext::getParticipantContextId).isEqualTo("participantId");
+        assertThat(supplier.get().getContent()).extracting(ParticipantContext::getId).isEqualTo("participantId");
     }
 
     @Test
@@ -52,6 +52,6 @@ public class ClassicParticipantContextDefaultServicesExtensionTest {
         var extension = factory.constructInstance(ClassicParticipantContextDefaultServicesExtension.class);
 
         var supplier = extension.participantContextSupplier();
-        assertThat(supplier.get().getContent()).extracting(ParticipantContext::getParticipantContextId).isEqualTo("participantContextId");
+        assertThat(supplier.get().getContent()).extracting(ParticipantContext::getId).isEqualTo("participantContextId");
     }
 }

--- a/core/common/participant-context-core/src/main/java/org/eclipse/edc/participantcontext/defaults/store/InMemoryParticipantContextStore.java
+++ b/core/common/participant-context-core/src/main/java/org/eclipse/edc/participantcontext/defaults/store/InMemoryParticipantContextStore.java
@@ -44,20 +44,20 @@ public class InMemoryParticipantContextStore implements ParticipantContextStore 
 
     @Override
     public StoreResult<Void> create(ParticipantContext participantContext) {
-        var prev = participants.putIfAbsent(participantContext.getParticipantContextId(), participantContext);
+        var prev = participants.putIfAbsent(participantContext.getId(), participantContext);
         if (prev != null) {
-            return StoreResult.alreadyExists(alreadyExistsErrorMessage(participantContext.getParticipantContextId()));
+            return StoreResult.alreadyExists(alreadyExistsErrorMessage(participantContext.getId()));
         }
         return StoreResult.success();
     }
 
     @Override
     public StoreResult<Void> update(ParticipantContext participantContext) {
-        var prev = participants.replace(participantContext.getParticipantContextId(), participantContext);
+        var prev = participants.replace(participantContext.getId(), participantContext);
         if (prev != null) {
             return StoreResult.success();
         } else {
-            return StoreResult.notFound(notFoundErrorMessage(participantContext.getParticipantContextId()));
+            return StoreResult.notFound(notFoundErrorMessage(participantContext.getId()));
         }
     }
 
@@ -69,5 +69,15 @@ public class InMemoryParticipantContextStore implements ParticipantContextStore 
         } else {
             return StoreResult.notFound(notFoundErrorMessage(id));
         }
+    }
+
+    @Override
+    public StoreResult<ParticipantContext> findById(String participantContextId) {
+        var participantContext = participants.get(participantContextId);
+        if (participantContext != null) {
+            return StoreResult.success(participantContext);
+        }
+
+        return  StoreResult.notFound(notFoundErrorMessage(participantContextId));
     }
 }

--- a/core/common/participant-context-core/src/test/java/org/eclipse/edc/participantcontext/service/ParticipantContextServiceImplTest.java
+++ b/core/common/participant-context-core/src/test/java/org/eclipse/edc/participantcontext/service/ParticipantContextServiceImplTest.java
@@ -168,7 +168,7 @@ class ParticipantContextServiceImplTest {
     }
 
     private ParticipantContext createParticipantContextContext() {
-        return ParticipantContext.Builder.newInstance().participantContextId("test-id").identity("test-id").build();
+        return ParticipantContext.Builder.newInstance().id("test-id").identity("test-id").build();
     }
 
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogProtocolServiceImpl.java
@@ -62,12 +62,12 @@ public class CatalogProtocolServiceImpl implements CatalogProtocolService {
         return transactionContext.execute(() -> protocolTokenValidator.verify(participantContext, tokenRepresentation, RequestCatalogPolicyContext::new, message)
                 .map(agent -> {
                     try (var datasets = datasetResolver.query(participantContext, agent, message.getQuerySpec(), message.getProtocol())) {
-                        var dataServices = dataServiceRegistry.getDataServices(participantContext.getParticipantContextId(), message.getProtocol());
+                        var dataServices = dataServiceRegistry.getDataServices(participantContext.getId(), message.getProtocol());
 
                         return Catalog.Builder.newInstance()
                                 .dataServices(dataServices)
                                 .datasets(datasets.toList())
-                                .participantId(identityResolver.getParticipantId(participantContext.getParticipantContextId(), message.getProtocol()))
+                                .participantId(identityResolver.getParticipantId(participantContext.getId(), message.getProtocol()))
                                 .build();
                     }
                 })

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogServiceImpl.java
@@ -43,7 +43,7 @@ public class CatalogServiceImpl implements CatalogService {
                 .additionalScopes(additionalScopes)
                 .build();
 
-        return dispatcher.dispatch(participantContext.getParticipantContextId(), byte[].class, request);
+        return dispatcher.dispatch(participantContext.getId(), byte[].class, request);
     }
 
     @Override
@@ -55,6 +55,6 @@ public class CatalogServiceImpl implements CatalogService {
                 .counterPartyAddress(counterPartyAddress)
                 .build();
 
-        return dispatcher.dispatch(participantContext.getParticipantContextId(), byte[].class, request);
+        return dispatcher.dispatch(participantContext.getId(), byte[].class, request);
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -204,7 +204,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
         }
 
         var negotiation = leaseNegotiation.getContent();
-        if (!negotiation.getParticipantContextId().equals(participantContext.getParticipantContextId())) {
+        if (!negotiation.getParticipantContextId().equals(participantContext.getId())) {
             store.breakLease(negotiation);
             return ServiceResult.notFound("No negotiation with id %s found".formatted(negotiation.getId()));
         }
@@ -234,7 +234,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
                 .protocol(message.getProtocol())
                 .traceContext(telemetry.getCurrentTraceContext())
                 .type(type)
-                .participantContextId(participantContext.getParticipantContextId())
+                .participantContextId(participantContext.getId())
                 .build();
     }
 
@@ -244,14 +244,14 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
 
         var result = consumerOfferResolver.resolveOffer(offerId);
 
-        if (result.succeeded() && participantContext.getParticipantContextId().equals(result.getContent().getContractDefinition().getParticipantContextId())) {
+        if (result.succeeded() && participantContext.getId().equals(result.getContent().getContractDefinition().getParticipantContextId())) {
             return result;
         }
 
         if (result.failed()) {
             monitor.debug(() -> "Failed to resolve offer: %s".formatted(result.getFailureDetail()));
         } else {
-            monitor.debug(() -> "Offer %s does not belong to participantContext %s".formatted(offerId, participantContext.getParticipantContextId()));
+            monitor.debug(() -> "Offer %s does not belong to participantContext %s".formatted(offerId, participantContext.getId()));
         }
 
         return ServiceResult.notFound("Not found");
@@ -372,7 +372,7 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
 
     private ServiceResult<ContractNegotiation> getNegotiation(ParticipantContext participantContext, String negotiationId) {
         return Optional.ofNullable(store.findById(negotiationId))
-                .filter(cn -> participantContext.getParticipantContextId().equals(cn.getParticipantContextId()))
+                .filter(cn -> participantContext.getId().equals(cn.getParticipantContextId()))
                 .map(ServiceResult::success)
                 .orElseGet(() -> ServiceResult.notFound("No negotiation with id %s found".formatted(negotiationId)));
     }

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/protocol/ProtocolTokenValidatorImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/protocol/ProtocolTokenValidatorImpl.java
@@ -72,7 +72,7 @@ public class ProtocolTokenValidatorImpl implements ProtocolTokenValidator {
                 .dataspaceProfileContext(profileContext)
                 .build();
 
-        var tokenValidation = identityService.verifyJwtToken(participantContext.getParticipantContextId(), tokenRepresentation, verificationContext);
+        var tokenValidation = identityService.verifyJwtToken(participantContext.getId(), tokenRepresentation, verificationContext);
         if (tokenValidation.failed()) {
             monitor.debug(() -> "Unauthorized: %s".formatted(tokenValidation.getFailureDetail()));
             return ServiceResult.unauthorized("Unauthorized");

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -280,7 +280,7 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
 
     private ServiceResult<ContractAgreement> fetchContractAgreement(ParticipantContext participantContext, TransferRequestMessage message) {
         return Optional.ofNullable(findAgreement(participantContext, message.getContractId()))
-                .filter(agreement -> participantContext.getParticipantContextId().equals(agreement.getParticipantContextId()))
+                .filter(agreement -> participantContext.getId().equals(agreement.getParticipantContextId()))
                 .map(ServiceResult::success)
                 .orElseGet(() -> ServiceResult.notFound(format("Cannot process %s because %s", message.getClass().getSimpleName(), "agreement not found or not valid")));
     }
@@ -291,7 +291,7 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
             return notFound(transferProcessId);
         }
 
-        if (!participantContext.getParticipantContextId().equals(transferProcess.getParticipantContextId())) {
+        if (!participantContext.getId().equals(transferProcess.getParticipantContextId())) {
             return notFound(transferProcess.getId());
         }
 
@@ -336,7 +336,7 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     }
 
     private ContractAgreement findAgreement(ParticipantContext participantContext, String contractId) {
-        var query = queryByParticipantContextId(participantContext.getParticipantContextId())
+        var query = queryByParticipantContextId(participantContext.getId())
                 .filter(Criterion.criterion("agreementId", "=", contractId))
                 .build();
         try (var stream = negotiationStore.queryAgreements(query)) {

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProviderFactory.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProviderFactory.java
@@ -73,7 +73,7 @@ public class TransferProcessProviderFactory {
                 .type(PROVIDER)
                 .clock(clock)
                 .traceContext(telemetry.getCurrentTraceContext())
-                .participantContextId(participantContext.getParticipantContextId())
+                .participantContextId(participantContext.getId())
                 .dataplaneMetadata(asset.getDataplaneMetadata())
                 .claims(participantAgent.getClaims())
                 .build();

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogProtocolServiceImplTest.java
@@ -61,7 +61,7 @@ class CatalogProtocolServiceImplTest {
     private final ParticipantIdentityResolver identityResolver = mock();
     private final TransactionContext transactionContext = spy(new NoopTransactionContext());
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/catalog/CatalogServiceImplTest.java
@@ -39,7 +39,7 @@ class CatalogServiceImplTest {
     private final ProtocolRemoteMessageDispatcher dispatcher = mock(ProtocolRemoteMessageDispatcher.class);
     private final CatalogService service = new CatalogServiceImpl(dispatcher);
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
 
@@ -52,7 +52,7 @@ class CatalogServiceImplTest {
         assertThat(result).succeedsWithin(5, SECONDS).satisfies(statusResult -> {
             assertThat(statusResult).isSucceeded().isEqualTo("content".getBytes());
         });
-        verify(dispatcher).dispatch(eq(participantContext.getParticipantContextId()), eq(byte[].class), isA(CatalogRequestMessage.class));
+        verify(dispatcher).dispatch(eq(participantContext.getId()), eq(byte[].class), isA(CatalogRequestMessage.class));
     }
 
     @Test
@@ -64,6 +64,6 @@ class CatalogServiceImplTest {
         assertThat(result).succeedsWithin(5, SECONDS).satisfies(statusResult -> {
             assertThat(statusResult).isSucceeded().isEqualTo("content".getBytes());
         });
-        verify(dispatcher).dispatch(eq(participantContext.getParticipantContextId()), eq(byte[].class), isA(DatasetRequestMessage.class));
+        verify(dispatcher).dispatch(eq(participantContext.getId()), eq(byte[].class), isA(DatasetRequestMessage.class));
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationEventDispatchTest.java
@@ -80,7 +80,7 @@ class ContractNegotiationEventDispatchTest {
     private final ClaimToken token = ClaimToken.Builder.newInstance().claim("client_id", CONSUMER).build();
     private final TokenRepresentation tokenRepresentation = TokenRepresentation.Builder.newInstance().token(UUID.randomUUID().toString()).build();
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
     protected DataspaceProfileContextRegistry dataspaceProfileContextRegistry = mock();

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImplTest.java
@@ -103,7 +103,7 @@ import static org.mockito.Mockito.when;
 class ContractNegotiationProtocolServiceImplTest {
 
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
     private final ContractNegotiationStore store = mock();
@@ -670,7 +670,7 @@ class ContractNegotiationProtocolServiceImplTest {
         when(store.findById(any())).thenReturn(cn);
         when(store.findByIdAndLease(any())).thenReturn(StoreResult.success(cn));
         var wrongParticipantContext = ParticipantContext.Builder.newInstance()
-                .participantContextId("wrongParticipantContext")
+                .id("wrongParticipantContext")
                 .identity("wrongParticipantId")
                 .build();
         when(protocolTokenValidator.verify(eq(wrongParticipantContext), eq(tokenRepresentation), any(), any(), eq(message)))
@@ -706,7 +706,7 @@ class ContractNegotiationProtocolServiceImplTest {
                 .counterPartyId("connectorId")
                 .counterPartyAddress("counterPartyAddress")
                 .protocol("protocol")
-                .participantContextId(participantContext.getParticipantContextId())
+                .participantContextId(participantContext.getId())
                 .stateTimestamp(Instant.now().toEpochMilli());
     }
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationServiceImplTest.java
@@ -70,7 +70,7 @@ class ContractNegotiationServiceImplTest {
 
     private final ContractNegotiationService service = new ContractNegotiationServiceImpl(store, transactionContext, commandHandlerRegistry, queryValidator);
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/protocol/ProtocolTokenValidatorImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/protocol/ProtocolTokenValidatorImplTest.java
@@ -60,7 +60,7 @@ class ProtocolTokenValidatorImplTest {
             policyEngine, mock(), agentService, dataspaceProfileContextRegistry);
 
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
 
@@ -87,7 +87,7 @@ class ProtocolTokenValidatorImplTest {
         })));
         verify(dataspaceProfileContextRegistry).getProfile(protocol);
         verify(identityService).verifyJwtToken(
-                eq(participantContext.getParticipantContextId()),
+                eq(participantContext.getId()),
                 same(tokenRepresentation),
                 argThat(verificationContext -> verificationContext.getDataspaceProfileContext().equals(dataspaceProfileContext))
         );

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessEventDispatchTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessEventDispatchTest.java
@@ -106,7 +106,7 @@ public class TransferProcessEventDispatchTest {
             .registerServiceMock(ProtocolWebhookResolver.class, mock())
             .registerServiceMock(ProtocolRemoteMessageDispatcher.class, DSP_DISPATCHER);
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
     private final EventSubscriber eventSubscriber = mock();

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -110,7 +110,7 @@ class TransferProcessProtocolServiceImplTest {
     private final DataFlowController dataFlowController = mock();
     private final TransferProcessProviderFactory transferProcessProviderFactory = mock();
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
     private TransferProcessProtocolService service;
@@ -232,7 +232,7 @@ class TransferProcessProtocolServiceImplTest {
         return TransferProcess.Builder.newInstance()
                 .contractId("contractId")
                 .dataDestination(DataAddress.Builder.newInstance().type("type").build())
-                .participantContextId(participantContext.getParticipantContextId());
+                .participantContextId(participantContext.getId());
     }
 
     private ParticipantAgent participantAgent() {
@@ -256,7 +256,7 @@ class TransferProcessProtocolServiceImplTest {
                 .consumerId("consumer")
                 .assetId("assetId")
                 .policy(Policy.Builder.newInstance().build())
-                .participantContextId(participantContext.getParticipantContextId());
+                .participantContextId(participantContext.getId());
     }
 
     @FunctionalInterface
@@ -1197,7 +1197,7 @@ class TransferProcessProtocolServiceImplTest {
 
 
             var wrongParticipantContext = ParticipantContext.Builder.newInstance()
-                    .participantContextId("wrongParticipantContext")
+                    .id("wrongParticipantContext")
                     .identity("wrongParticipantId")
                     .build();
 

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProviderFactoryTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProviderFactoryTest.java
@@ -82,6 +82,6 @@ class TransferProcessProviderFactoryTest {
     }
 
     private ParticipantContext createParticipantContext(String participantContextId) {
-        return ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity("any").build();
+        return ParticipantContext.Builder.newInstance().id(participantContextId).identity("any").build();
     }
 }

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessServiceImplTest.java
@@ -74,7 +74,7 @@ class TransferProcessServiceImplTest {
             commandHandlerRegistry, contractNegotiationStore, queryValidator);
 
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
 

--- a/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/ContractDefinitionResolverImpl.java
+++ b/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/ContractDefinitionResolverImpl.java
@@ -52,7 +52,7 @@ public class ContractDefinitionResolverImpl implements ContractDefinitionResolve
     @Override
     public ResolvedContractDefinitions resolveFor(ParticipantContext participantContext, ParticipantAgent agent) {
         var policies = new HashMap<String, Policy>();
-        var query = queryByParticipantContextId(participantContext.getParticipantContextId()).limit(Integer.MAX_VALUE).build();
+        var query = queryByParticipantContextId(participantContext.getId()).limit(Integer.MAX_VALUE).build();
         var definitions = definitionStore.findAll(query)
                 .filter(definition -> {
                     var accessResult = Optional.of(definition.getAccessPolicyId())

--- a/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImpl.java
+++ b/core/control-plane/control-plane-catalog/src/main/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImpl.java
@@ -78,7 +78,7 @@ public class DatasetResolverImpl implements DatasetResolver {
 
         var assetsQuery = QuerySpec.Builder.newInstance()
                 .offset(0).limit(MAX_VALUE).filter(querySpec.getFilterExpression())
-                .filter(filterByParticipantContextId(participantContext.getParticipantContextId()))
+                .filter(filterByParticipantContextId(participantContext.getId()))
                 .build();
 
         return assetIndex.queryAssets(assetsQuery)

--- a/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/ContractDefinitionResolverImplTest.java
+++ b/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/ContractDefinitionResolverImplTest.java
@@ -54,7 +54,7 @@ class ContractDefinitionResolverImplTest {
     private final ContractDefinitionStore definitionStore = mock();
 
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
 
@@ -77,7 +77,7 @@ class ContractDefinitionResolverImplTest {
                 eq(def.getPolicy()),
                 and(isA(CatalogPolicyContext.class), argThat(c -> c.participantAgent().equals(agent)))
         );
-        var query = queryByParticipantContextId(participantContext.getParticipantContextId()).limit(Integer.MAX_VALUE).build();
+        var query = queryByParticipantContextId(participantContext.getId()).limit(Integer.MAX_VALUE).build();
 
         verify(definitionStore).findAll(query);
     }

--- a/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplIntegrationTest.java
+++ b/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplIntegrationTest.java
@@ -176,7 +176,7 @@ class DatasetResolverImplIntegrationTest {
 
     private ParticipantContext createParticipantContext() {
         return ParticipantContext.Builder.newInstance()
-                .participantContextId("participantContextId")
+                .id("participantContextId")
                 .identity("participantId")
                 .build();
     }

--- a/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplTest.java
+++ b/core/control-plane/control-plane-catalog/src/test/java/org/eclipse/edc/connector/controlplane/catalog/DatasetResolverImplTest.java
@@ -97,7 +97,7 @@ class DatasetResolverImplTest {
     }
 
     private ParticipantContext createParticipantContext() {
-        return ParticipantContext.Builder.newInstance().participantContextId("participantContextId")
+        return ParticipantContext.Builder.newInstance().id("participantContextId")
                 .identity("id").build();
     }
 
@@ -347,7 +347,7 @@ class DatasetResolverImplTest {
                         assertThat(policy.getInheritsFrom()).isEqualTo("inherits2");
                     });
             verify(assetIndex).findById("datasetId");
-            verify(definitionResolver).resolveFor(argThat(argument -> argument.getParticipantContextId().equals("participantContextId")), eq(participantAgent));
+            verify(definitionResolver).resolveFor(argThat(argument -> argument.getId().equals("participantContextId")), eq(participantAgent));
         }
 
         @Test

--- a/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/command/handlers/InitiateNegotiationCommandHandler.java
+++ b/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/negotiation/command/handlers/InitiateNegotiationCommandHandler.java
@@ -70,7 +70,7 @@ public class InitiateNegotiationCommandHandler implements CommandHandler<Initiat
                 .counterPartyAddress(request.getCounterPartyAddress())
                 .callbackAddresses(request.getCallbackAddresses())
                 .traceContext(telemetry.getCurrentTraceContext())
-                .participantContextId(participantContext.getParticipantContextId())
+                .participantContextId(participantContext.getId())
                 .type(CONSUMER)
                 .build();
 

--- a/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/command/handlers/InitiateNegotiationCommandHandlerTest.java
+++ b/core/control-plane/control-plane-contract/src/test/java/org/eclipse/edc/connector/controlplane/contract/negotiation/command/handlers/InitiateNegotiationCommandHandlerTest.java
@@ -56,7 +56,7 @@ class InitiateNegotiationCommandHandlerTest {
     void shouldSaveNewNegotiationInInitialState() {
         when(store.save(any())).thenReturn(StoreResult.success());
         var participantContext = ParticipantContext.Builder.newInstance()
-                .participantContextId("participantContextId")
+                .id("participantContextId")
                 .identity("participantId")
                 .build();
         var request = ContractRequest.Builder.newInstance()
@@ -90,7 +90,7 @@ class InitiateNegotiationCommandHandlerTest {
     void shouldFail_whenStorageFails() {
         when(store.save(any())).thenReturn(StoreResult.generalError("error"));
         var participantContext = ParticipantContext.Builder.newInstance()
-                .participantContextId("participantContextId")
+                .id("participantContextId")
                 .identity("participantId")
                 .build();
         var request = ContractRequest.Builder.newInstance()

--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/InitiateTransferCommandHandler.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/InitiateTransferCommandHandler.java
@@ -80,7 +80,7 @@ public class InitiateTransferCommandHandler implements CommandHandler<InitiateTr
                 .privateProperties(transferRequest.getPrivateProperties())
                 .callbackAddresses(transferRequest.getCallbackAddresses())
                 .traceContext(telemetry.getCurrentTraceContext())
-                .participantContextId(participantContext.getParticipantContextId())
+                .participantContextId(participantContext.getId())
                 .dataplaneMetadata(transferRequest.getDataplaneMetadata())
                 .build();
 

--- a/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/InitiateTransferCommandHandlerTest.java
+++ b/core/control-plane/control-plane-transfer/src/test/java/org/eclipse/edc/connector/controlplane/transfer/command/handlers/InitiateTransferCommandHandlerTest.java
@@ -82,7 +82,7 @@ class InitiateTransferCommandHandlerTest {
                 .callbackAddresses(List.of(callback))
                 .dataplaneMetadata(dataplaneMetadata)
                 .build();
-        var participantContext = ParticipantContext.Builder.newInstance().participantContextId("id")
+        var participantContext = ParticipantContext.Builder.newInstance().id("id")
                 .identity("identity")
                 .build();
         var command = new InitiateTransferCommand(participantContext, transferRequest);
@@ -119,7 +119,7 @@ class InitiateTransferCommandHandlerTest {
                 .callbackAddresses(List.of(callback))
                 .dataplaneMetadata(dataplaneMetadata)
                 .build();
-        var participantContext = ParticipantContext.Builder.newInstance().participantContextId("id")
+        var participantContext = ParticipantContext.Builder.newInstance().id("id")
                 .identity("identity")
                 .build();
 
@@ -137,7 +137,7 @@ class InitiateTransferCommandHandlerTest {
                 .build();
 
         var participantContext = ParticipantContext.Builder.newInstance()
-                .participantContextId("participantContextId").identity("id").build();
+                .id("participantContextId").identity("id").build();
         var result = handler.handle(new InitiateTransferCommand(participantContext, transferRequest));
 
         assertThat(result).isFailed();

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/from/JsonObjectFromParticipantContextTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/from/JsonObjectFromParticipantContextTransformer.java
@@ -45,7 +45,7 @@ public class JsonObjectFromParticipantContextTransformer extends AbstractJsonLdT
     public @Nullable JsonObject transform(@NotNull ParticipantContext participantContext, @NotNull TransformerContext context) {
         return jsonFactory.createObjectBuilder()
                 .add(TYPE, PARTICIPANT_CONTEXT_TYPE_IRI)
-                .add(ID, participantContext.getParticipantContextId())
+                .add(ID, participantContext.getId())
                 .add(PARTICIPANT_CONTEXT_IDENTITY_IRI, participantContext.getIdentity())
                 .add(PARTICIPANT_CONTEXT_PROPERTIES_IRI, createProperties(participantContext))
                 .add(PARTICIPANT_CONTEXT_STATE_IRI, createId(jsonFactory, ParticipantContextState.from(participantContext.getState()).name()))

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/to/JsonObjectToParticipantContextTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/to/JsonObjectToParticipantContextTransformer.java
@@ -36,7 +36,6 @@ public class JsonObjectToParticipantContextTransformer extends AbstractJsonLdTra
         var participantContext = ParticipantContext.Builder.newInstance();
         var nodeId = nodeId(jsonObject);
         var id = nodeId != null ? nodeId : UUID.randomUUID().toString();
-        participantContext.participantContextId(id);
         participantContext.id(id);
 
         transformString(jsonObject.get(PARTICIPANT_CONTEXT_IDENTITY_IRI), participantContext::identity, context);

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/from/JsonObjectFromParticipantContextTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/from/JsonObjectFromParticipantContextTransformerTest.java
@@ -49,7 +49,7 @@ class JsonObjectFromParticipantContextTransformerTest {
     @Test
     void transform_shouldConvertParticipantContextToJsonObject() {
         var participantContext = ParticipantContext.Builder.newInstance()
-                .participantContextId("participant-1")
+                .id("participant-1")
                 .state(ParticipantContextState.ACTIVATED)
                 .identity("did:example:123")
                 .properties(Map.of("key1", "value1", "key2", "value2"))
@@ -72,7 +72,7 @@ class JsonObjectFromParticipantContextTransformerTest {
     @Test
     void transform_withEmptyProperties_shouldReturnJsonObjectWithEmptyProperties() {
         var participantContext = ParticipantContext.Builder.newInstance()
-                .participantContextId("participant-2")
+                .id("participant-2")
                 .state(ParticipantContextState.ACTIVATED)
                 .identity("did:example:123")
                 .properties(Map.of())
@@ -89,7 +89,7 @@ class JsonObjectFromParticipantContextTransformerTest {
     @Test
     void transform_shouldIncludeCorrectState() {
         var participantContext = ParticipantContext.Builder.newInstance()
-                .participantContextId("participant-3")
+                .id("participant-3")
                 .state(ParticipantContextState.DEACTIVATED)
                 .identity("did:example:123")
                 .build();

--- a/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/to/JsonObjectToParticipantContextTransformerTest.java
+++ b/core/control-plane/control-plane-transform/src/test/java/org/eclipse/edc/connector/controlplane/transform/edc/participantcontext/to/JsonObjectToParticipantContextTransformerTest.java
@@ -66,7 +66,7 @@ class JsonObjectToParticipantContextTransformerTest {
 
         assertThat(result).isSucceeded()
                 .satisfies(participantContext -> {
-                    assertThat(participantContext.getParticipantContextId()).isEqualTo("participant-1");
+                    assertThat(participantContext.getId()).isEqualTo("participant-1");
                     assertThat(participantContext.getIdentity()).isEqualTo("did:example:123");
                     assertThat(participantContext.getProperties()).containsEntry("key1", "value1")
                             .containsEntry("key2", "value2");
@@ -84,7 +84,7 @@ class JsonObjectToParticipantContextTransformerTest {
         var result = typeTransformerRegistry.transform(jsonObject, ParticipantContext.class);
 
         assertThat(result).isSucceeded().satisfies(participantContext -> {
-            assertThat(participantContext.getParticipantContextId()).isNotNull().isNotEmpty();
+            assertThat(participantContext.getId()).isNotNull().isNotEmpty();
             assertThat(participantContext.getProperties()).containsEntry("key1", "value1");
         });
     }
@@ -100,7 +100,7 @@ class JsonObjectToParticipantContextTransformerTest {
         var result = typeTransformerRegistry.transform(jsonObject, ParticipantContext.class);
 
         assertThat(result).isSucceeded().satisfies(participantContext -> {
-            assertThat(participantContext.getParticipantContextId()).isNotNull().isNotEmpty();
+            assertThat(participantContext.getId()).isNotNull().isNotEmpty();
             assertThat(participantContext.getProperties()).isEmpty();
         });
     }
@@ -115,7 +115,7 @@ class JsonObjectToParticipantContextTransformerTest {
         var result = typeTransformerRegistry.transform(jsonObject, ParticipantContext.class);
 
         assertThat(result).isSucceeded().satisfies(participantContext -> {
-            assertThat(participantContext.getParticipantContextId()).isEqualTo("participant-3");
+            assertThat(participantContext.getId()).isEqualTo("participant-3");
             assertThat(participantContext.getProperties()).isEmpty();
         });
 
@@ -149,7 +149,7 @@ class JsonObjectToParticipantContextTransformerTest {
         var result = typeTransformerRegistry.transform(jsonObject, ParticipantContext.class);
 
         assertThat(result).isSucceeded().satisfies(participantContext -> {
-            assertThat(participantContext.getParticipantContextId()).isEqualTo("participant-5");
+            assertThat(participantContext.getId()).isEqualTo("participant-5");
             assertThat(participantContext.getProperties()).containsEntry("simpleKey", "simpleValue")
                     .containsEntry("booleanKey", true);
         });

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/management/DataPlaneRegistrationApiV4Controller.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/java/org/eclipse/edc/signaling/port/api/management/DataPlaneRegistrationApiV4Controller.java
@@ -55,7 +55,7 @@ public class DataPlaneRegistrationApiV4Controller implements DataPlaneRegistrati
                         .url(registration.endpoint())
                         .allowedTransferType(registration.transferTypes())
                         .authorizationProfile(toAuthorizationProfile(registration.authorization()))
-                        .participantContextId(participantContext.getParticipantContextId())
+                        .participantContextId(participantContext.getId())
                         .labels(registration.labels())
                         .build())
                 .compose(dataPlaneSelectorService::register)

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/management/DataPlaneRegistrationApiV4ControllerTest.java
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/test/java/org/eclipse/edc/signaling/port/api/management/DataPlaneRegistrationApiV4ControllerTest.java
@@ -39,7 +39,7 @@ class DataPlaneRegistrationApiV4ControllerTest extends RestControllerTestBase {
     private final DataPlaneSelectorService dataPlaneSelectorService = mock();
 
     private final SingleParticipantContextSupplier participantContextSupplier = () ->
-            ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId("participant-context-id").identity("identity").build());
+            ServiceResult.success(ParticipantContext.Builder.newInstance().id("participant-context-id").identity("identity").build());
 
     @Override
     protected Object controller() {

--- a/data-protocols/dsp/dsp-core/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImplTest.java
+++ b/data-protocols/dsp/dsp-core/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/dispatcher/DspHttpRemoteMessageDispatcherImplTest.java
@@ -80,7 +80,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
     private final Duration timeout = Duration.of(5, SECONDS);
 
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
 
@@ -126,7 +126,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
         dispatcher.registerMessage(TestMessage.class, requestFactory, mock());
 
         var message = new TestMessage();
-        var result = dispatcher.dispatch(participantContext.getParticipantContextId(), String.class, message);
+        var result = dispatcher.dispatch(participantContext.getId(), String.class, message);
 
         assertThat(result).succeedsWithin(timeout);
 
@@ -165,7 +165,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
         dispatcher.registerMessage(TestMessage.class, requestFactory, mock());
 
         var message = new TestMessage();
-        var result = dispatcher.dispatch(participantContext.getParticipantContextId(), String.class, message);
+        var result = dispatcher.dispatch(participantContext.getId(), String.class, message);
 
         assertThat(result).succeedsWithin(timeout);
 
@@ -204,7 +204,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
         dispatcher.registerMessage(TestMessage.class, requestFactory, mock());
 
         var message = new TestMessage();
-        var result = dispatcher.dispatch(participantContext.getParticipantContextId(), String.class, message);
+        var result = dispatcher.dispatch(participantContext.getId(), String.class, message);
 
         assertThat(result).succeedsWithin(timeout);
 
@@ -226,7 +226,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
 
     @Test
     void dispatch_messageNotRegistered_throwException() {
-        assertThat(dispatcher.dispatch(participantContext.getParticipantContextId(), String.class, new TestMessage())).failsWithin(timeout)
+        assertThat(dispatcher.dispatch(participantContext.getId(), String.class, new TestMessage())).failsWithin(timeout)
                 .withThrowableThat().withCauseInstanceOf(EdcException.class).withMessageContaining("found");
 
         verifyNoInteractions(httpClient);
@@ -239,7 +239,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
         when(requestFactory.createRequest(any())).thenReturn(new Request.Builder().url("http://url").build());
         when(identityService.obtainClientCredentials(any(), any())).thenReturn(Result.failure("error"));
 
-        assertThat(dispatcher.dispatch(participantContext.getParticipantContextId(), String.class, new TestMessage())).failsWithin(timeout)
+        assertThat(dispatcher.dispatch(participantContext.getId(), String.class, new TestMessage())).failsWithin(timeout)
                 .withThrowableThat().withCauseInstanceOf(EdcException.class).withMessageContaining("credentials");
 
         verifyNoInteractions(httpClient);
@@ -251,7 +251,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
         when(audienceResolver.resolve(any())).thenReturn(Result.failure("audience fetch failure"));
         when(requestFactory.createRequest(any())).thenReturn(new Request.Builder().url("http://url").build());
 
-        assertThat(dispatcher.dispatch(participantContext.getParticipantContextId(), String.class, new TestMessage())).failsWithin(timeout)
+        assertThat(dispatcher.dispatch(participantContext.getId(), String.class, new TestMessage())).failsWithin(timeout)
                 .withThrowableThat().withCauseInstanceOf(EdcException.class).withMessageContaining("audience fetch failure");
 
         verifyNoInteractions(httpClient);
@@ -266,7 +266,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
                 .thenReturn(Result.success(TokenRepresentation.Builder.newInstance().token("any").build()));
         dispatcher.registerMessage(TestMessage.class, requestFactory, mock());
 
-        var result = dispatcher.dispatch(participantContext.getParticipantContextId(), String.class, new TestMessage());
+        var result = dispatcher.dispatch(participantContext.getId(), String.class, new TestMessage());
 
         assertThat(result).succeedsWithin(timeout);
         verifyNoInteractions(policyEngine);
@@ -296,7 +296,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
         dispatcher.registerMessage(CatalogRequestMessage.class, rqFactory, mock());
 
         var message = CatalogRequestMessage.Builder.newInstance().additionalScopes("scope1", "scope2").build();
-        var result = dispatcher.dispatch(participantContext.getParticipantContextId(), String.class, message);
+        var result = dispatcher.dispatch(participantContext.getId(), String.class, message);
 
         assertThat(result).succeedsWithin(timeout);
 
@@ -331,7 +331,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
         dispatcher.registerMessage(TestMessage.class, requestFactory, mock());
         dispatcher.registerPolicyScope(TestMessage.class, m -> policy, TestPolicyContext::new);
 
-        var result = dispatcher.dispatch(participantContext.getParticipantContextId(), String.class, new TestMessage());
+        var result = dispatcher.dispatch(participantContext.getId(), String.class, new TestMessage());
 
         var captor = ArgumentCaptor.forClass(TokenParameters.class);
         verify(identityService).obtainClientCredentials(any(), captor.capture());
@@ -374,7 +374,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
             respondWith(dummyResponse(200), bodyExtractor);
             when(bodyExtractor.extractBody(any(), any())).thenReturn("response");
 
-            var future = dispatcher.dispatch(participantContext.getParticipantContextId(), String.class, new TestMessage());
+            var future = dispatcher.dispatch(participantContext.getId(), String.class, new TestMessage());
 
             assertThat(future).succeedsWithin(timeout).satisfies(result -> {
                 assertThat(result).isSucceeded().isEqualTo("response");
@@ -386,7 +386,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
             var responseBody = ResponseBody.create("expectedValue", MediaType.get("application/json"));
             respondWith(dummyResponseBuilder(400).body(responseBody).build(), bodyExtractor);
 
-            var future = dispatcher.dispatch(participantContext.getParticipantContextId(), String.class, new TestMessage());
+            var future = dispatcher.dispatch(participantContext.getId(), String.class, new TestMessage());
 
             assertThat(future).succeedsWithin(timeout).satisfies(result -> {
                 assertThat(result).isFailed().satisfies(failure -> {
@@ -401,7 +401,7 @@ class DspHttpRemoteMessageDispatcherImplTest {
         void shouldReturnRetryError_whenResponseIsServerError() {
             respondWith(dummyResponse(500), bodyExtractor);
 
-            var future = dispatcher.dispatch(participantContext.getParticipantContextId(), String.class, new TestMessage());
+            var future = dispatcher.dispatch(participantContext.getId(), String.class, new TestMessage());
 
             assertThat(future).succeedsWithin(timeout).satisfies(result -> {
                 assertThat(result).isFailed().satisfies(failure -> {

--- a/data-protocols/dsp/dsp-core/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/message/DspRequestHandlerImplTest.java
+++ b/data-protocols/dsp/dsp-core/dsp-http-core/src/test/java/org/eclipse/edc/protocol/dsp/http/message/DspRequestHandlerImplTest.java
@@ -68,7 +68,7 @@ class DspRequestHandlerImplTest {
     private final DspRequestHandlerImpl handler = new DspRequestHandlerImpl(mock(), validatorRegistry, dspTransformerRegistry);
     private final String protocol = DATASPACE_PROTOCOL_HTTP;
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
     private final ParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);

--- a/data-protocols/dsp/dsp-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiControllerTestBase.java
+++ b/data-protocols/dsp/dsp-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/catalog/http/api/controller/DspCatalogApiControllerTestBase.java
@@ -68,7 +68,7 @@ public abstract class DspCatalogApiControllerTestBase extends RestControllerTest
     protected final DspRequestHandler dspRequestHandler = mock();
     protected final ContinuationTokenManager continuationTokenManager = mock();
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
     protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);

--- a/data-protocols/dsp/dsp-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiControllerTestBase.java
+++ b/data-protocols/dsp/dsp-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/controller/DspNegotiationApiControllerTestBase.java
@@ -74,7 +74,7 @@ public abstract class DspNegotiationApiControllerTestBase extends RestController
     protected final ContractNegotiationProtocolService protocolService = mock();
     protected final DspRequestHandler dspRequestHandler = mock();
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
     protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);

--- a/data-protocols/dsp/dsp-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiControllerBaseTest.java
+++ b/data-protocols/dsp/dsp-lib/src/testFixtures/java/org/eclipse/edc/protocol/dsp/transferprocess/http/api/controller/DspTransferProcessApiControllerBaseTest.java
@@ -72,7 +72,7 @@ public abstract class DspTransferProcessApiControllerBaseTest extends RestContro
     protected final TransferProcessProtocolService protocolService = mock();
     protected final DspRequestHandler dspRequestHandler = mock();
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
     protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);

--- a/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-catalog-http-api-2025-virtual/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-catalog-http-api-2025-virtual/src/test/java/org/eclipse/edc/protocol/dsp/catalog/http/api/v2025/controller/DspCatalogApiControllerV20251Test.java
@@ -45,21 +45,21 @@ public class DspCatalogApiControllerV20251Test extends DspCatalogApiControllerTe
     private final ParticipantContextService participantContextService = mock();
     private final ParticipantProfileService profileResolver = mock();
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("identity")
             .build();
 
     @BeforeEach
     void setUp() {
-        when(participantContextService.getParticipantContext(participantContext.getParticipantContextId()))
+        when(participantContextService.getParticipantContext(participantContext.getId()))
                 .thenReturn(ServiceResult.success(participantContext));
-        when(profileResolver.resolve(participantContext.getParticipantContextId(), PROFILE_ID))
+        when(profileResolver.resolve(participantContext.getId(), PROFILE_ID))
                 .thenReturn(PROFILE);
     }
 
     @Override
     protected String basePath() {
-        return "/%s/%s".formatted(participantContext.getParticipantContextId(), PROFILE_ID) + BASE_PATH;
+        return "/%s/%s".formatted(participantContext.getId(), PROFILE_ID) + BASE_PATH;
     }
 
     @Override

--- a/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-negotiation-http-api-2025-virtual/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-negotiation-http-api-2025-virtual/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspNegotiationApiControllerV20251Test.java
@@ -47,21 +47,21 @@ class DspNegotiationApiControllerV20251Test extends DspNegotiationApiControllerT
     private final ParticipantContextService participantContextService = mock();
     private final ParticipantProfileService profileResolver = mock();
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("identity")
             .build();
 
     @BeforeEach
     void setUp() {
-        when(participantContextService.getParticipantContext(participantContext.getParticipantContextId()))
+        when(participantContextService.getParticipantContext(participantContext.getId()))
                 .thenReturn(ServiceResult.success(participantContext));
-        when(profileResolver.resolve(participantContext.getParticipantContextId(), PROFILE_ID))
+        when(profileResolver.resolve(participantContext.getId(), PROFILE_ID))
                 .thenReturn(PROFILE);
     }
 
     @Override
     protected String basePath() {
-        return "/%s/%s".formatted(participantContext.getParticipantContextId(), PROFILE_ID) + BASE_PATH;
+        return "/%s/%s".formatted(participantContext.getId(), PROFILE_ID) + BASE_PATH;
     }
 
     @Override

--- a/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-transfer-process-http-api-2025-virtual/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspTransferProcessApiControllerV20251Test.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-2025-virtual/dsp-transfer-process-http-api-2025-virtual/src/test/java/org/eclipse/edc/protocol/dsp/negotiation/http/api/v2025/controller/DspTransferProcessApiControllerV20251Test.java
@@ -45,21 +45,21 @@ class DspTransferProcessApiControllerV20251Test extends DspTransferProcessApiCon
     private final ParticipantContextService participantContextService = mock();
     private final ParticipantProfileService profileResolver = mock();
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("identity")
             .build();
 
     @BeforeEach
     void setUp() {
-        when(participantContextService.getParticipantContext(participantContext.getParticipantContextId()))
+        when(participantContextService.getParticipantContext(participantContext.getId()))
                 .thenReturn(ServiceResult.success(participantContext));
-        when(profileResolver.resolve(participantContext.getParticipantContextId(), PROFILE_ID))
+        when(profileResolver.resolve(participantContext.getId(), PROFILE_ID))
                 .thenReturn(PROFILE);
     }
 
     @Override
     protected String basePath() {
-        return "/%s/%s".formatted(participantContext.getParticipantContextId(), PROFILE_ID) + BASE_PATH;
+        return "/%s/%s".formatted(participantContext.getId(), PROFILE_ID) + BASE_PATH;
     }
 
     @Override

--- a/data-protocols/dsp/dsp-virtual/dsp-metadata-http-api-virtual/src/test/java/org/eclipse/edc/protocol/dsp/metadata/http/api/DspVirtualMetadataApiControllerTest.java
+++ b/data-protocols/dsp/dsp-virtual/dsp-metadata-http-api-virtual/src/test/java/org/eclipse/edc/protocol/dsp/metadata/http/api/DspVirtualMetadataApiControllerTest.java
@@ -54,7 +54,7 @@ class DspVirtualMetadataApiControllerTest extends RestControllerTestBase {
 
         when(participantContextService.getParticipantContext(participantContextId))
                 .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().identity("identity")
-                        .participantContextId("participantcontextId").build()));
+                        .id("participantcontextId").build()));
         var protocolVersion = new ProtocolVersion("version", "/1.0", "binding");
 
         var profile = new DataspaceProfileContext("profileId", protocolVersion, mock(), mock(), new JsonLdNamespace("https://example.org/dspace/"), List.of("https://example.org/context.jsonld"), List.of());

--- a/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/BaseCatalogApiControllerTest.java
+++ b/extensions/control-plane/api/management-api-v5/catalog-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/BaseCatalogApiControllerTest.java
@@ -71,7 +71,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
     @BeforeEach
     void setup() {
         when(participantContextService.getParticipantContext(eq(participantContextId)))
-                .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId(participantContextId)
+                .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().id(participantContextId)
                         .identity(participantContextId).build()));
 
         when(authorizationService.authorize(any(), any(), any(), any())).thenReturn(ServiceResult.success());

--- a/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiControllerTestBase.java
+++ b/extensions/control-plane/api/management-api-v5/contract-negotiation-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/ContractNegotiationApiControllerTestBase.java
@@ -233,7 +233,7 @@ public abstract class ContractNegotiationApiControllerTestBase extends RestContr
                             .build()));
 
             when(participantContextService.getParticipantContext(any()))
-                    .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build()));
+                    .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().id(participantContextId).identity(participantContextId).build()));
             when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
             when(service.initiateNegotiation(any(ParticipantContext.class), any(ContractRequest.class))).thenReturn(ServiceResult.success(contractNegotiation));
 

--- a/extensions/control-plane/api/management-api-v5/participant-context-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/v5/ParticipantContextApiV5Controller.java
+++ b/extensions/control-plane/api/management-api-v5/participant-context-api-v5/src/main/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/v5/ParticipantContextApiV5Controller.java
@@ -75,10 +75,10 @@ public class ParticipantContextApiV5Controller implements ParticipantContextApiV
                 .orElseThrow(InvalidRequestException::new);
 
         var created = participantContextService.createParticipantContext(participantContext)
-                .orElseThrow(exceptionMapper(ParticipantContext.class, participantContext.getParticipantContextId()));
+                .orElseThrow(exceptionMapper(ParticipantContext.class, participantContext.getId()));
 
         var responseDto = IdResponse.Builder.newInstance()
-                .id(created.getParticipantContextId())
+                .id(created.getId())
                 .createdAt(created.getCreatedAt())
                 .build();
 

--- a/extensions/control-plane/api/management-api-v5/participant-context-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/ParticipantContextApiControllerTestBase.java
+++ b/extensions/control-plane/api/management-api-v5/participant-context-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/participantcontext/ParticipantContextApiControllerTestBase.java
@@ -82,7 +82,7 @@ public abstract class ParticipantContextApiControllerTestBase extends RestContro
 
     private ParticipantContext createParticipantContext() {
         return createParticipantContextBuilder()
-                .participantContextId(UUID.randomUUID().toString())
+                .id(UUID.randomUUID().toString())
                 .identity(UUID.randomUUID().toString())
                 .properties(Map.of())
                 .build();
@@ -102,13 +102,13 @@ public abstract class ParticipantContextApiControllerTestBase extends RestContro
             when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(expandedBody));
 
             baseRequest()
-                    .get("/participants/" + participantContext.getParticipantContextId())
+                    .get("/participants/" + participantContext.getId())
                     .then()
                     .statusCode(200)
                     .contentType(JSON)
                     .body("id", is("id"))
                     .body("createdAt", is(1234));
-            verify(service).getParticipantContext(participantContext.getParticipantContextId());
+            verify(service).getParticipantContext(participantContext.getId());
             verify(transformerRegistry).transform(participantContext, JsonObject.class);
         }
 
@@ -194,11 +194,11 @@ public abstract class ParticipantContextApiControllerTestBase extends RestContro
             when(service.deleteParticipantContext(any())).thenReturn(ServiceResult.success());
 
             baseRequest()
-                    .delete("/participants/" + participantContext.getParticipantContextId())
+                    .delete("/participants/" + participantContext.getId())
                     .then()
                     .statusCode(204);
 
-            verify(service).deleteParticipantContext(participantContext.getParticipantContextId());
+            verify(service).deleteParticipantContext(participantContext.getId());
         }
 
         @Test
@@ -229,7 +229,7 @@ public abstract class ParticipantContextApiControllerTestBase extends RestContro
             baseRequest()
                     .body(requestBody)
                     .contentType(JSON)
-                    .put("/participants/" + participantContext.getParticipantContextId())
+                    .put("/participants/" + participantContext.getId())
                     .then()
                     .statusCode(204);
             verify(transformerRegistry).transform(isA(JsonObject.class), eq(ParticipantContext.class));
@@ -280,7 +280,7 @@ public abstract class ParticipantContextApiControllerTestBase extends RestContro
         void create() {
             var participantContext = createParticipantContext();
             var response = Json.createObjectBuilder()
-                    .add("id", participantContext.getParticipantContextId())
+                    .add("id", participantContext.getId())
                     .add("createdAt", participantContext.getCreatedAt())
                     .build();
 
@@ -300,7 +300,7 @@ public abstract class ParticipantContextApiControllerTestBase extends RestContro
                     .then()
                     .statusCode(200)
                     .contentType(JSON)
-                    .body("id", is(participantContext.getParticipantContextId()))
+                    .body("id", is(participantContext.getId()))
                     .body("createdAt", is(participantContext.getCreatedAt()));
 
             verify(transformerRegistry).transform(isA(JsonObject.class), eq(ParticipantContext.class));

--- a/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/BaseTransferProcessApiControllerTest.java
+++ b/extensions/control-plane/api/management-api-v5/transfer-process-api-v5/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/BaseTransferProcessApiControllerTest.java
@@ -278,7 +278,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
             var transferProcess = createTransferProcess().id("id").build();
             var responseBody = Json.createObjectBuilder().add(ID, "transferProcessId").build();
             when(participantContextService.getParticipantContext(any()))
-                    .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build()));
+                    .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().id(participantContextId).identity(participantContextId).build()));
             when(transformerRegistry.transform(any(), eq(TransferRequest.class))).thenReturn(Result.success(transferRequest));
             when(service.initiateTransfer(isA(ParticipantContext.class), any())).thenReturn(ServiceResult.success(transferProcess));
             when(transformerRegistry.transform(any(), eq(JsonObject.class))).thenReturn(Result.success(responseBody));
@@ -316,7 +316,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
         void shouldReturnConflict_whenItAlreadyExists() {
             var transferRequest = TransferRequest.Builder.newInstance().build();
             when(participantContextService.getParticipantContext(any()))
-                    .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build()));
+                    .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().id(participantContextId).identity(participantContextId).build()));
             when(transformerRegistry.transform(any(), eq(TransferRequest.class))).thenReturn(Result.success(transferRequest));
             when(service.initiateTransfer(any(), any())).thenReturn(ServiceResult.conflict("already exists"));
             var requestBody = Json.createObjectBuilder().add(TYPE, TRANSFER_REQUEST_TYPE_TERM).build();

--- a/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/BaseAssetApiController.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/asset/BaseAssetApiController.java
@@ -60,7 +60,7 @@ public abstract class BaseAssetApiController {
         var asset = transformerRegistry.transform(assetJson, Asset.class)
                 .orElseThrow(InvalidRequestException::new)
                 .toBuilder()
-                .participantContextId(participantContext.getParticipantContextId())
+                .participantContextId(participantContext.getId())
                 .build();
 
         var idResponse = service.create(asset)
@@ -115,7 +115,7 @@ public abstract class BaseAssetApiController {
         var assetResult = transformerRegistry.transform(assetJson, Asset.class)
                 .orElseThrow(InvalidRequestException::new)
                 .toBuilder()
-                .participantContextId(participantContext.getParticipantContextId())
+                .participantContextId(participantContext.getId())
                 .build();
 
         service.update(assetResult)

--- a/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/BaseAssetApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/asset-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/asset/BaseAssetApiControllerTest.java
@@ -75,7 +75,7 @@ public abstract class BaseAssetApiControllerTest extends RestControllerTestBase 
     protected final TypeTransformerRegistry transformerRegistry = mock(TypeTransformerRegistry.class);
     protected final JsonObjectValidatorRegistry validator = mock(JsonObjectValidatorRegistry.class);
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
     protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);
@@ -353,7 +353,7 @@ public abstract class BaseAssetApiControllerTest extends RestControllerTestBase 
     @Test
     void updateAsset_whenExists() {
         var asset = Asset.Builder.newInstance().property("key1", "value1")
-                .participantContextId(participantContext.getParticipantContextId())
+                .participantContextId(participantContext.getId())
                 .build();
         when(transformerRegistry.transform(isA(JsonObject.class), eq(Asset.class))).thenReturn(Result.success(asset));
         when(service.update(any(Asset.class))).thenReturn(ServiceResult.success());

--- a/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/BaseCatalogApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/catalog-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/catalog/BaseCatalogApiControllerTest.java
@@ -64,7 +64,7 @@ public abstract class BaseCatalogApiControllerTest extends RestControllerTestBas
     protected final TypeTransformerRegistry transformerRegistry = mock();
     protected final JsonObjectValidatorRegistry validatorRegistry = mock();
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
     protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/BaseContractDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/BaseContractDefinitionApiController.java
@@ -90,7 +90,7 @@ public abstract class BaseContractDefinitionApiController {
         var transform = transformerRegistry.transform(createObject, ContractDefinition.class)
                 .orElseThrow(InvalidRequestException::new)
                 .toBuilder()
-                .participantContextId(participantContext.getParticipantContextId())
+                .participantContextId(participantContext.getId())
                 .build();
 
         var responseDto = service.create(transform)
@@ -118,7 +118,7 @@ public abstract class BaseContractDefinitionApiController {
         var contractDefinition = transformerRegistry.transform(updateObject, ContractDefinition.class)
                 .orElseThrow(InvalidRequestException::new)
                 .toBuilder()
-                .participantContextId(participantContext.getParticipantContextId())
+                .participantContextId(participantContext.getId())
                 .build();
 
         service.update(contractDefinition).orElseThrow(exceptionMapper(ContractDefinition.class));

--- a/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/BaseContractDefinitionApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractdefinition/BaseContractDefinitionApiControllerTest.java
@@ -68,7 +68,7 @@ public abstract class BaseContractDefinitionApiControllerTest extends RestContro
     protected final TypeTransformerRegistry transformerRegistry = mock();
     protected final JsonObjectValidatorRegistry validatorRegistry = mock();
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
     protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/contractnegotiation/BaseContractNegotiationApiControllerTest.java
@@ -72,7 +72,7 @@ public abstract class BaseContractNegotiationApiControllerTest extends RestContr
     protected final TypeTransformerRegistry transformerRegistry = mock();
     protected final JsonObjectValidatorRegistry validatorRegistry = mock();
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
     protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/BasePolicyDefinitionApiController.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/main/java/org/eclipse/edc/connector/controlplane/api/management/policy/BasePolicyDefinitionApiController.java
@@ -96,7 +96,7 @@ public abstract class BasePolicyDefinitionApiController {
         var definition = transformerRegistry.transform(request, PolicyDefinition.class)
                 .orElseThrow(InvalidRequestException::new)
                 .toBuilder()
-                .participantContextId(participantContext.getParticipantContextId())
+                .participantContextId(participantContext.getId())
                 .build();
 
         var createdDefinition = service.create(definition)
@@ -127,7 +127,7 @@ public abstract class BasePolicyDefinitionApiController {
         var policyDefinition = transformerRegistry.transform(input, PolicyDefinition.class)
                 .orElseThrow(InvalidRequestException::new)
                 .toBuilder()
-                .participantContextId(participantContext.getParticipantContextId())
+                .participantContextId(participantContext.getId())
                 .build();
 
         service.update(policyDefinition)

--- a/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/BasePolicyDefinitionApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/policy-definition-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/policy/BasePolicyDefinitionApiControllerTest.java
@@ -65,7 +65,7 @@ public abstract class BasePolicyDefinitionApiControllerTest extends RestControll
     protected final PolicyDefinitionService service = mock();
     protected final JsonObjectValidatorRegistry validatorRegistry = mock();
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
     protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);

--- a/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/BaseTransferProcessApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/transfer-process-api/src/test/java/org/eclipse/edc/connector/controlplane/api/management/transferprocess/BaseTransferProcessApiControllerTest.java
@@ -72,7 +72,7 @@ public abstract class BaseTransferProcessApiControllerTest extends RestControlle
     protected final TransferProcessService service = mock();
     protected final JsonObjectValidatorRegistry validatorRegistry = mock();
     private final ParticipantContext participantContext = ParticipantContext.Builder.newInstance()
-            .participantContextId("participantContextId")
+            .id("participantContextId")
             .identity("participantId")
             .build();
     protected final SingleParticipantContextSupplier participantContextSupplier = () -> ServiceResult.success(participantContext);

--- a/extensions/control-plane/store/sql/participantcontext-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/SqlParticipantContextStore.java
+++ b/extensions/control-plane/store/sql/participantcontext-store-sql/src/main/java/org/eclipse/edc/connector/store/sql/participantcontext/SqlParticipantContextStore.java
@@ -56,16 +56,16 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
 
     @Override
     public StoreResult<Void> create(ParticipantContext participantContext) {
-        var id = participantContext.getParticipantContextId();
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {
+                var id = participantContext.getId();
                 if (findByIdInternal(connection, id) != null) {
                     return alreadyExists(alreadyExistsErrorMessage(id));
                 }
 
                 var stmt = statements.getInsertTemplate();
                 queryExecutor.execute(connection, stmt,
-                        participantContext.getParticipantContextId(),
+                        participantContext.getId(),
                         participantContext.getIdentity(),
                         participantContext.getCreatedAt(),
                         participantContext.getLastModified(),
@@ -94,7 +94,7 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
 
     @Override
     public StoreResult<Void> update(ParticipantContext participantContext) {
-        var id = participantContext.getParticipantContextId();
+        var id = participantContext.getId();
 
         Objects.requireNonNull(participantContext);
         Objects.requireNonNull(id);
@@ -136,6 +136,22 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
         });
     }
 
+    @Override
+    public StoreResult<ParticipantContext> findById(String participantContextId) {
+        return transactionContext.execute(() -> {
+            try (var connection = getConnection()) {
+                var entity = findByIdInternal(connection, participantContextId);
+                if (entity != null) {
+                    return StoreResult.success(entity);
+                }
+
+                return StoreResult.notFound(notFoundErrorMessage(participantContextId));
+            } catch (SQLException e) {
+                throw new EdcPersistenceException(e);
+            }
+        });
+    }
+
     private ParticipantContext findByIdInternal(Connection connection, String id) {
         return transactionContext.execute(() -> {
             var stmt = statements.getFindByIdTemplate();
@@ -148,15 +164,15 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
         var participantContextId = resultSet.getString(statements.getIdColumn());
         var identity = resultSet.getString(statements.getIdentityColumn());
         var created = resultSet.getLong(statements.getCreateTimestampColumn());
-        var lastmodified = resultSet.getLong(statements.getLastModifiedTimestampColumn());
+        var lastModified = resultSet.getLong(statements.getLastModifiedTimestampColumn());
         var state = resultSet.getInt(statements.getStateColumn());
         Map<String, Object> props = fromJson(resultSet.getString(statements.getPropertiesColumn()), getTypeRef());
 
         return ParticipantContext.Builder.newInstance()
-                .participantContextId(participantContextId)
+                .id(participantContextId)
                 .identity(identity)
                 .createdAt(created)
-                .lastModified(lastmodified)
+                .lastModified(lastModified)
                 .state(ParticipantContextState.from(state))
                 .properties(props)
                 .build();

--- a/spi/core-spi/src/main/java/org/eclipse/edc/participantcontext/spi/store/ParticipantContextStore.java
+++ b/spi/core-spi/src/main/java/org/eclipse/edc/participantcontext/spi/store/ParticipantContextStore.java
@@ -20,8 +20,6 @@ import org.eclipse.edc.spi.result.StoreResult;
 
 import java.util.Collection;
 
-import static org.eclipse.edc.participantcontext.spi.types.ParticipantResource.queryByParticipantContextId;
-
 public interface ParticipantContextStore {
 
     /**
@@ -62,15 +60,7 @@ public interface ParticipantContextStore {
      * @param participantContextId The unique identifier of the ParticipantContext.
      * @return The {@link ParticipantContext} if found, otherwise null.
      */
-    default StoreResult<ParticipantContext> findById(String participantContextId) {
-        var res = query(queryByParticipantContextId(participantContextId).build());
-        if (res.succeeded()) {
-            return res.getContent().stream().findFirst()
-                           .map(StoreResult::success)
-                           .orElse(StoreResult.notFound("ParticipantContext with ID '%s' does not exist.".formatted(participantContextId)));
-        }
-        return StoreResult.generalError(res.getFailureDetail());
-    }
+    StoreResult<ParticipantContext> findById(String participantContextId);
 
     default String alreadyExistsErrorMessage(String id) {
         return "A ParticipantContext with ID '%s' already exists.".formatted(id);

--- a/spi/core-spi/src/main/java/org/eclipse/edc/participantcontext/spi/types/ParticipantContext.java
+++ b/spi/core-spi/src/main/java/org/eclipse/edc/participantcontext/spi/types/ParticipantContext.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.spi.entity.Entity;
 
 import java.time.Instant;
 import java.util.HashMap;
@@ -32,7 +33,7 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
  * Representation of a participant in Identity Hub.
  */
 @JsonDeserialize(builder = ParticipantContext.Builder.class)
-public class ParticipantContext extends AbstractParticipantResource {
+public class ParticipantContext extends Entity implements ParticipantResource {
     public static final String PARTICIPANT_CONTEXT_TYPE_TERM = "ParticipantContext";
     public static final String PARTICIPANT_CONTEXT_TYPE_IRI = EDC_NAMESPACE + PARTICIPANT_CONTEXT_TYPE_TERM;
     public static final String PARTICIPANT_CONTEXT_IDENTITY_TERM = "identity";
@@ -76,25 +77,9 @@ public class ParticipantContext extends AbstractParticipantResource {
         return ParticipantContextState.from(state);
     }
 
-    /**
-     * Updates the last-modified field.
-     */
-    public void updateLastModified() {
-        this.lastModified = Instant.now().toEpochMilli();
-    }
-
-    /**
-     * Transitions this participant context to the {@link ParticipantContextState#ACTIVATED} state.
-     */
-    public void activate() {
-        this.state = ParticipantContextState.ACTIVATED.code();
-    }
-
-    /**
-     * Transitions this participant context to the {@link ParticipantContextState#DEACTIVATED} state.
-     */
-    public void deactivate() {
-        this.state = ParticipantContextState.DEACTIVATED.code();
+    @Override
+    public String getParticipantContextId() {
+        return getId();
     }
 
     public Map<String, Object> getProperties() {
@@ -104,7 +89,6 @@ public class ParticipantContext extends AbstractParticipantResource {
     public ParticipantContext.Builder toBuilder() {
         return Builder.newInstance()
                 .id(getId())
-                .participantContextId(participantContextId)
                 .createdAt(createdAt)
                 .lastModified(lastModified)
                 .state(getStateAsEnum())
@@ -112,7 +96,7 @@ public class ParticipantContext extends AbstractParticipantResource {
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static final class Builder extends AbstractParticipantResource.Builder<ParticipantContext, Builder> {
+    public static final class Builder extends Entity.Builder<ParticipantContext, Builder> {
 
         private Builder() {
             super(new ParticipantContext());
@@ -136,7 +120,7 @@ public class ParticipantContext extends AbstractParticipantResource {
 
         @Override
         public ParticipantContext build() {
-            Objects.requireNonNull(entity.participantContextId, "Participant Context ID cannot be null");
+            Objects.requireNonNull(entity.id, "Participant Context ID cannot be null");
             Objects.requireNonNull(entity.identity, "identity cannot be null");
 
             if (entity.state == 0) {
@@ -168,5 +152,9 @@ public class ParticipantContext extends AbstractParticipantResource {
             return this;
         }
 
+        @Deprecated(since = "0.18.0")
+        public Builder participantContextId(String participantContextId) {
+            return id(participantContextId);
+        }
     }
 }

--- a/spi/core-spi/src/test/java/org/eclipse/edc/participantcontext/spi/types/ParticipantContextTest.java
+++ b/spi/core-spi/src/test/java/org/eclipse/edc/participantcontext/spi/types/ParticipantContextTest.java
@@ -28,14 +28,14 @@ class ParticipantContextTest {
     @Test
     void verifyCreateTimestamp() {
         var context = ParticipantContext.Builder.newInstance()
-                .participantContextId("test-id")
+                .id("test-id")
                 .identity("test-identity")
                 .build();
 
         assertThat(context.getCreatedAt()).isNotZero().isLessThanOrEqualTo(Instant.now().toEpochMilli());
 
         var context2 = ParticipantContext.Builder.newInstance()
-                .participantContextId("test-id")
+                .id("test-id")
                 .identity("test-identity")
                 .createdAt(42)
                 .build();
@@ -46,14 +46,14 @@ class ParticipantContextTest {
     @Test
     void verifyLastModifiedTimestamp() {
         var context = ParticipantContext.Builder.newInstance()
-                .participantContextId("test-id")
+                .id("test-id")
                 .identity("test-identity")
                 .build();
 
         assertThat(context.getLastModified()).isNotZero().isEqualTo(context.getCreatedAt());
 
         var context2 = ParticipantContext.Builder.newInstance()
-                .participantContextId("test-id")
+                .id("test-id")
                 .identity("test-identity")
                 .lastModified(42)
                 .build();
@@ -64,7 +64,7 @@ class ParticipantContextTest {
     @Test
     void verifyState() {
         var context = ParticipantContext.Builder.newInstance()
-                .participantContextId("test-id")
+                .id("test-id")
                 .identity("test-identity")
                 .state(CREATED);
 

--- a/spi/core-spi/src/testFixtures/java/org/eclipse/edc/participantcontext/spi/store/ParticipantContextStoreTestBase.java
+++ b/spi/core-spi/src/testFixtures/java/org/eclipse/edc/participantcontext/spi/store/ParticipantContextStoreTestBase.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.participantcontext.spi.store;
 import org.eclipse.edc.participantcontext.spi.types.ParticipantContext;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.StoreFailure;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -24,7 +25,7 @@ import java.util.Map;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
-import static org.eclipse.edc.participantcontext.spi.types.ParticipantResource.queryByParticipantContextId;
+import static org.eclipse.edc.spi.result.StoreFailure.Reason.NOT_FOUND;
 
 public abstract class ParticipantContextStoreTestBase {
 
@@ -57,11 +58,10 @@ public abstract class ParticipantContextStoreTestBase {
                 .mapToObj(i -> createParticipantContext("id" + i))
                 .forEach(getStore()::create);
 
-        var query = queryByParticipantContextId("id2")
-                .build();
+        var result = getStore().findById("id2");
 
-        assertThat(getStore().query(query)).isSucceeded()
-                .satisfies(str -> assertThat(str).hasSize(1));
+        assertThat(result).isSucceeded()
+                .satisfies(str -> assertThat(str.getId()).isEqualTo("id2"));
     }
 
     @Test
@@ -105,11 +105,9 @@ public abstract class ParticipantContextStoreTestBase {
 
         resources.forEach(getStore()::create);
 
-        var query = queryByParticipantContextId("id7")
-                .build();
-        var res = getStore().query(query);
-        assertThat(res).isSucceeded();
-        assertThat(res.getContent()).isEmpty();
+        var res = getStore().findById("id7");
+
+        assertThat(res).isFailed().extracting(StoreFailure::getReason).isEqualTo(NOT_FOUND);
     }
 
     @Test
@@ -135,13 +133,13 @@ public abstract class ParticipantContextStoreTestBase {
         var result = getStore().create(participantContext);
         assertThat(result).isSucceeded();
 
-        var toUpdate = createParticipantContextBuilder(participantContext.getParticipantContextId(), participantContext.getIdentity())
+        var toUpdate = createParticipantContextBuilder(participantContext.getId(), participantContext.getIdentity())
                 .properties(Map.of("new-key", "new-value"))
                 .build();
         var updateRes = getStore().update(toUpdate);
         assertThat(updateRes).isSucceeded();
 
-        var storeResult = getStore().findById(participantContext.getParticipantContextId());
+        var storeResult = getStore().findById(participantContext.getId());
         assertThat(storeResult).isSucceeded();
 
         assertThat(storeResult.getContent().getProperties()).containsEntry("new-key", "new-value");
@@ -160,7 +158,7 @@ public abstract class ParticipantContextStoreTestBase {
         var context = createParticipantContext();
         getStore().create(context);
 
-        var deleteRes = getStore().deleteById(context.getParticipantContextId());
+        var deleteRes = getStore().deleteById(context.getId());
         assertThat(deleteRes).isSucceeded();
     }
 
@@ -183,7 +181,7 @@ public abstract class ParticipantContextStoreTestBase {
     }
 
     private ParticipantContext.Builder createParticipantContextBuilder(String id, String identifier) {
-        return ParticipantContext.Builder.newInstance().participantContextId(id).identity(identifier);
+        return ParticipantContext.Builder.newInstance().id(id).identity(identifier);
 
     }
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CatalogApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CatalogApiV5EndToEndTest.java
@@ -96,7 +96,7 @@ public class CatalogApiV5EndToEndTest {
                     .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
 
             for (var p : list) {
-                participantContextService.deleteParticipantContext(p.getParticipantContextId()).orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+                participantContextService.deleteParticipantContext(p.getId()).orElseThrow(f -> new AssertionError(f.getFailureDetail()));
             }
 
             dataPlaneInstanceStore.getAll().toList().forEach(dp -> dataPlaneInstanceStore.deleteById(dp.getId()));
@@ -660,7 +660,7 @@ public class CatalogApiV5EndToEndTest {
         private void createParticipant(ParticipantContextService participantContextService,
                                        ParticipantContextConfigStore configStore, String participantContextId) {
             var pc = ParticipantContext.Builder.newInstance()
-                    .participantContextId(participantContextId)
+                    .id(participantContextId)
                     .state(ParticipantContextState.ACTIVATED)
                     .identity(participantContextId)
                     .build();

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CatalogApiV5MultiProfileEndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/CatalogApiV5MultiProfileEndToEndTest.java
@@ -94,7 +94,7 @@ public class CatalogApiV5MultiProfileEndToEndTest {
                     .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
 
             for (var p : list) {
-                participantContextService.deleteParticipantContext(p.getParticipantContextId()).orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+                participantContextService.deleteParticipantContext(p.getId()).orElseThrow(f -> new AssertionError(f.getFailureDetail()));
             }
         }
 
@@ -193,7 +193,7 @@ public class CatalogApiV5MultiProfileEndToEndTest {
         private void createParticipant(ParticipantContextService participantContextService,
                                        ParticipantContextConfigStore configStore, String participantContextId, List<String> profiles) {
             var pc = ParticipantContext.Builder.newInstance()
-                    .participantContextId(participantContextId)
+                    .id(participantContextId)
                     .state(ParticipantContextState.ACTIVATED)
                     .identity(participantContextId)
                     .build();

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/DataspaceProfileContextApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/DataspaceProfileContextApiV5EndToEndTest.java
@@ -53,7 +53,7 @@ public class DataspaceProfileContextApiV5EndToEndTest {
         @AfterEach
         void tearDown(ParticipantContextService pcService) {
             pcService.search(QuerySpec.max()).getContent()
-                    .forEach(pc -> pcService.deleteParticipantContext(pc.getParticipantContextId()).getContent());
+                    .forEach(pc -> pcService.deleteParticipantContext(pc.getId()).getContent());
 
         }
 
@@ -61,7 +61,7 @@ public class DataspaceProfileContextApiV5EndToEndTest {
         void getProfiles(ManagementEndToEndV5TestContext context, OauthServer authServer, ParticipantContextService service) {
             var participantContextId = "test-user";
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build());
+            service.createParticipantContext(ParticipantContext.Builder.newInstance().id(participantContextId).identity(participantContextId).build());
 
             var token = authServer.createToken(participantContextId);
 
@@ -86,7 +86,7 @@ public class DataspaceProfileContextApiV5EndToEndTest {
         void getProfiles_withProvisioner(ManagementEndToEndV5TestContext context, OauthServer authServer, ParticipantContextService service) {
             var participantContextId = "test-user";
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build());
+            service.createParticipantContext(ParticipantContext.Builder.newInstance().id(participantContextId).identity(participantContextId).build());
 
             var token = authServer.createAdminToken();
 
@@ -103,7 +103,7 @@ public class DataspaceProfileContextApiV5EndToEndTest {
         void getProfiles_withAdmin(ManagementEndToEndV5TestContext context, OauthServer authServer, ParticipantContextService service) {
             var participantContextId = "test-user";
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build());
+            service.createParticipantContext(ParticipantContext.Builder.newInstance().id(participantContextId).identity(participantContextId).build());
 
             var token = authServer.createAdminToken();
 
@@ -123,7 +123,7 @@ public class DataspaceProfileContextApiV5EndToEndTest {
 
             var participantContextId = "test-user";
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build());
+            service.createParticipantContext(ParticipantContext.Builder.newInstance().id(participantContextId).identity(participantContextId).build());
 
             var otherParticipantId = UUID.randomUUID().toString();
 
@@ -142,7 +142,7 @@ public class DataspaceProfileContextApiV5EndToEndTest {
         void associateProfiles(ManagementEndToEndV5TestContext context, OauthServer authServer, ParticipantContextService service) {
             var participantContextId = "test-user";
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build());
+            service.createParticipantContext(ParticipantContext.Builder.newInstance().id(participantContextId).identity(participantContextId).build());
 
             var token = authServer.createAdminToken();
 
@@ -161,7 +161,7 @@ public class DataspaceProfileContextApiV5EndToEndTest {
         void associateProfiles_validationFails(ManagementEndToEndV5TestContext context, OauthServer authServer, ParticipantContextService service) {
             var participantContextId = "test-user";
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build());
+            service.createParticipantContext(ParticipantContext.Builder.newInstance().id(participantContextId).identity(participantContextId).build());
 
             var token = authServer.createAdminToken();
 
@@ -184,7 +184,7 @@ public class DataspaceProfileContextApiV5EndToEndTest {
         void associateProfiles_profileNotValid(ManagementEndToEndV5TestContext context, OauthServer authServer, ParticipantContextService service) {
             var participantContextId = "test-user";
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build());
+            service.createParticipantContext(ParticipantContext.Builder.newInstance().id(participantContextId).identity(participantContextId).build());
 
             var token = authServer.createAdminToken();
 
@@ -204,7 +204,7 @@ public class DataspaceProfileContextApiV5EndToEndTest {
         void associateProfiles_tokenBearerWrong(ManagementEndToEndV5TestContext context, OauthServer authServer, ParticipantContextService service) {
             var participantContextId = "test-user";
 
-            service.createParticipantContext(ParticipantContext.Builder.newInstance().participantContextId(participantContextId).identity(participantContextId).build());
+            service.createParticipantContext(ParticipantContext.Builder.newInstance().id(participantContextId).identity(participantContextId).build());
 
             var token = authServer.createToken(participantContextId);
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/DcpScopeApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/DcpScopeApiV5EndToEndTest.java
@@ -74,7 +74,7 @@ public class DcpScopeApiV5EndToEndTest {
                     .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
 
             for (var p : list) {
-                participantContextService.deleteParticipantContext(p.getParticipantContextId()).orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+                participantContextService.deleteParticipantContext(p.getId()).orElseThrow(f -> new AssertionError(f.getFailureDetail()));
             }
             registry.query(QuerySpec.max()).getContent()
                     .forEach(scope -> registry.remove(scope.getId()).getContent());

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/DiscoveryApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/DiscoveryApiV5EndToEndTest.java
@@ -67,7 +67,7 @@ public class DiscoveryApiV5EndToEndTest {
                     .orElseThrow(f -> new AssertionError(f.getFailureDetail()));
 
             for (var p : list) {
-                participantContextService.deleteParticipantContext(p.getParticipantContextId()).orElseThrow(f -> new AssertionError(f.getFailureDetail()));
+                participantContextService.deleteParticipantContext(p.getId()).orElseThrow(f -> new AssertionError(f.getFailureDetail()));
             }
         }
 
@@ -132,7 +132,7 @@ public class DiscoveryApiV5EndToEndTest {
         private void createParticipant(ParticipantContextService participantContextService,
                                        ParticipantContextConfigStore configStore, String participantContextId, List<String> profiles) {
             var pc = ParticipantContext.Builder.newInstance()
-                    .participantContextId(participantContextId)
+                    .id(participantContextId)
                     .state(ParticipantContextState.ACTIVATED)
                     .identity(participantContextId)
                     .build();

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/ParticipantContextApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/ParticipantContextApiV5EndToEndTest.java
@@ -54,7 +54,7 @@ public class ParticipantContextApiV5EndToEndTest {
         @AfterEach
         void tearDown(ParticipantContextService pcService) {
             pcService.search(QuerySpec.max()).getContent()
-                    .forEach(pc -> pcService.deleteParticipantContext(pc.getParticipantContextId()).getContent());
+                    .forEach(pc -> pcService.deleteParticipantContext(pc.getId()).getContent());
 
         }
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/ParticipantContextConfigApiV5EndToEndTest.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/ParticipantContextConfigApiV5EndToEndTest.java
@@ -53,7 +53,7 @@ public class ParticipantContextConfigApiV5EndToEndTest {
         @AfterEach
         void tearDown(ParticipantContextService pcService) {
             pcService.search(QuerySpec.max()).getContent()
-                    .forEach(pc -> pcService.deleteParticipantContext(pc.getParticipantContextId()).getContent());
+                    .forEach(pc -> pcService.deleteParticipantContext(pc.getId()).getContent());
 
         }
 

--- a/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/TestFunction.java
+++ b/system-tests/management-api/management-api-test-runner/src/test/java/org/eclipse/edc/test/e2e/managementapi/v5/TestFunction.java
@@ -50,7 +50,7 @@ public class TestFunction {
 
     public static ParticipantContext participantContext(String participantContextId, String identity, Map<String, Object> properties) {
         return ParticipantContext.Builder.newInstance()
-                .participantContextId(participantContextId)
+                .id(participantContextId)
                 .properties(properties)
                 .identity(identity)
                 .state(ParticipantContextState.ACTIVATED)

--- a/system-tests/tck/tasks-tck-extension/src/main/java/org/eclipse/edc/tasks/tck/dsp/setup/TckSetupExtension.java
+++ b/system-tests/tck/tasks-tck-extension/src/main/java/org/eclipse/edc/tasks/tck/dsp/setup/TckSetupExtension.java
@@ -80,7 +80,7 @@ public class TckSetupExtension implements ServiceExtension {
         createContractNegotiations(participantContextId).forEach(negotiation -> contractNegotiationStore.save(negotiation));
 
         participantContextService.createParticipantContext(ParticipantContext.Builder.newInstance()
-                        .participantContextId(participantContextId)
+                        .id(participantContextId)
                         .identity(participantContextId)
                         .build())
                 .onFailure(f -> monitor.warning("Failed to create ParticipantContext"));


### PR DESCRIPTION
## What this PR changes/adds

Replace `AbstractParticipantResource` with `Entity` as superclass of `ParticipantContext`.
Put deprecated get and builder methods for `participantContextId` for downstreams.
Switch all usages of `participantContextId` to `id`.

EDIT: I had to add `ParticipantResource` as super-interface, as `ParticipantContext` is used for management api authorization.

## Why it does that

simplification

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5963 

_Please be sure to take a look at the [contributing guidelines](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/#submitting-a-pull-request) and our [etiquette for pull requests](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/pr-etiquette/)._
