### PR TITLE
refactor: use config injection in static callback extension

### DIFF
--- a/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/processors/TransferProcessorsImpl.java
+++ b/core/control-plane/control-plane-transfer/src/main/java/org/eclipse/edc/connector/controlplane/transfer/processors/TransferProcessorsImpl.java
@@ -216,7 +216,7 @@ public class TransferProcessorsImpl implements TransferProcessors {
     @Override
     public CompletableFuture<StatusResult<Void>> processStarting(TransferProcess process) {
         return entityRetryProcessFactory.retryProcessor(process)
-                .doProcess(futureResult("Dispatch TransferRequestMessage to: " + process.getCounterPartyAddress(), (t, ignored) -> {
+                .doProcess(futureResult("Dispatch TransferStartMessage to: " + process.getCounterPartyAddress(), (t, ignored) -> {
                     var dataAddress = dataAddressStore.resolve(process).orElse(f -> null);
                     var messageBuilder = TransferStartMessage.Builder.newInstance().dataAddress(dataAddress);
                     return dispatch(messageBuilder, t, Object.class);

--- a/extensions/control-plane/callback/callback-static-endpoint/src/main/java/org/eclipse/edc/connector/controlplane/callback/staticendpoint/CallbackStaticEndpointExtension.java
+++ b/extensions/control-plane/callback/callback-static-endpoint/src/main/java/org/eclipse/edc/connector/controlplane/callback/staticendpoint/CallbackStaticEndpointExtension.java
@@ -15,20 +15,19 @@
 package org.eclipse.edc.connector.controlplane.callback.staticendpoint;
 
 import org.eclipse.edc.connector.controlplane.services.spi.callback.CallbackRegistry;
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
 import org.eclipse.edc.spi.EdcException;
-import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.stream.Collectors;
-
-import static java.lang.String.format;
 
 /**
  * Extension for configuring the static endpoints for callbacks
@@ -37,35 +36,37 @@ import static java.lang.String.format;
 public class CallbackStaticEndpointExtension implements ServiceExtension {
 
     public static final String EDC_CALLBACK_SETTING_PREFIX = "edc.callback";
-    public static final String EDC_CALLBACK_SETTING_ALIAS = EDC_CALLBACK_SETTING_PREFIX + ".<cbAlias>.";
-    @Setting(context = EDC_CALLBACK_SETTING_ALIAS, description = "URI of the callback endpoint.")
-    public static final String EDC_CALLBACK_URI = "uri";
-    @Setting(context = EDC_CALLBACK_SETTING_ALIAS, description = "Comma separated list of events to trigger the callback. If not provided, the callback will be triggered for all events.")
-    public static final String EDC_CALLBACK_EVENTS = "events";
-    @Setting(context = EDC_CALLBACK_SETTING_ALIAS, description = "Whether the callback should be invoked in a transactional context. Default is false.")
-    public static final String EDC_CALLBACK_TRANSACTIONAL = "transactional";
-    @Deprecated(since = "0.17.0")
-    public static final String EDC_CALLBACK_AUTH_KEY_LEGACY = "auth-key";
-    @Deprecated(since = "0.17.0")
-    public static final String EDC_CALLBACK_AUTH_CODE_ID_LEGACY = "auth-code-id";
 
-    @Setting(context = EDC_CALLBACK_SETTING_ALIAS, description = "Authentication key to use for the callback. If not provided, no authentication will be used.")
-    public static final String EDC_CALLBACK_AUTH_KEY = "auth.key";
-    @Setting(context = EDC_CALLBACK_SETTING_ALIAS, description = "Vault Alias of the authentication token to use for the callback. If not provided, no authentication will be used.")
-    public static final String EDC_CALLBACK_AUTH_CODE_ID = "auth.codeid";
     static final String NAME = "Static callbacks extension";
+
+    @Configuration(context = EDC_CALLBACK_SETTING_PREFIX)
+    private Map<String, CallbackStaticConfiguration> configurationMap;
     @Inject
     private CallbackRegistry callbackRegistry;
-    @Inject
-    private Monitor monitor;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        context.getConfig(EDC_CALLBACK_SETTING_PREFIX)
-                .partition()
-                .map(this::configureCallback)
+        configurationMap.values().stream()
+                .map(this::createCallbackAddress)
                 .forEach(callbackRegistry::register);
+    }
 
+    private CallbackAddress createCallbackAddress(CallbackStaticConfiguration configuration) {
+        if (configuration.authKey() != null && configuration.authCodeId() == null) {
+            throw new EdcException("Static callback configuration: auth.codeid cannot be null if auth.key is provided");
+        }
+
+        var events = Arrays.stream(configuration.events().split(","))
+                .map(String::trim)
+                .collect(Collectors.toSet());
+
+        return CallbackAddress.Builder.newInstance()
+                .uri(configuration.uri())
+                .transactional(configuration.transactional())
+                .authKey(configuration.authKey())
+                .authCodeId(configuration.authCodeId())
+                .events(events)
+                .build();
     }
 
     @Override
@@ -73,43 +74,34 @@ public class CallbackStaticEndpointExtension implements ServiceExtension {
         return NAME;
     }
 
-    public CallbackAddress configureCallback(Config config) {
-        var events = Arrays.stream(config.getString(EDC_CALLBACK_EVENTS).split(","))
-                .map(String::trim)
-                .collect(Collectors.toSet());
-
-        var authKey = config.getString(EDC_CALLBACK_AUTH_KEY, null);
-
-        if (authKey == null) {
-            authKey = config.getString(EDC_CALLBACK_AUTH_KEY_LEGACY, null);
-
-            if (authKey == null) {
-                monitor.warning("Using deprecated configuration '%s'. Please switch to '%s'".formatted(EDC_CALLBACK_AUTH_KEY_LEGACY, EDC_CALLBACK_AUTH_KEY));
-            }
-            // warn about deprecation
-        }
-        var authCodeId = config.getString(EDC_CALLBACK_AUTH_CODE_ID, null);
-
-        if (authCodeId == null) {
-            authCodeId = config.getString(EDC_CALLBACK_AUTH_CODE_ID_LEGACY, null);
-
-            if (authCodeId == null) {
-                monitor.warning("Using deprecated configuration '%s'. Please switch to '%s'".formatted(EDC_CALLBACK_AUTH_CODE_ID_LEGACY, EDC_CALLBACK_AUTH_CODE_ID));
-            }
-        }
-
-
-        if (authKey != null && authCodeId == null) {
-            throw new EdcException(format("%s cannot be null if %s is present", EDC_CALLBACK_AUTH_CODE_ID_LEGACY, EDC_CALLBACK_AUTH_KEY_LEGACY));
-        }
-
-        return CallbackAddress.Builder.newInstance()
-                .uri(config.getString(EDC_CALLBACK_URI))
-                .transactional(config.getBoolean(EDC_CALLBACK_TRANSACTIONAL, false))
-                .authKey(authKey)
-                .authCodeId(authCodeId)
-                .events(events)
-                .build();
+    @Settings
+    record CallbackStaticConfiguration(
+            @Setting(
+                    key = "uri",
+                    description = "URI of the callback endpoint.")
+            String uri,
+            @Setting(
+                    key = "events",
+                    description = "Comma separated list of events to trigger the callback. If not provided, the callback will be triggered for all events.",
+                    defaultValue = "")
+            String events,
+            @Setting(
+                    key = "transactional",
+                    description = "Whether the callback should be invoked in a transactional context. Default is false.",
+                    defaultValue = "false"
+            )
+            boolean transactional,
+            @Setting(
+                    key = "auth.key",
+                    description = "Authentication key to use for the callback. If not provided, no authentication will be used.",
+                    required = false)
+            String authKey,
+            @Setting(
+                    key = "auth.codeid",
+                    description = "Vault Alias of the authentication token to use for the callback. If not provided, no authentication will be used.",
+                    required = false)
+            String authCodeId
+    ) {
     }
 
 }

--- a/extensions/control-plane/callback/callback-static-endpoint/src/test/java/org/eclipse/edc/connector/controlplane/callback/staticendpoint/CallbackStaticEndpointExtensionTest.java
+++ b/extensions/control-plane/callback/callback-static-endpoint/src/test/java/org/eclipse/edc/connector/controlplane/callback/staticendpoint/CallbackStaticEndpointExtensionTest.java
@@ -17,8 +17,8 @@ package org.eclipse.edc.connector.controlplane.callback.staticendpoint;
 import org.eclipse.edc.boot.system.injection.ObjectFactory;
 import org.eclipse.edc.connector.controlplane.services.spi.callback.CallbackRegistry;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.junit.extensions.TestExtensionContext;
 import org.eclipse.edc.spi.EdcException;
-import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.spi.types.domain.callback.CallbackAddress;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +29,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Map;
@@ -37,55 +38,21 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.eclipse.edc.connector.controlplane.callback.staticendpoint.CallbackStaticEndpointExtension.EDC_CALLBACK_SETTING_PREFIX;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
 public class CallbackStaticEndpointExtensionTest {
 
-    CallbackStaticEndpointExtension extension;
-    CallbackRegistry callbackRegistry = mock(CallbackRegistry.class);
+    private final CallbackRegistry callbackRegistry = mock(CallbackRegistry.class);
 
     @BeforeEach
-    void setUp(ServiceExtensionContext context, ObjectFactory factory) {
+    void setUp(TestExtensionContext context) {
         context.registerService(CallbackRegistry.class, callbackRegistry);
-        extension = factory.constructInstance(CallbackStaticEndpointExtension.class);
     }
 
     @Test
-    void initialize_shouldConfigureMultipleCallbacksLegacy(ServiceExtensionContext context) {
-        var callback = CallbackAddress.Builder.newInstance()
-                .uri("http://url2")
-                .transactional(false)
-                .events(Set.of("asset", "policy"))
-                .authCodeId("codeId")
-                .authKey("key")
-                .build();
-
-        var mapConfig = Map.of("edc.callback.endpoint1.uri", callback.getUri(),
-                "edc.callback.endpoint1.transactional", String.valueOf(callback.isTransactional()),
-                "edc.callback.endpoint1.events", String.join(" ,", callback.getEvents()),
-                "edc.callback.endpoint1.auth-code-id", callback.getAuthCodeId(),
-                "edc.callback.endpoint1.auth-key", callback.getAuthKey());
-
-        var cfg = ConfigFactory.fromMap(mapConfig);
-
-        when(context.getConfig(EDC_CALLBACK_SETTING_PREFIX)).thenReturn(cfg.getConfig(EDC_CALLBACK_SETTING_PREFIX));
-
-        extension.initialize(context);
-
-        var captor = ArgumentCaptor.forClass(CallbackAddress.class);
-
-        verify(callbackRegistry).register(captor.capture());
-
-        assertThat(captor.getValue()).usingRecursiveComparison().isEqualTo(callback);
-
-    }
-
-    @Test
-    void initialize_shouldConfigureMultipleCallbacks(ServiceExtensionContext context) {
+    void initialize_shouldConfigureMultipleCallbacks(TestExtensionContext context, ObjectFactory factory) {
         var callback = CallbackAddress.Builder.newInstance()
                 .uri("http://url2")
                 .transactional(false)
@@ -100,43 +67,34 @@ public class CallbackStaticEndpointExtensionTest {
                 "edc.callback.endpoint1.auth.codeid", callback.getAuthCodeId(),
                 "edc.callback.endpoint1.auth.key", callback.getAuthKey());
 
-        var cfg = ConfigFactory.fromMap(mapConfig);
-
-        when(context.getConfig(EDC_CALLBACK_SETTING_PREFIX)).thenReturn(cfg.getConfig(EDC_CALLBACK_SETTING_PREFIX));
-
+        context.setConfig(ConfigFactory.fromMap(mapConfig));
+        var extension = factory.constructInstance(CallbackStaticEndpointExtension.class);
         extension.initialize(context);
 
         var captor = ArgumentCaptor.forClass(CallbackAddress.class);
-
         verify(callbackRegistry).register(captor.capture());
-
         assertThat(captor.getValue()).usingRecursiveComparison().isEqualTo(callback);
-
     }
 
     @ParameterizedTest
     @ArgumentsSource(CallbackArgumentProvider.class)
-    void initialize_shouldThrow_WhenWrongConfiguration(Map<String, String> callbackConfig, ServiceExtensionContext context) {
+    void initialize_shouldThrow_WhenWrongConfiguration(Map<String, String> callbackConfig, TestExtensionContext context, ObjectFactory factory) {
+        context.setConfig(ConfigFactory.fromMap(callbackConfig));
 
-        var cfg = ConfigFactory.fromMap(callbackConfig);
-
-        when(context.getConfig(EDC_CALLBACK_SETTING_PREFIX)).thenReturn(cfg.getConfig(EDC_CALLBACK_SETTING_PREFIX));
-
-        assertThatThrownBy(() -> extension.initialize(context))
-                .isInstanceOf(EdcException.class);
-
+        assertThatThrownBy(() -> {
+            var extension = factory.constructInstance(CallbackStaticEndpointExtension.class);
+            extension.initialize(context);
+        }).isInstanceOf(EdcException.class);
     }
 
     static class CallbackArgumentProvider implements ArgumentsProvider {
-        CallbackArgumentProvider() {
-        }
 
         @Override
-        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
             return Stream.of(
                     Map.of("edc.callback.cb.transactional", "false", "edc.cb.callback.events", "test"),
                     Map.of("edc.callback.cb.uri", "url", "edc.callback.cb.transactional", "false"),
-                    Map.of("edc.callback.cb.uri", "url", "edc.callback.cb.transactional", "false", "edc.callback.cb.events", "test", "edc.callback.cb.auth-key", "test")
+                    Map.of("edc.callback.cb.uri", "url", "edc.callback.cb.transactional", "false", "edc.callback.cb.events", "test", "edc.callback.cb.auth.key", "test")
             ).map(Arguments::arguments);
         }
     }


### PR DESCRIPTION
## What this PR changes/adds

Uses configuration injection in `CallbackStaticEndpointExtension`, get rid of deprecated aliases.

## Why it does that

cleanup

## Further notes
- documentation about static callbacks will be provided in the documentation website with a separate PR


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #5809 

_Please be sure to take a look at the [contributing guidelines](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/#submitting-a-pull-request) and our [etiquette for pull requests](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/pr-etiquette/)._
