### PR TITLE
chore: add dedicated "Security" section to release notes

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -8,6 +8,11 @@ changelog:
     - title: Breaking changes
       labels:
         - breaking-change
+    # must come before Bugfixes/New Features: PRs land in the first matching
+    # category, and security-relevant PRs usually also carry "bug" or "enhancement"
+    - title: Security
+      labels:
+        - security
     - title: Bugfixes
       labels:
         - bug

--- a/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/resources/signaling-api-version.json
+++ b/data-protocols/data-plane-signaling/data-plane-signaling-core/src/main/resources/signaling-api-version.json
@@ -2,6 +2,6 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1",
-    "lastUpdated": "2026-04-17T14:00:01Z"
+    "lastUpdated": "2026-09-07T12:02:15Z"
   }
 ]

--- a/extensions/common/api/api-observability/src/main/resources/observability-api-version.json
+++ b/extensions/common/api/api-observability/src/main/resources/observability-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0",
     "urlPath": "/v1",
-    "lastUpdated": "2025-09-22T09:12:45Z",
+    "lastUpdated": "2026-09-07T12:02:15Z",
     "maturity": "stable"
   }
 ]

--- a/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
+++ b/extensions/common/api/management-api-configuration/src/main/resources/management-api-version.json
@@ -8,7 +8,7 @@
   {
     "version": "5.0.0",
     "urlPath": "/v5",
-    "lastUpdated": "2026-09-03T08:00:00Z",
+    "lastUpdated": "2026-09-07T12:02:15Z",
     "maturity": "stable"
   }
 ]

--- a/extensions/common/api/version-api/src/main/resources/version-api-version.json
+++ b/extensions/common/api/version-api/src/main/resources/version-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.1",
     "urlPath": "/v1",
-    "lastUpdated": "2025-10-02T09:12:45Z",
+    "lastUpdated": "2026-09-07T12:02:15Z",
     "maturity": "stable"
   }
 ]


### PR DESCRIPTION
## What this PR changes

Adds a dedicated `Security` category to the auto-generated release notes, mapped to the new `security` label (already created in this repo).

The category is placed before `Bugfixes` and `New Features & Improvements` — not just before the catch-all — because GitHub assigns each PR to the *first* category whose labels match, and security-relevant PRs will typically also carry a `bug` or `enhancement` label.

Closes eclipse-edc/Connector#5955

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171VrV7JWP82oQPFQMtwqsJ