### PR TITLE
feat: add missing capabilityInvocation field on DidDocument

### DIFF
--- a/spi/core-spi/src/main/java/org/eclipse/edc/iam/did/spi/document/DidDocument.java
+++ b/spi/core-spi/src/main/java/org/eclipse/edc/iam/did/spi/document/DidDocument.java
@@ -29,12 +29,13 @@ import java.util.List;
 public class DidDocument {
 
     public static final String DID_CONTEXT = "https://www.w3.org/ns/did/v1";
-    private final List<Service> service = new ArrayList<>();
+    private String id;
     @JsonProperty("@context")
     private final List<Object> context = new ArrayList<>();
+    private final List<Service> service = new ArrayList<>();
     private final List<VerificationMethod> verificationMethod = new ArrayList<>();
     private final List<String> authentication = new ArrayList<>();
-    private String id;
+    private final List<String> capabilityInvocation = new ArrayList<>();
 
     public String getId() {
         return id;
@@ -54,6 +55,10 @@ public class DidDocument {
 
     public List<String> getAuthentication() {
         return authentication;
+    }
+
+    public List<String> getCapabilityInvocation() {
+        return capabilityInvocation;
     }
 
     @Override
@@ -97,6 +102,11 @@ public class DidDocument {
 
         public Builder authentication(List<String> authentication) {
             document.authentication.addAll(authentication);
+            return this;
+        }
+
+        public Builder capabilityInvocation(List<String> capabilityInvocation) {
+            document.capabilityInvocation.addAll(capabilityInvocation);
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

Adds `capabilityInvocation` field on `DidDocument`

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of https://github.com/eclipse-edc/IdentityHub/issues/1061

_Please be sure to take a look at the [contributing guidelines](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/#submitting-a-pull-request) and our [etiquette for pull requests](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/pr-etiquette/)._
