### PR TITLE
fix: jwt validator cors preflight

### DIFF
--- a/core/common/lib/core-lib/src/main/java/org/eclipse/edc/api/authentication/filter/JwtValidatorFilter.java
+++ b/core/common/lib/core-lib/src/main/java/org/eclipse/edc/api/authentication/filter/JwtValidatorFilter.java
@@ -26,8 +26,8 @@ import org.eclipse.edc.token.spi.TokenValidationService;
 
 import java.util.List;
 
-import static org.eclipse.edc.api.authentication.filter.Constants.REQUEST_PROPERTY_CLAIMS;
 import static jakarta.ws.rs.HttpMethod.OPTIONS;
+import static org.eclipse.edc.api.authentication.filter.Constants.REQUEST_PROPERTY_CLAIMS;
 
 /**
  * Validates the JWT signature against the IdP's public key and validates basic claims, such as {@code iss} and {@code exp}.
@@ -53,8 +53,8 @@ public class JwtValidatorFilter implements ContainerRequestFilter {
         if (!OPTIONS.equalsIgnoreCase(requestContext.getMethod())) {
             var authHeader = requestContext.getHeaderString("Authorization");
             if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-              abort(requestContext, "Missing Authorization header");
-              return;
+                abort(requestContext, "Missing Authorization header");
+                return;
             }
 
             var token = authHeader.substring("Bearer ".length()).trim();
@@ -62,8 +62,8 @@ public class JwtValidatorFilter implements ContainerRequestFilter {
             var tokenValidationResult = tokenValidationService.validate(token, publicKeyResolver, rules);
 
             if (tokenValidationResult.failed()) {
-              abort(requestContext, tokenValidationResult.getFailureDetail());
-              return;
+                abort(requestContext, tokenValidationResult.getFailureDetail());
+                return;
             }
 
             requestContext.setProperty(REQUEST_PROPERTY_CLAIMS, tokenValidationResult.getContent());

--- a/core/common/lib/core-lib/src/main/java/org/eclipse/edc/api/authentication/filter/JwtValidatorFilter.java
+++ b/core/common/lib/core-lib/src/main/java/org/eclipse/edc/api/authentication/filter/JwtValidatorFilter.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.token.spi.TokenValidationService;
 import java.util.List;
 
 import static org.eclipse.edc.api.authentication.filter.Constants.REQUEST_PROPERTY_CLAIMS;
+import static jakarta.ws.rs.HttpMethod.OPTIONS;
 
 /**
  * Validates the JWT signature against the IdP's public key and validates basic claims, such as {@code iss} and {@code exp}.
@@ -48,22 +49,25 @@ public class JwtValidatorFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
-        var authHeader = requestContext.getHeaderString("Authorization");
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            abort(requestContext, "Missing Authorization header");
-            return;
+        // OPTIONS requests don't have credentials - do not authenticate
+        if (!OPTIONS.equalsIgnoreCase(requestContext.getMethod())) {
+            var authHeader = requestContext.getHeaderString("Authorization");
+            if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+              abort(requestContext, "Missing Authorization header");
+              return;
+            }
+
+            var token = authHeader.substring("Bearer ".length()).trim();
+
+            var tokenValidationResult = tokenValidationService.validate(token, publicKeyResolver, rules);
+
+            if (tokenValidationResult.failed()) {
+              abort(requestContext, tokenValidationResult.getFailureDetail());
+              return;
+            }
+
+            requestContext.setProperty(REQUEST_PROPERTY_CLAIMS, tokenValidationResult.getContent());
         }
-
-        var token = authHeader.substring("Bearer ".length()).trim();
-
-        var tokenValidationResult = tokenValidationService.validate(token, publicKeyResolver, rules);
-
-        if (tokenValidationResult.failed()) {
-            abort(requestContext, tokenValidationResult.getFailureDetail());
-            return;
-        }
-
-        requestContext.setProperty(REQUEST_PROPERTY_CLAIMS, tokenValidationResult.getContent());
     }
 
 

--- a/core/common/lib/core-lib/src/test/java/org/eclipse/edc/api/authentication/filter/JwtValidatorFilterTest.java
+++ b/core/common/lib/core-lib/src/test/java/org/eclipse/edc/api/authentication/filter/JwtValidatorFilterTest.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -42,6 +43,7 @@ class JwtValidatorFilterTest {
     @Test
     void filter_success_setsClaimsProperty() {
         var request = mock(ContainerRequestContext.class);
+        when(request.getMethod()).thenReturn("GET");
         when(request.getHeaderString("Authorization")).thenReturn("Bearer valid-token");
 
         var claims = ClaimToken.Builder.newInstance().build();
@@ -51,6 +53,7 @@ class JwtValidatorFilterTest {
 
         filter.filter(request);
 
+        verify(request).getMethod();
         verify(request).getHeaderString("Authorization");
         verify(request).setProperty(REQUEST_PROPERTY_CLAIMS, claims);
         verifyNoMoreInteractions(request);
@@ -59,10 +62,12 @@ class JwtValidatorFilterTest {
     @Test
     void filter_missingAuthorizationHeader_abortsWith401() {
         var request = mock(ContainerRequestContext.class);
+        when(request.getMethod()).thenReturn("GET");
         when(request.getHeaderString("Authorization")).thenReturn(null);
 
         filter.filter(request);
 
+        verify(request).getMethod();
         verify(request).getHeaderString("Authorization");
         verify(request).abortWith(argThat(response ->
                 response.getStatus() == Response.Status.UNAUTHORIZED.getStatusCode() &&
@@ -74,10 +79,12 @@ class JwtValidatorFilterTest {
     @Test
     void filter_nonBearerAuthorization_abortsWith401() {
         var request = mock(ContainerRequestContext.class);
+        when(request.getMethod()).thenReturn("GET");
         when(request.getHeaderString("Authorization")).thenReturn("Basic abc");
 
         filter.filter(request);
 
+        verify(request).getMethod();
         verify(request).getHeaderString("Authorization");
         verify(request).abortWith(argThat(response ->
                 response.getStatus() == Response.Status.UNAUTHORIZED.getStatusCode() &&
@@ -89,6 +96,7 @@ class JwtValidatorFilterTest {
     @Test
     void filter_tokenValidationFailed_abortsWithFailureDetail() {
         var request = mock(ContainerRequestContext.class);
+        when(request.getMethod()).thenReturn("GET");
         when(request.getHeaderString("Authorization")).thenReturn("Bearer bad-token");
 
         when(tokenValidationService.validate(eq("bad-token"), any(), anyList()))
@@ -96,11 +104,24 @@ class JwtValidatorFilterTest {
 
         filter.filter(request);
 
+        verify(request).getMethod();
         verify(request).getHeaderString("Authorization");
         verify(request).abortWith(argThat(response ->
                 response.getStatus() == Response.Status.UNAUTHORIZED.getStatusCode() &&
                         response.getEntity() instanceof String &&
                         ((String) response.getEntity()).contains("invalid token")));
         verifyNoMoreInteractions(request);
+    }
+
+    @Test
+    void filter_optionsMethod_skipsAuthentication() {
+        var request = mock(ContainerRequestContext.class);
+        when(request.getMethod()).thenReturn("options");
+
+        filter.filter(request);
+
+        verify(request).getMethod();
+        verifyNoMoreInteractions(request);
+        verifyNoInteractions(tokenValidationService);
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Skip credential check for `OPTIONS` requests in `JwtValidatorFilter`. 

## Why it does that
To allow CORS preflight with JWT/OAuth enabled.


## Who will sponsor this feature?
@wolf4ood 


## Linked Issue(s)

Closes #5968 


