### PR TITLE
docs(auth-delegated): removed superfluous setting context for audience setting

### DIFF
--- a/extensions/common/auth/auth-delegated/src/main/java/org/eclipse/edc/api/auth/delegated/DelegatedAuthenticationExtension.java
+++ b/extensions/common/auth/auth-delegated/src/main/java/org/eclipse/edc/api/auth/delegated/DelegatedAuthenticationExtension.java
@@ -10,6 +10,7 @@
  *  Contributors:
  *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
  *       Dawex Systems - Add audience validation
+ *       Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V. - improvements to the documentation
  *
  */
 
@@ -61,7 +62,7 @@ public class DelegatedAuthenticationExtension implements ServiceExtension {
     public String participantId;
     @Setting(description = "Default token validation time tolerance (in ms), e.g. for nbf or exp claims", defaultValue = "" + DEFAULT_VALIDATION_TOLERANCE, key = "edc.api.auth.dac.validation.tolerance")
     private int validationTolerance;
-    @Setting(context = CONFIG_ALIAS, description = "Expected audience in the token received by the api management", key = "web.http.management." + AUTH_KEY + "." + AUDIENCE_KEY, required = false)
+    @Setting(description = "Expected audience in the token received by the api management", key = "web.http.management." + AUTH_KEY + "." + AUDIENCE_KEY, required = false)
     private String audience;
     @Inject
     private ApiAuthenticationProviderRegistry providerRegistry;


### PR DESCRIPTION
## What this PR changes/adds

This PR removes the superfluous setting context for the audience setting (`web.http.management.auth.dac.audience`) in the `auth-delegated` module.

## Why it does that

Setting `web.http.management.auth.dac.audience` was rendered incorrectly by autodoc. See #5952

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

@ndr-brt 


## Linked Issue(s)

Closes #5952

_Please be sure to take a look at the [contributing guidelines](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/#submitting-a-pull-request) and our [etiquette for pull requests](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/pr-etiquette/)._
