### PR TITLE
feat: allow to pass extensibleProperties and profiles from Consumer to Provider during Negotiation

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/contractnegotiation/ContractNegotiationProtocolServiceImpl.java
@@ -245,7 +245,19 @@ public class ContractNegotiationProtocolServiceImpl implements ContractNegotiati
         var result = consumerOfferResolver.resolveOffer(offerId);
 
         if (result.succeeded() && participantContext.getId().equals(result.getContent().getContractDefinition().getParticipantContextId())) {
-            return result;
+            ValidatableConsumerOffer.Builder offer_builder = ValidatableConsumerOffer.Builder.newInstance();
+
+            Policy contractPolicy = result.getContent().getContractPolicy().toBuilder()
+                    .extensibleProperties(message.getPolicy().getExtensibleProperties())
+                    .profiles(message.getPolicy().getProfiles())
+                    .build();
+
+            offer_builder.offerId(result.getContent().getOfferId());
+            offer_builder.contractDefinition(result.getContent().getContractDefinition());
+            offer_builder.contractPolicy(contractPolicy);
+            offer_builder.accessPolicy(result.getContent().getAccessPolicy());
+
+            return ServiceResult.success(offer_builder.build());
         }
 
         if (result.failed()) {

--- a/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/policy/PolicyEquality.java
+++ b/core/control-plane/control-plane-contract/src/main/java/org/eclipse/edc/connector/controlplane/contract/policy/PolicyEquality.java
@@ -24,7 +24,7 @@ import java.util.function.BiPredicate;
 
 public class PolicyEquality implements BiPredicate<Policy, Policy> {
 
-    private static final List<String> EXCLUDED_PROPERTIES = List.of("@type", "assignee", "target");
+    private static final List<String> EXCLUDED_PROPERTIES = List.of("@type", "assignee", "target", "extensibleProperties", "profiles");
     private final ObjectMapper mapper;
 
     public PolicyEquality(TypeManager typeManager) {

--- a/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
+++ b/core/control-plane/control-plane-transform/src/main/java/org/eclipse/edc/connector/controlplane/transform/odrl/from/JsonObjectFromPolicyTransformer.java
@@ -65,6 +65,7 @@ import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PERMISSION_AT
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_AGREEMENT;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_OFFER;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_POLICY_TYPE_SET;
+import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_EXTENSIBLE_PROPERTIES_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROFILE_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_PROHIBITION_ATTRIBUTE;
 import static org.eclipse.edc.jsonld.spi.PropertyAndTypeNames.ODRL_REFINEMENT_ATTRIBUTE;
@@ -194,6 +195,14 @@ public class JsonObjectFromPolicyTransformer extends AbstractJsonLdTransformer<P
                             ODRL_TARGET_ATTRIBUTE,
                             jsonFactory.createArrayBuilder().add(jsonFactory.createObjectBuilder().add(ID, target)))
                     );
+
+            Optional.ofNullable(policy.getExtensibleProperties()).ifPresent(properties -> {
+                JsonObjectBuilder extensibleProperties = jsonFactory.createObjectBuilder();
+
+                properties.forEach((key, value) -> extensibleProperties.add(key, toJsonValue(value)));
+
+                builder.add(ODRL_EXTENSIBLE_PROPERTIES_ATTRIBUTE, extensibleProperties);
+            });
 
             if (!policy.getProfiles().isEmpty()) {
                 var profiles = jsonFactory.createArrayBuilder();

--- a/spi/core-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
+++ b/spi/core-spi/src/main/java/org/eclipse/edc/jsonld/spi/PropertyAndTypeNames.java
@@ -72,6 +72,7 @@ public interface PropertyAndTypeNames {
     String ODRL_XONE_CONSTRAINT_ATTRIBUTE = ODRL_SCHEMA + "xone";
     String ODRL_USE_ACTION_ATTRIBUTE = ODRL_SCHEMA + "use";
     String ODRL_PROFILE_ATTRIBUTE = ODRL_SCHEMA + "profile";
+    String ODRL_EXTENSIBLE_PROPERTIES_ATTRIBUTE = ODRL_SCHEMA + "extensibleProperties";
     String DSPACE_PROPERTY_PARTICIPANT_ID_TERM = "participantId";
     // ref: https://www.w3.org/ns/odrl.jsonld
     String ODRL_PREFIX = "odrl";


### PR DESCRIPTION

## What this PR changes/adds

- Ignore `extensibleProperties` and `profiles` fields in PolicyEquality
- add extensibleProperties serialisation in JsonObjectFromPolicyTransformer
- create the validatable offer policy with `extensibleProperties` and `profiles` merged with consumer

## Linked Issue(s)

Closes #5966
