### PR TITLE
feat: validate capabilityInvocation in SelfSigned Token

### DIFF
--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpCoreExtension.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/DcpCoreExtension.java
@@ -192,7 +192,7 @@ public class DcpCoreExtension implements ServiceExtension {
     @Provider
     public IdentityService createIdentityService(ServiceExtensionContext context) {
         var didConfigProvider = new DidConfigProvider(participantContextConfig, context.getMonitor());
-        var validationAction = new SelfIssueIdTokenValidationAction(tokenValidationService, rulesRegistry, didPublicKeyResolver, didConfigProvider);
+        var validationAction = new SelfIssueIdTokenValidationAction(tokenValidationService, rulesRegistry, didPublicKeyResolver, didConfigProvider, didResolverRegistry);
 
         var rules = List.of(
                 new IsInValidityPeriod(clock),

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/validation/CapabilityInvocationValidationRule.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/validation/CapabilityInvocationValidationRule.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.decentralizedclaims.core.validation;
+
+import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
+import org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames;
+import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.token.spi.TokenValidationRule;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+/**
+ * Verifies that the signing key (identified by the JWT {@code kid} header) is listed in the
+ * {@code capabilityInvocation} section of the issuer's DID document, as required by DCP spec
+ * §4.3.3 point 3.
+ */
+public class CapabilityInvocationValidationRule implements TokenValidationRule {
+
+    private final String keyId;
+    private final DidResolverRegistry didResolverRegistry;
+
+    public CapabilityInvocationValidationRule(String keyId, DidResolverRegistry didResolverRegistry) {
+        this.keyId = keyId;
+        this.didResolverRegistry = didResolverRegistry;
+    }
+
+    @Override
+    public Result<Void> checkRule(@NotNull ClaimToken toVerify, @Nullable Map<String, Object> additional) {
+        var iss = toVerify.getStringClaim(JwtRegisteredClaimNames.ISSUER);
+        if (iss == null) {
+            return Result.failure("Required 'iss' claim is missing");
+        }
+
+        var didResult = didResolverRegistry.resolve(iss);
+        if (didResult.failed()) {
+            return didResult.mapEmpty();
+        }
+
+        var capabilityInvocations = didResult.getContent().getCapabilityInvocation();
+        if (capabilityInvocations.stream().anyMatch(keyId::equals)) {
+            return Result.success();
+        }
+        return Result.failure("The key '%s' is not listed in the 'capabilityInvocation' section of the DID document '%s'".formatted(keyId, iss));
+    }
+}

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/validation/SelfIssueIdTokenValidationAction.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/core/validation/SelfIssueIdTokenValidationAction.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.iam.decentralizedclaims.core.validation;
 import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.edc.iam.decentralizedclaims.spi.validation.TokenValidationAction;
 import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
-import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
@@ -38,13 +38,17 @@ public class SelfIssueIdTokenValidationAction implements TokenValidationAction {
     private final TokenValidationService tokenValidationService;
     private final TokenValidationRulesRegistry rulesRegistry;
     private final DidPublicKeyResolver didPublicKeyResolver;
-    private final Function<String, String> didResolver;
+    private final Function<String, String> didConfigProvider;
+    private final DidResolverRegistry didResolverRegistry;
 
-    public SelfIssueIdTokenValidationAction(TokenValidationService tokenValidationService, TokenValidationRulesRegistry rulesRegistry, DidPublicKeyResolver didPublicKeyResolver, Function<String, String> didResolver) {
+    public SelfIssueIdTokenValidationAction(TokenValidationService tokenValidationService, TokenValidationRulesRegistry rulesRegistry,
+                                            DidPublicKeyResolver didPublicKeyResolver, Function<String, String> didConfigProvider,
+                                            DidResolverRegistry didResolverRegistry) {
         this.tokenValidationService = tokenValidationService;
         this.rulesRegistry = rulesRegistry;
         this.didPublicKeyResolver = didPublicKeyResolver;
-        this.didResolver = didResolver;
+        this.didConfigProvider = didConfigProvider;
+        this.didResolverRegistry = didResolverRegistry;
     }
 
     @Override
@@ -54,10 +58,11 @@ public class SelfIssueIdTokenValidationAction implements TokenValidationAction {
             var keyId = signedJwt.getHeader().getKeyID();
             var rules = new ArrayList<>(rulesRegistry.getRules(DCP_SELF_ISSUED_TOKEN_CONTEXT));
             rules.add(new IssuerKeyIdValidationRule(keyId));
-            rules.add(new AudienceValidationRule(didResolver.apply(participantContextId)));
+            rules.add(new AudienceValidationRule(didConfigProvider.apply(participantContextId)));
+            rules.add(new CapabilityInvocationValidationRule(keyId, didResolverRegistry));
             return tokenValidationService.validate(tokenRepresentation, didPublicKeyResolver, rules);
         } catch (ParseException e) {
-            throw new EdcException(e);
+            return Result.failure("Error parsing JWT: " + e.getMessage());
         }
     }
 }

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/validation/CapabilityInvocationValidationRuleTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/validation/CapabilityInvocationValidationRuleTest.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.decentralizedclaims.core.validation;
+
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
+import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.result.Result;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CapabilityInvocationValidationRuleTest {
+
+    private static final String ISSUER = "did:web:consumer";
+    private static final String KEY_ID = "did:web:consumer#key-1";
+
+    private final DidResolverRegistry resolverRegistry = mock();
+
+    @Test
+    void keyInCapabilityInvocation() {
+        var rule = new CapabilityInvocationValidationRule(KEY_ID, resolverRegistry);
+        when(resolverRegistry.resolve(ISSUER)).thenReturn(Result.success(didDocument(List.of(KEY_ID))));
+
+        assertThat(rule.checkRule(claimToken(ISSUER), Map.of())).isSucceeded();
+    }
+
+    @Test
+    void keyNotInCapabilityInvocation() {
+        var rule = new CapabilityInvocationValidationRule(KEY_ID, resolverRegistry);
+        when(resolverRegistry.resolve(ISSUER)).thenReturn(Result.success(didDocument(List.of("did:web:consumer#other-key"))));
+
+        assertThat(rule.checkRule(claimToken(ISSUER), Map.of())).isFailed()
+                .detail()
+                .isEqualTo("The key 'did:web:consumer#key-1' is not listed in the 'capabilityInvocation' section of the DID document 'did:web:consumer'");
+    }
+
+    @Test
+    void emptyCapabilityInvocation() {
+        var rule = new CapabilityInvocationValidationRule(KEY_ID, resolverRegistry);
+        when(resolverRegistry.resolve(ISSUER)).thenReturn(Result.success(didDocument(List.of())));
+
+        assertThat(rule.checkRule(claimToken(ISSUER), Map.of())).isFailed();
+    }
+
+    @Test
+    void issuerClaimMissing() {
+        var rule = new CapabilityInvocationValidationRule(KEY_ID, resolverRegistry);
+        var token = ClaimToken.Builder.newInstance().build();
+
+        assertThat(rule.checkRule(token, Map.of())).isFailed()
+                .detail()
+                .isEqualTo("Required 'iss' claim is missing");
+    }
+
+    @Test
+    void didResolutionFails() {
+        var rule = new CapabilityInvocationValidationRule(KEY_ID, resolverRegistry);
+        when(resolverRegistry.resolve(ISSUER)).thenReturn(Result.failure("DID not found"));
+
+        assertThat(rule.checkRule(claimToken(ISSUER), Map.of())).isFailed()
+                .detail()
+                .contains("DID not found");
+    }
+
+    private ClaimToken claimToken(String iss) {
+        return ClaimToken.Builder.newInstance().claim("iss", iss).build();
+    }
+
+    private DidDocument didDocument(List<String> capabilityInvocations) {
+        return DidDocument.Builder.newInstance()
+                .id(ISSUER)
+                .capabilityInvocation(capabilityInvocations)
+                .build();
+    }
+}

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/validation/SelfIssueIdTokenValidationActionComponentTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/core/validation/SelfIssueIdTokenValidationActionComponentTest.java
@@ -22,12 +22,13 @@ import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jwt.JWTClaimsSet;
 import org.eclipse.edc.iam.decentralizedclaims.core.DcpCoreExtension;
 import org.eclipse.edc.iam.decentralizedclaims.spi.SecureTokenService;
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
 import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
+import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.jwt.validation.jti.JtiValidationStore;
-import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.system.ExecutorInstrumentation;
@@ -43,16 +44,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.text.ParseException;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.iam.decentralizedclaims.core.DcpCoreExtension.PARTICIPANT_DID;
 import static org.eclipse.edc.iam.decentralizedclaims.spi.TestFunctions.createToken;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -70,9 +71,10 @@ public class SelfIssueIdTokenValidationActionComponentTest {
     private final JtiValidationStore storeMock = mock();
     private final TypeTransformerRegistry transformerRegistry = mock();
     private final DidPublicKeyResolver publicKeyResolver = mock();
+    private final DidResolverRegistry didResolverRegistry = mock();
     private final TokenValidationRulesRegistryImpl ruleRegistry = new TokenValidationRulesRegistryImpl();
     private final TokenValidationService tokenValidationService = new TokenValidationServiceImpl();
-    private final SelfIssueIdTokenValidationAction verifier = new SelfIssueIdTokenValidationAction(tokenValidationService, ruleRegistry, publicKeyResolver, (it) -> EXPECTED_AUDIENCE);
+    private final SelfIssueIdTokenValidationAction verifier = new SelfIssueIdTokenValidationAction(tokenValidationService, ruleRegistry, publicKeyResolver, (it) -> EXPECTED_AUDIENCE, didResolverRegistry);
 
     public static ECKey generateEcKey(String kid) {
         try {
@@ -98,14 +100,23 @@ public class SelfIssueIdTokenValidationActionComponentTest {
                 CLEANUP_PERIOD, "1"
         ));
         when(context.getConfig()).thenReturn(config);
+
+        // default: any DID resolves to a document with all known test keys in capabilityInvocation,
+        // so tests not exercising this specific check are not affected
+        when(didResolverRegistry.resolve(anyString())).thenReturn(Result.success(
+                DidDocument.Builder.newInstance()
+                        .id(CONSUMER_DID)
+                        .capabilityInvocation(List.of(CONSUMER_DID_KEY, "did:web:issuer#key"))
+                        .build()));
     }
 
     @Test
     void verify_invalidToken(ServiceExtensionContext context, DcpCoreExtension extension) {
         extension.initialize(context);
-        assertThatThrownBy(() -> verifier.validate(PARTICIPANT_CONTEXT_ID, TokenRepresentation.Builder.newInstance().token("token").build()))
-                .isInstanceOf(EdcException.class)
-                .hasCauseInstanceOf(ParseException.class);
+
+        var result = verifier.validate(PARTICIPANT_CONTEXT_ID, TokenRepresentation.Builder.newInstance().token("token").build());
+
+        assertThat(result).isFailed().messages().anyMatch(m -> m.contains("Error parsing JWT"));
     }
 
     @Test
@@ -123,6 +134,27 @@ public class SelfIssueIdTokenValidationActionComponentTest {
         when(publicKeyResolver.resolveKey(CONSUMER_DID_KEY)).thenReturn(Result.success(key.toPublicKey()));
         var token = createToken(claims, key);
         assertThat(verifier.validate(PARTICIPANT_CONTEXT_ID, token)).isSucceeded();
+    }
+
+    @Test
+    void verify_whenKeyNotInCapabilityInvocation(ServiceExtensionContext context, DcpCoreExtension extension) throws JOSEException {
+        extension.initialize(context);
+        var key = generateEcKey(CONSUMER_DID_KEY);
+        var claims = new JWTClaimsSet.Builder()
+                .issuer(CONSUMER_DID)
+                .subject(CONSUMER_DID)
+                .audience(EXPECTED_AUDIENCE)
+                .claim("token", "accessToken")
+                .expirationTime(Date.from(Instant.now().plusSeconds(10)))
+                .build();
+
+        when(publicKeyResolver.resolveKey(CONSUMER_DID_KEY)).thenReturn(Result.success(key.toPublicKey()));
+        when(didResolverRegistry.resolve(CONSUMER_DID)).thenReturn(Result.success(
+                DidDocument.Builder.newInstance().id(CONSUMER_DID).capabilityInvocation(List.of("did:web:consumer#other-key")).build()));
+        var token = createToken(claims, key);
+        assertThat(verifier.validate(PARTICIPANT_CONTEXT_ID, token)).isFailed()
+                .detail()
+                .contains("is not listed in the 'capabilityInvocation' section");
     }
 
 

--- a/extensions/common/iam/decentralized-identity/identity-did-web/src/test/resources/did.json
+++ b/extensions/common/iam/decentralized-identity/identity-did-web/src/test/resources/did.json
@@ -28,5 +28,8 @@
   ],
   "authentication": [
     "#my-key-1"
+  ],
+  "capabilityInvocation": [
+    "#my-key-1"
   ]
 }

--- a/spi/decentralized-claims-spi/src/testFixtures/java/org/eclipse/edc/iam/decentralizedclaims/spi/credentialservice/CredentialService.java
+++ b/spi/decentralized-claims-spi/src/testFixtures/java/org/eclipse/edc/iam/decentralizedclaims/spi/credentialservice/CredentialService.java
@@ -78,7 +78,6 @@ public class CredentialService {
         }
 
         var did = didFor(participantContextId);
-        var credentialServiceUrl = "http://localhost:" + port + "/credentials/" + participantContextId;
 
         var ecKey = generateKey(participantContextId, did);
 
@@ -90,6 +89,8 @@ public class CredentialService {
                 .publicKeyJwk(ecKey.toPublicJWK().toJSONObject())
                 .build());
 
+        var capabilityInvocationKeys = new ArrayList<String>();
+        capabilityInvocationKeys.add(ecKey.getKeyID());
         if (additionalKey != null) {
             verificationMethods.add(VerificationMethod.Builder.newInstance()
                     .id(additionalKey.getKeyID())
@@ -97,22 +98,22 @@ public class CredentialService {
                     .controller(did)
                     .publicKeyJwk(additionalKey.toPublicJWK().toJSONObject())
                     .build());
+            capabilityInvocationKeys.add(additionalKey.getKeyID());
         }
 
+        var credentialService = new Service(
+                UUID.randomUUID().toString(),
+                "CredentialService",
+                "http://localhost:" + port + "/credentials/" + participantContextId);
 
         var didDocument = DidDocument.Builder.newInstance()
                 .id(did)
-                .verificationMethod(
-                        verificationMethods
-                )
-                .service(List.of(new Service(
-                        UUID.randomUUID().toString(),
-                        "CredentialService",
-                        credentialServiceUrl)))
+                .verificationMethod(verificationMethods)
+                .capabilityInvocation(capabilityInvocationKeys)
+                .service(List.of(credentialService))
                 .build();
 
-        var ctx = new ParticipantContext(didDocument, ecKey);
-        participants.put(participantContextId, ctx);
+        participants.put(participantContextId, new ParticipantContext(didDocument, ecKey));
     }
 
     /**


### PR DESCRIPTION
## What this PR changes/adds

Validates key against capabilityInvocation in self signed token.

## Why it does that

see https://github.com/eclipse-edc/IdentityHub/issues/1061

## Further notes

this PR should be merged after the related one in the IH: https://github.com/eclipse-edc/IdentityHub/pull/1064 otherwise it will break control-plane/IH interoperability


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/#submitting-a-pull-request) and our [etiquette for pull requests](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/pr-etiquette/)._
