### PR TITLE
fix: allow VC 2.0 credentials without credentialSubject.id

### DIFF
--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -8,7 +8,7 @@
   {
     "version": "5.0.0",
     "urlPath": "/v5",
-    "lastUpdated": "2026-09-02T16:00:00Z",
+    "lastUpdated": "2026-09-03T08:00:00Z",
     "maturity": "stable"
   }
 ]

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/main/java/org/eclipse/edc/iam/decentralizedclaims/transform/to/JwtToVerifiableCredentialTransformer.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/main/java/org/eclipse/edc/iam/decentralizedclaims/transform/to/JwtToVerifiableCredentialTransformer.java
@@ -31,7 +31,6 @@ import java.text.ParseException;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import static java.util.Optional.ofNullable;
@@ -150,8 +149,11 @@ public class JwtToVerifiableCredentialTransformer extends AbstractJwtTransformer
 
     private CredentialSubject extractSubject(Map<String, ?> subject, String fallback) {
         var builder = CredentialSubject.Builder.newInstance();
-        var id = Objects.requireNonNullElse(subject.remove(ID_PROPERTY), fallback);
-        builder.id(id.toString());
+        // the id is optional, c.f. https://www.w3.org/TR/vc-data-model-2.0/#identifiers
+        ofNullable(subject.remove(ID_PROPERTY))
+                .map(Object::toString)
+                .or(() -> ofNullable(fallback))
+                .ifPresent(builder::id);
         subject.forEach(builder::claim);
         return builder.build();
     }

--- a/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/test/java/org/eclipse/edc/iam/decentralizedclaims/transform/to/JwtToVerifiableCredentialTransformerTest.java
+++ b/extensions/common/iam/decentralized-claims/decentralized-claims-transform/src/test/java/org/eclipse/edc/iam/decentralizedclaims/transform/to/JwtToVerifiableCredentialTransformerTest.java
@@ -128,6 +128,55 @@ class JwtToVerifiableCredentialTransformerTest {
         verifyNoInteractions(context);
     }
 
+    @Test
+    @DisplayName("VCDM 2.0 credential without credentialSubject.id and without JWT 'sub' claim")
+    void transform_vcdm20_subjectWithoutIdAndNoFallback() {
+        var jwt = createVcdm20Jwt(null);
+
+        var vc = transformer.transform(jwt, context);
+
+        assertThat(vc).isNotNull();
+        assertThat(vc.getCredentialSubject()).hasSize(1).first().satisfies(subject -> {
+            assertThat(subject.getId()).isNull();
+            assertThat(subject.getClaims()).containsEntry("foo", "bar");
+        });
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    @DisplayName("Credential without credentialSubject.id falls back to the JWT 'sub' claim")
+    void transform_subjectWithoutId_fallsBackToJwtSubject() {
+        var jwt = createVcdm20Jwt("did:example:fallback");
+
+        var vc = transformer.transform(jwt, context);
+
+        assertThat(vc).isNotNull();
+        assertThat(vc.getCredentialSubject()).hasSize(1).first().satisfies(subject -> {
+            assertThat(subject.getId()).isEqualTo("did:example:fallback");
+            assertThat(subject.getClaims()).containsEntry("foo", "bar");
+        });
+        verifyNoInteractions(context);
+    }
+
+    private String createVcdm20Jwt(String jwtSubject) {
+        try {
+            var claimsSet = new JWTClaimsSet.Builder()
+                    .issuer("https://university.example/issuers/14")
+                    .subject(jwtSubject)
+                    .claim("@context", List.of("https://www.w3.org/ns/credentials/v2"))
+                    .claim("type", List.of("VerifiableCredential"))
+                    .claim("validFrom", "2010-01-01T19:23:24Z")
+                    .claim("credentialSubject", Map.of("foo", "bar"))
+                    .build();
+
+            var jwt = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), claimsSet);
+            jwt.sign(new MACSigner("test-secret-test-secret-test-secret-12345".getBytes()));
+            return jwt.serialize();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private String createJwt(Map<String, Object> additionalVcProps) {
         try {
             var vcClaims = new HashMap<String, Object>();


### PR DESCRIPTION
## What this PR changes/adds

Makes `JwtToVerifiableCredentialTransformer.extractSubject()` tolerate a missing `credentialSubject.id`: the id is taken from the subject if present, falls back to the JWT `sub` claim as before, and is simply omitted when both are absent instead of throwing a `NullPointerException`.

## Why it does that

The [VC Data Model 2.0 spec](https://www.w3.org/TR/vc-data-model-2.0/#identifiers) declares the `id` property optional, so spec-conformant credentials without a subject id must be transformable. `CredentialSubject` already permits a null id, only the transformer was too strict.

## Linked Issue(s)

Closes #5979
