### PR TITLE
fix: switch associate profile on atomic merge

### DIFF
--- a/core/common/participant-context-config-core/src/main/java/org/eclipse/edc/participantcontext/config/defaults/store/InMemoryParticipantContextConfigStore.java
+++ b/core/common/participant-context-config-core/src/main/java/org/eclipse/edc/participantcontext/config/defaults/store/InMemoryParticipantContextConfigStore.java
@@ -18,7 +18,6 @@ import org.eclipse.edc.participantcontext.spi.config.model.ParticipantContextCon
 import org.eclipse.edc.participantcontext.spi.config.store.ParticipantContextConfigStore;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -34,21 +33,19 @@ public class InMemoryParticipantContextConfigStore implements ParticipantContext
     @Override
     public ParticipantContextConfiguration merge(ParticipantContextConfiguration patch) {
         // compute() performs the remapping atomically, so concurrent merges cannot lose entries
-        return store.compute(patch.getParticipantContextId(), (id, existing) -> patch.mergeOnto(existing));
+        return copy(store.compute(patch.getParticipantContextId(), (id, existing) -> patch.mergeOnto(existing)));
     }
 
     @Override
     public @Nullable ParticipantContextConfiguration get(String participantContextId) {
-        return store.get(participantContextId);
+        var config = store.get(participantContextId);
+        return config == null ? null : copy(config);
     }
 
     /**
-     * Copies the entry maps so that callers cannot mutate stored state through the reference they passed in.
+     * Copies the entry maps so that stored state is never shared with callers, in either direction.
      */
     private ParticipantContextConfiguration copy(ParticipantContextConfiguration config) {
-        return config.toBuilder()
-                .entries(new HashMap<>(config.getEntries()))
-                .privateEntries(new HashMap<>(config.getPrivateEntries()))
-                .build();
+        return config.toBuilder().build();
     }
 }

--- a/core/common/participant-context-connector-classic-core/src/test/java/org/eclipse/edc/participantcontext/config/store/SingleParticipantContextConfigStoreTest.java
+++ b/core/common/participant-context-connector-classic-core/src/test/java/org/eclipse/edc/participantcontext/config/store/SingleParticipantContextConfigStoreTest.java
@@ -104,6 +104,22 @@ public class SingleParticipantContextConfigStoreTest extends ParticipantContextC
         super.merge_shouldReturnMergedConfiguration();
     }
 
+    // SingleParticipantContextConfigStore is read-only, so the base test cannot seed it via save()
+    @Override
+    @Disabled
+    protected void get_shouldReturnSnapshot_notLiveStoredState() {
+        super.get_shouldReturnSnapshot_notLiveStoredState();
+    }
+
+    @Test
+    void get_shouldNotExposeMutableEntries() {
+        var retrieved = getStore().get(PARTICIPANT_CONTEXT_ID);
+
+        assertThatThrownBy(() -> retrieved.getEntries().put("key", "mutated"))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThat(getStore().get(PARTICIPANT_CONTEXT_ID).getEntries()).containsEntry("key", "value");
+    }
+
     @Test
     void get() {
         assertThat(getStore().get(PARTICIPANT_CONTEXT_ID))

--- a/core/common/participant-context-connector-core/src/main/java/org/eclipse/edc/participantcontext/connector/profile/ParticipantProfileServiceImpl.java
+++ b/core/common/participant-context-connector-core/src/main/java/org/eclipse/edc/participantcontext/connector/profile/ParticipantProfileServiceImpl.java
@@ -114,14 +114,14 @@ public class ParticipantProfileServiceImpl implements ParticipantProfileService 
 
         if (result.succeeded()) {
             return transactionContext.execute(() -> {
-                var storedConfig = participantContextConfigStore.get(participantContextId);
-                // automatically create config if it does not exist, otherwise update existing config
-                var config = Optional.ofNullable(storedConfig)
-                        .orElseGet(() -> ParticipantContextConfiguration.Builder.newInstance()
-                                .participantContextId(participantContextId)
-                                .build());
-                config.getEntries().put(PROFILES_CONFIG_KEY, String.join(",", profiles));
-                participantContextConfigStore.save(config);
+                // hand a single-key patch to the store: applying it has to happen atomically inside the store,
+                // otherwise a concurrent merge reading the same base would be clobbered. The store creates the
+                // configuration if none exists yet.
+                var patch = ParticipantContextConfiguration.Builder.newInstance()
+                        .participantContextId(participantContextId)
+                        .entry(PROFILES_CONFIG_KEY, String.join(",", profiles))
+                        .build();
+                participantContextConfigStore.merge(patch);
                 return ServiceResult.success();
             });
 

--- a/core/common/participant-context-connector-core/src/test/java/org/eclipse/edc/participantcontext/connector/profile/ParticipantProfileServiceImplTest.java
+++ b/core/common/participant-context-connector-core/src/test/java/org/eclipse/edc/participantcontext/connector/profile/ParticipantProfileServiceImplTest.java
@@ -23,11 +23,13 @@ import org.eclipse.edc.protocol.spi.ProtocolVersion;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.HashMap;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.eclipse.edc.protocol.spi.ParticipantProfileService.PROFILES_CONFIG_KEY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -111,17 +113,33 @@ class ParticipantProfileServiceImplTest {
     }
 
     @Test
-    void associateProfiles_validProfiles_savesCsvAndReturnsSuccess() {
+    void associateProfiles_validProfiles_mergesCsvAndReturnsSuccess() {
         when(registry.getProfile("a")).thenReturn(profile("a"));
         when(registry.getProfile("b")).thenReturn(profile("b"));
-        var existing = config("p1", "old");
-        when(configStore.get("p1")).thenReturn(existing);
 
         var result = resolver.associateProfiles("p1", List.of("a", "b"));
 
         assertThat(result.succeeded()).isTrue();
-        assertThat(existing.getEntries()).containsEntry(PROFILES_CONFIG_KEY, "a,b");
-        verify(configStore).save(existing);
+        assertThat(capturePatch())
+                .satisfies(patch -> assertThat(patch.getParticipantContextId()).isEqualTo("p1"))
+                .satisfies(patch -> assertThat(patch.getEntries()).containsOnly(entry(PROFILES_CONFIG_KEY, "a,b")));
+        verify(configStore, never()).save(any());
+    }
+
+    @Test
+    void associateProfiles_shouldNotRewriteUnrelatedEntries() {
+        when(registry.getProfile("a")).thenReturn(profile("a"));
+
+        var result = resolver.associateProfiles("p1", List.of("a"));
+
+        assertThat(result.succeeded()).isTrue();
+        var patch = capturePatch();
+        // the patch must carry the profiles key alone: anything else would clobber entries written concurrently
+        assertThat(patch.getEntries()).containsOnlyKeys(PROFILES_CONFIG_KEY);
+        assertThat(patch.getPrivateEntries()).isEmpty();
+        // reading the stored configuration first would reintroduce the read-modify-write race
+        verify(configStore, never()).get(any());
+        verify(configStore, never()).save(any());
     }
 
     @Test
@@ -134,7 +152,7 @@ class ParticipantProfileServiceImplTest {
         assertThat(result.failed()).isTrue();
         assertThat(result.getFailureMessages()).anyMatch(m -> m.contains("Profile unknown does not exist"));
         verify(configStore, never()).get(any());
-        verify(configStore, never()).save(any());
+        verify(configStore, never()).merge(any());
     }
 
     @Test
@@ -148,32 +166,34 @@ class ParticipantProfileServiceImplTest {
         assertThat(result.getFailureMessages())
                 .anyMatch(m -> m.contains("Profile x does not exist"))
                 .anyMatch(m -> m.contains("Profile y does not exist"));
-        verify(configStore, never()).save(any());
+        verify(configStore, never()).merge(any());
     }
 
     @Test
     void associateProfiles_emptyList_writesEmptyEntryAndReturnsSuccess() {
-        var existing = config("p1", "a,b");
-        when(configStore.get("p1")).thenReturn(existing);
-
         var result = resolver.associateProfiles("p1", List.of());
 
         assertThat(result.succeeded()).isTrue();
-        assertThat(existing.getEntries()).containsEntry(PROFILES_CONFIG_KEY, "");
-        verify(configStore).save(existing);
+        assertThat(capturePatch().getEntries()).containsOnly(entry(PROFILES_CONFIG_KEY, ""));
     }
 
     @Test
-    void associateProfiles_configNotFound_returnsFailure() {
+    void associateProfiles_configNotExisting_delegatesCreationToStore() {
         when(registry.getProfile("a")).thenReturn(profile("a"));
-        when(configStore.get("p1")).thenReturn(null);
 
         var result = resolver.associateProfiles("p1", List.of("a"));
 
         assertThat(result.failed()).isFalse();
-        verify(configStore).save(any());
+        // the store creates the configuration from the patch when none exists yet
+        verify(configStore).merge(any());
     }
 
+
+    private ParticipantContextConfiguration capturePatch() {
+        var captor = ArgumentCaptor.forClass(ParticipantContextConfiguration.class);
+        verify(configStore).merge(captor.capture());
+        return captor.getValue();
+    }
 
     private ParticipantContextConfiguration config(String participantContextId, String profiles) {
 

--- a/spi/control-plane-spi/src/main/java/org/eclipse/edc/participantcontext/spi/config/model/ParticipantContextConfiguration.java
+++ b/spi/control-plane-spi/src/main/java/org/eclipse/edc/participantcontext/spi/config/model/ParticipantContextConfiguration.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.time.Clock;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -48,11 +49,11 @@ public class ParticipantContextConfiguration implements ParticipantResource {
 
     @NotNull
     public Map<String, String> getEntries() {
-        return entries;
+        return Collections.unmodifiableMap(entries);
     }
 
     public Map<String, String> getPrivateEntries() {
-        return privateEntries;
+        return Collections.unmodifiableMap(privateEntries);
     }
 
     public long getCreatedAt() {
@@ -139,12 +140,13 @@ public class ParticipantContextConfiguration implements ParticipantResource {
         }
 
         public Builder entries(Map<String, String> entries) {
-            configuration.entries = entries;
+            // copy: the builder must never alias a map owned by the caller, or by the configuration toBuilder() came from
+            configuration.entries = entries == null ? null : new HashMap<>(entries);
             return this;
         }
 
         public Builder privateEntries(Map<String, String> privateEntries) {
-            configuration.privateEntries = privateEntries;
+            configuration.privateEntries = privateEntries == null ? null : new HashMap<>(privateEntries);
             return this;
         }
 

--- a/spi/control-plane-spi/src/test/java/org/eclipse/edc/participantcontext/spi/config/model/ParticipantContextConfigurationTest.java
+++ b/spi/control-plane-spi/src/test/java/org/eclipse/edc/participantcontext/spi/config/model/ParticipantContextConfigurationTest.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ParticipantContextConfigurationTest {
 
@@ -102,13 +103,39 @@ class ParticipantContextConfigurationTest {
 
         var merged = patch.mergeOnto(base);
 
-        assertThat(merged.getEntries()).isNotSameAs(base.getEntries()).isNotSameAs(patch.getEntries());
-        assertThat(merged.getPrivateEntries()).isNotSameAs(base.getPrivateEntries()).isNotSameAs(patch.getPrivateEntries());
+        // the entry maps are not writable through the accessors at all, so no result can be mutated into an input
+        assertThatThrownBy(() -> merged.getEntries().put("c", "3")).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> merged.getPrivateEntries().put("s3", "z")).isInstanceOf(UnsupportedOperationException.class);
 
-        // mutating the result must leave both inputs untouched
-        merged.getEntries().put("c", "3");
-        assertThat(base.getEntries()).doesNotContainKey("c");
-        assertThat(patch.getEntries()).doesNotContainKey("c");
+        assertThat(base.getEntries()).containsOnlyKeys("a");
+        assertThat(patch.getEntries()).containsOnlyKeys("b");
+    }
+
+    @Test
+    void builder_shouldCopyTheGivenMaps() {
+        var entries = new HashMap<>(Map.of("a", "1"));
+        var privateEntries = new HashMap<>(Map.of("s1", "x"));
+
+        var config = config(entries, privateEntries, 1000, 1000);
+
+        // a caller holding on to the map it passed in must not be able to reach into the configuration afterwards
+        entries.put("b", "2");
+        privateEntries.put("s2", "y");
+
+        assertThat(config.getEntries()).containsOnlyKeys("a");
+        assertThat(config.getPrivateEntries()).containsOnlyKeys("s1");
+    }
+
+    @Test
+    void toBuilder_shouldCopyTheEntryMaps() {
+        var original = config(new HashMap<>(Map.of("a", "1")), new HashMap<>(Map.of("s1", "x")), 1000, 1000);
+
+        var copy = original.toBuilder().entry("b", "2").privateEntry("s2", "y").build();
+
+        assertThat(copy.getEntries()).containsOnlyKeys("a", "b");
+        assertThat(original.getEntries()).containsOnlyKeys("a");
+        assertThat(copy.getPrivateEntries()).containsOnlyKeys("s1", "s2");
+        assertThat(original.getPrivateEntries()).containsOnlyKeys("s1");
     }
 
     private ParticipantContextConfiguration config(Map<String, String> entries, Map<String, String> privateEntries,

--- a/spi/control-plane-spi/src/testFixtures/java/org/eclipse/edc/participantcontext/spi/config/store/ParticipantContextConfigStoreTestBase.java
+++ b/spi/control-plane-spi/src/testFixtures/java/org/eclipse/edc/participantcontext/spi/config/store/ParticipantContextConfigStoreTestBase.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public abstract class ParticipantContextConfigStoreTestBase {
 
@@ -173,6 +174,23 @@ public abstract class ParticipantContextConfigStoreTestBase {
                     assertThat(cfg.getPrivateEntries()).containsExactlyInAnyOrderEntriesOf(merged.getPrivateEntries());
                     assertThat(cfg.getLastModified()).isEqualTo(merged.getLastModified());
                 });
+    }
+
+    @Test
+    protected void get_shouldReturnSnapshot_notLiveStoredState() {
+        getStore().save(config());
+
+        var retrieved = getStore().get("participant1");
+
+        // handing out the live maps is what allowed callers to mutate stored state behind the store's back and
+        // clobber concurrent merges, see ParticipantProfileServiceImpl
+        assertThatThrownBy(() -> retrieved.getEntries().put("key1", "mutated"))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> retrieved.getPrivateEntries().put("sensitive1", "mutated"))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThat(getStore().get("participant1").getEntries()).containsEntry("key1", "value1");
+        assertThat(getStore().get("participant1").getPrivateEntries()).containsEntry("sensitive1", "supersecret");
     }
 
     private ParticipantContextConfiguration patch(Map<String, String> entries, Map<String, String> privateEntries) {


### PR DESCRIPTION
## What this PR changes/adds


#5956 made config merges atomic by moving the RFC-7396 patch application inside ParticipantContextConfigStore.merge(), but it only converted one of the two writers to edc_participant_context_config. ParticipantProfileServiceImpl.associateProfiles — behind POST /v5/participantcontexts/{id}/profiles — still performed the read-modify-write that PR removed:

var storedConfig = participantContextConfigStore.get(participantContextId);   // no row lock
config.getEntries().put(PROFILES_CONFIG_KEY, ...);                            // in-place mutation
participantContextConfigStore.save(config);                                    // full-blob UPSERT

save() rewrites the entire entries JSON column and the preceding get() takes no lock, so nothing serialized this against merge()'s SELECT … FOR UPDATE. A profile association racing a PATCH …/config — or another profile association — silently dropped the other writer's entries.

- associateProfiles now builds a single-key patch and calls configStore.merge(). It no longer reads the stored config, and the patch carries only PROFILES_CONFIG_KEY, so it cannot touch entries owned by another writer. Creation-if-absent is delegated to the store, preserving existing behaviour.
- ParticipantContextConfiguration getters return unmodifiable views, and the builder copies the entry maps instead of aliasing them (this also stops toBuilder() sharing maps with its source). Copies use new HashMap<> rather than Map.copyOf, since RFC-7396 removals require null values to survive.
- InMemoryParticipantContextConfigStore.get()/merge() return snapshots. save() already copied defensively; get() did not, which is what allowed the mutation above to reach stored state directly and race readers on a plain HashMap.

No change to the SQL merge — the controlplane-feature-sql-bom pulls in transaction-local, so Postgres runtimes get a real LocalTransactionContext and the row lock is held to commit.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/#submitting-a-pull-request) and our [etiquette for pull requests](https://eclipse-edc.github.io/documentation/for-contributors/guidelines/pr-etiquette/)._
